### PR TITLE
feat(ar): camera error handling, permission persistence, fallback UI (cm--3m7)

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -47,6 +47,18 @@ jest.mock('expo-file-system', () => ({
   })),
 }));
 
+// Mock @react-native-async-storage/async-storage
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  __esModule: true,
+  default: {
+    getItem: jest.fn(() => Promise.resolve(null)),
+    setItem: jest.fn(() => Promise.resolve()),
+    removeItem: jest.fn(() => Promise.resolve()),
+    clear: jest.fn(() => Promise.resolve()),
+    getAllKeys: jest.fn(() => Promise.resolve([])),
+  },
+}));
+
 // Silence the warning about animated values
 // NativeAnimatedHelper path changed in RN 0.76+ new architecture
 try {

--- a/src/screens/ARScreen.tsx
+++ b/src/screens/ARScreen.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef } from 'react';
+import React, { useState, useCallback, useRef, useEffect } from 'react';
 import { StyleSheet, View, Text, TouchableOpacity, Platform, Alert, Share } from 'react-native';
 import { CameraView, useCameraPermissions } from 'expo-camera';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
@@ -13,6 +13,11 @@ import { ARControls } from '@/components/ARControls';
 import { events } from '@/services/analytics';
 import { formatPrice } from '@/utils';
 import { useWishlist } from '@/hooks/useWishlist';
+import {
+  loadCachedPermission,
+  saveCachedPermission,
+  getCachedPermissionSync,
+} from '@/services/cameraPermissionCache';
 
 interface Props {
   onClose?: () => void;
@@ -28,6 +33,7 @@ interface Props {
  */
 export function ARScreen({ onClose, initialModelId, testID }: Props) {
   const [permission, requestPermission] = useCameraPermissions();
+  const [cameraError, setCameraError] = useState(false);
 
   const [selectedModel, setSelectedModel] = useState<FutonModel>(
     FUTON_MODELS.find((m) => m.id === initialModelId) ?? FUTON_MODELS[0],
@@ -39,6 +45,18 @@ export function ARScreen({ onClose, initialModelId, testID }: Props) {
 
   const viewShotRef = useRef<ViewShot>(null);
   const wishlist = useWishlist();
+
+  // Load cached permission on mount for faster UI decisions
+  useEffect(() => {
+    loadCachedPermission();
+  }, []);
+
+  // Persist permission state whenever it changes
+  useEffect(() => {
+    if (permission) {
+      saveCachedPermission(permission.granted ? 'granted' : 'denied');
+    }
+  }, [permission]);
 
   // Map current futon model to its product for wishlist
   const currentProduct = PRODUCTS.find((p) => p.id === `prod-${selectedModel.id}`) ?? null;
@@ -74,6 +92,14 @@ export function ARScreen({ onClose, initialModelId, testID }: Props) {
   const handleClose = useCallback(() => {
     onClose?.();
   }, [onClose]);
+
+  const handleCameraError = useCallback(() => {
+    setCameraError(true);
+  }, []);
+
+  const handleRetryCamera = useCallback(() => {
+    setCameraError(false);
+  }, []);
 
   /** Capture the AR scene (camera + overlay + watermark) as an image URI */
   const captureScene = useCallback(async (): Promise<string | null> => {
@@ -159,8 +185,42 @@ export function ARScreen({ onClose, initialModelId, testID }: Props) {
     }
   }, [currentProduct, wishlist, isInWishlist, selectedModel.id, selectedFabric.id]);
 
-  // Permission not yet determined
+  // Permission not yet determined — use cached state to avoid flash
   if (!permission) {
+    const cached = getCachedPermissionSync();
+    if (cached === 'denied') {
+      // Show permission request immediately instead of loading spinner
+      return (
+        <View style={styles.permissionContainer} testID="ar-permission">
+          <View style={styles.permissionCard}>
+            <Text style={styles.permissionIcon}>{'\ud83d\udcf7'}</Text>
+            <Text style={styles.permissionTitle}>See Futons in Your Room</Text>
+            <Text style={styles.permissionDescription}>
+              Point your camera at your room to see how our futons look in your space. We need camera
+              access to make the magic happen.
+            </Text>
+            <TouchableOpacity
+              style={styles.permissionButton}
+              onPress={requestPermission}
+              testID="ar-grant-permission"
+              accessibilityLabel="Allow camera access"
+              accessibilityRole="button"
+            >
+              <Text style={styles.permissionButtonText}>Allow Camera Access</Text>
+            </TouchableOpacity>
+            {onClose && (
+              <TouchableOpacity
+                style={styles.permissionDismiss}
+                onPress={handleClose}
+                testID="ar-permission-dismiss"
+              >
+                <Text style={styles.permissionDismissText}>Maybe Later</Text>
+              </TouchableOpacity>
+            )}
+          </View>
+        </View>
+      );
+    }
     return (
       <View style={styles.permissionContainer} testID="ar-loading">
         <Text style={styles.permissionText}>Initializing camera...</Text>
@@ -173,7 +233,7 @@ export function ARScreen({ onClose, initialModelId, testID }: Props) {
     return (
       <View style={styles.permissionContainer} testID="ar-permission">
         <View style={styles.permissionCard}>
-          <Text style={styles.permissionIcon}>📷</Text>
+          <Text style={styles.permissionIcon}>{'\ud83d\udcf7'}</Text>
           <Text style={styles.permissionTitle}>See Futons in Your Room</Text>
           <Text style={styles.permissionDescription}>
             Point your camera at your room to see how our futons look in your space. We need camera
@@ -202,12 +262,71 @@ export function ARScreen({ onClose, initialModelId, testID }: Props) {
     );
   }
 
+  // Camera error — show fallback with overlay-only mode
+  if (cameraError) {
+    return (
+      <GestureHandlerRootView style={styles.root} testID={testID ?? 'ar-screen'}>
+        <ViewShot ref={viewShotRef} style={styles.camera} options={{ format: 'png', quality: 1 }}>
+          <View style={[styles.camera, styles.fallbackBackground]} testID="ar-camera-fallback">
+            <View style={styles.fallbackBanner}>
+              <Text style={styles.fallbackIcon}>{'\u26a0\ufe0f'}</Text>
+              <Text style={styles.fallbackText}>
+                Camera unavailable. You can still browse futon models below.
+              </Text>
+              <TouchableOpacity
+                onPress={handleRetryCamera}
+                testID="ar-retry-camera"
+                accessibilityLabel="Retry camera"
+                accessibilityRole="button"
+              >
+                <Text style={styles.fallbackRetryText}>Retry</Text>
+              </TouchableOpacity>
+            </View>
+
+            {/* Futon overlay still works without camera */}
+            <View style={styles.overlayContainer}>
+              <ARFutonOverlay
+                model={selectedModel}
+                fabric={selectedFabric}
+                showDimensions={showDimensions}
+                testID="ar-futon-overlay"
+              />
+            </View>
+          </View>
+        </ViewShot>
+
+        <ARControls
+          models={FUTON_MODELS}
+          selectedModel={selectedModel}
+          selectedFabric={selectedFabric}
+          showDimensions={showDimensions}
+          onSelectModel={handleSelectModel}
+          onSelectFabric={handleSelectFabric}
+          onToggleDimensions={handleToggleDimensions}
+          onClose={handleClose}
+          onShare={handleShare}
+          onSaveToGallery={handleSaveToGallery}
+          onToggleWishlist={currentProduct ? handleToggleWishlist : undefined}
+          isInWishlist={isInWishlist}
+          wishlistSaved={wishlistSaved}
+          isCapturing={isCapturing}
+          testID="ar-controls"
+        />
+      </GestureHandlerRootView>
+    );
+  }
+
   // Camera granted — show AR view
   return (
     <GestureHandlerRootView style={styles.root} testID={testID ?? 'ar-screen'}>
       {/* Capturable area: camera feed + overlay + watermark */}
       <ViewShot ref={viewShotRef} style={styles.camera} options={{ format: 'png', quality: 1 }}>
-        <CameraView style={styles.camera} facing="back" testID="ar-camera">
+        <CameraView
+          style={styles.camera}
+          facing="back"
+          testID="ar-camera"
+          onMountError={handleCameraError}
+        >
           {/* Crosshair / placement guide */}
           <View style={styles.crosshairContainer}>
             <View style={styles.crosshairH} />
@@ -326,6 +445,36 @@ const styles = StyleSheet.create({
   permissionDismissText: {
     color: 'rgba(242, 232, 213, 0.5)',
     fontSize: 14,
+  },
+  fallbackBackground: {
+    backgroundColor: '#2A2018',
+  },
+  fallbackBanner: {
+    position: 'absolute',
+    top: 60,
+    left: 16,
+    right: 16,
+    backgroundColor: 'rgba(0,0,0,0.7)',
+    borderRadius: 12,
+    padding: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    zIndex: 10,
+  },
+  fallbackIcon: {
+    fontSize: 20,
+  },
+  fallbackText: {
+    color: '#F2E8D5',
+    fontSize: 13,
+    flex: 1,
+    lineHeight: 18,
+  },
+  fallbackRetryText: {
+    color: '#E8845C',
+    fontSize: 14,
+    fontWeight: '700',
   },
   crosshairContainer: {
     position: 'absolute',

--- a/src/screens/__tests__/ARScreen.test.tsx
+++ b/src/screens/__tests__/ARScreen.test.tsx
@@ -80,6 +80,19 @@ jest.mock('expo-sharing', () => ({
   shareAsync: jest.fn(() => Promise.resolve()),
 }));
 
+// Mock camera permission cache
+const mockLoadCachedPermission = jest.fn(() => Promise.resolve('undetermined'));
+const mockSaveCachedPermission = jest.fn(() => Promise.resolve());
+const mockGetCachedPermissionSync = jest.fn(() => null);
+const mockResetPermCache = jest.fn();
+
+jest.mock('@/services/cameraPermissionCache', () => ({
+  loadCachedPermission: (...args: any[]) => mockLoadCachedPermission(...args),
+  saveCachedPermission: (...args: any[]) => mockSaveCachedPermission(...args),
+  getCachedPermissionSync: () => mockGetCachedPermissionSync(),
+  resetCache: () => mockResetPermCache(),
+}));
+
 /** Helper to render ARScreen with required providers */
 function renderARScreen(props: React.ComponentProps<typeof ARScreen> = {}) {
   return render(
@@ -599,6 +612,136 @@ describe('ARScreen', () => {
         fireEvent.press(getByTestId('ar-dimension-toggle'));
       }
       expect(getByTestId('ar-screen')).toBeTruthy();
+    });
+  });
+
+  // =========================================================================
+  // Camera Error Handling & Fallback UI
+  // =========================================================================
+  describe('Camera Error Handling', () => {
+    it('shows fallback UI when camera reports mount error', () => {
+      // CameraView mock needs to support onMountError
+      const CameraViewMock = jest.fn();
+      jest.requireMock('expo-camera').CameraView = ({ children, onMountError, testID }: any) => {
+        const { createElement } = require('react');
+        const { View } = require('react-native');
+        // Simulate calling onMountError on mount
+        const React = require('react');
+        React.useEffect(() => {
+          if (onMountError) onMountError({ message: 'Camera init failed' });
+        }, []);
+        return createElement(View, { testID }, children);
+      };
+
+      const { getByTestId, getByText } = renderARScreen();
+      expect(getByTestId('ar-camera-fallback')).toBeTruthy();
+      expect(getByText(/Camera unavailable/)).toBeTruthy();
+    });
+
+    it('shows retry button in fallback UI', () => {
+      jest.requireMock('expo-camera').CameraView = ({ children, onMountError, testID }: any) => {
+        const { createElement } = require('react');
+        const { View } = require('react-native');
+        const React = require('react');
+        React.useEffect(() => {
+          if (onMountError) onMountError({ message: 'Camera init failed' });
+        }, []);
+        return createElement(View, { testID }, children);
+      };
+
+      const { getByTestId } = renderARScreen();
+      expect(getByTestId('ar-retry-camera')).toBeTruthy();
+    });
+
+    it('still shows futon overlay and controls in fallback mode', () => {
+      jest.requireMock('expo-camera').CameraView = ({ children, onMountError, testID }: any) => {
+        const { createElement } = require('react');
+        const { View } = require('react-native');
+        const React = require('react');
+        React.useEffect(() => {
+          if (onMountError) onMountError({ message: 'Camera init failed' });
+        }, []);
+        return createElement(View, { testID }, children);
+      };
+
+      const { getByTestId } = renderARScreen();
+      expect(getByTestId('ar-futon-overlay')).toBeTruthy();
+      expect(getByTestId('ar-controls')).toBeTruthy();
+    });
+
+    it('retry button attempts to reinitialize camera', () => {
+      let mountErrorCallback: any = null;
+      jest.requireMock('expo-camera').CameraView = ({ children, onMountError, testID }: any) => {
+        const { createElement } = require('react');
+        const { View } = require('react-native');
+        const React = require('react');
+        React.useEffect(() => {
+          mountErrorCallback = onMountError;
+          if (onMountError) onMountError({ message: 'Camera init failed' });
+        }, []);
+        return createElement(View, { testID }, children);
+      };
+
+      const { getByTestId, queryByTestId } = renderARScreen();
+      expect(getByTestId('ar-camera-fallback')).toBeTruthy();
+
+      // Reset CameraView mock to succeed
+      jest.requireMock('expo-camera').CameraView = ({ children, testID, facing }: any) => {
+        const { createElement } = require('react');
+        const { View } = require('react-native');
+        return createElement(View, { testID, accessibilityHint: facing }, children);
+      };
+
+      fireEvent.press(getByTestId('ar-retry-camera'));
+      // After retry, camera fallback should be gone (camera re-mounted)
+      expect(queryByTestId('ar-camera-fallback')).toBeNull();
+      expect(getByTestId('ar-camera')).toBeTruthy();
+    });
+
+    afterEach(() => {
+      // Restore CameraView mock
+      jest.requireMock('expo-camera').CameraView = ({ children, testID, facing }: any) => {
+        const { createElement } = require('react');
+        const { View } = require('react-native');
+        return createElement(View, { testID, accessibilityHint: facing }, children);
+      };
+    });
+  });
+
+  // =========================================================================
+  // Permission State Persistence
+  // =========================================================================
+  describe('Permission State Persistence', () => {
+    it('loads cached permission on mount', () => {
+      renderARScreen();
+      expect(mockLoadCachedPermission).toHaveBeenCalled();
+    });
+
+    it('saves "granted" when permission is granted', () => {
+      (useCameraPermissions as jest.Mock).mockReturnValue([{ granted: true }, jest.fn()]);
+      renderARScreen();
+      expect(mockSaveCachedPermission).toHaveBeenCalledWith('granted');
+    });
+
+    it('saves "denied" when permission is denied', () => {
+      (useCameraPermissions as jest.Mock).mockReturnValue([{ granted: false }, jest.fn()]);
+      renderARScreen();
+      expect(mockSaveCachedPermission).toHaveBeenCalledWith('denied');
+    });
+
+    it('shows permission prompt instead of loading when cached state is "denied"', () => {
+      (useCameraPermissions as jest.Mock).mockReturnValue([null, jest.fn()]);
+      mockGetCachedPermissionSync.mockReturnValue('denied');
+      const { getByTestId, queryByTestId } = renderARScreen();
+      expect(getByTestId('ar-permission')).toBeTruthy();
+      expect(queryByTestId('ar-loading')).toBeNull();
+    });
+
+    it('shows loading state when cached state is null (first launch)', () => {
+      (useCameraPermissions as jest.Mock).mockReturnValue([null, jest.fn()]);
+      mockGetCachedPermissionSync.mockReturnValue(null);
+      const { getByTestId } = renderARScreen();
+      expect(getByTestId('ar-loading')).toBeTruthy();
     });
   });
 });

--- a/src/services/__tests__/cameraPermissionCache.test.ts
+++ b/src/services/__tests__/cameraPermissionCache.test.ts
@@ -1,0 +1,132 @@
+// Mock AsyncStorage — must be defined before import
+const mockGetItem = jest.fn();
+const mockSetItem = jest.fn();
+
+jest.mock('@react-native-async-storage/async-storage', () => {
+  return {
+    __esModule: true,
+    default: {
+      getItem: (...args: any[]) => mockGetItem(...args),
+      setItem: (...args: any[]) => mockSetItem(...args),
+    },
+  };
+});
+
+import {
+  loadCachedPermission,
+  saveCachedPermission,
+  getCachedPermissionSync,
+  resetCache,
+} from '../cameraPermissionCache';
+
+describe('cameraPermissionCache', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    resetCache();
+  });
+
+  describe('loadCachedPermission', () => {
+    it('returns "undetermined" when nothing is cached', async () => {
+      mockGetItem.mockResolvedValue(null);
+      const result = await loadCachedPermission();
+      expect(result).toBe('undetermined');
+    });
+
+    it('returns "granted" when cached as granted', async () => {
+      mockGetItem.mockResolvedValue('granted');
+      const result = await loadCachedPermission();
+      expect(result).toBe('granted');
+    });
+
+    it('returns "denied" when cached as denied', async () => {
+      mockGetItem.mockResolvedValue('denied');
+      const result = await loadCachedPermission();
+      expect(result).toBe('denied');
+    });
+
+    it('returns "undetermined" for invalid cached values', async () => {
+      mockGetItem.mockResolvedValue('invalid-state');
+      const result = await loadCachedPermission();
+      expect(result).toBe('undetermined');
+    });
+
+    it('returns "undetermined" when AsyncStorage throws', async () => {
+      mockGetItem.mockRejectedValue(new Error('Storage error'));
+      const result = await loadCachedPermission();
+      expect(result).toBe('undetermined');
+    });
+
+    it('uses in-memory cache on subsequent calls', async () => {
+      mockGetItem.mockResolvedValue('granted');
+      await loadCachedPermission();
+      await loadCachedPermission();
+      // Second call should use in-memory cache, not call getItem again
+      expect(mockGetItem).toHaveBeenCalledTimes(1);
+    });
+
+    it('reads from storage key @cfutons/camera-permission', async () => {
+      mockGetItem.mockResolvedValue(null);
+      await loadCachedPermission();
+      expect(mockGetItem).toHaveBeenCalledWith('@cfutons/camera-permission');
+    });
+  });
+
+  describe('saveCachedPermission', () => {
+    it('persists "granted" to AsyncStorage', async () => {
+      mockSetItem.mockResolvedValue(undefined);
+      await saveCachedPermission('granted');
+      expect(mockSetItem).toHaveBeenCalledWith('@cfutons/camera-permission', 'granted');
+    });
+
+    it('persists "denied" to AsyncStorage', async () => {
+      mockSetItem.mockResolvedValue(undefined);
+      await saveCachedPermission('denied');
+      expect(mockSetItem).toHaveBeenCalledWith('@cfutons/camera-permission', 'denied');
+    });
+
+    it('updates in-memory cache', async () => {
+      mockSetItem.mockResolvedValue(undefined);
+      await saveCachedPermission('granted');
+      expect(getCachedPermissionSync()).toBe('granted');
+    });
+
+    it('does not throw when AsyncStorage fails', async () => {
+      mockSetItem.mockRejectedValue(new Error('Storage error'));
+      await expect(saveCachedPermission('granted')).resolves.toBeUndefined();
+    });
+
+    it('still updates in-memory cache when AsyncStorage fails', async () => {
+      mockSetItem.mockRejectedValue(new Error('Storage error'));
+      await saveCachedPermission('denied');
+      expect(getCachedPermissionSync()).toBe('denied');
+    });
+  });
+
+  describe('getCachedPermissionSync', () => {
+    it('returns null before loadCachedPermission is called', () => {
+      expect(getCachedPermissionSync()).toBeNull();
+    });
+
+    it('returns cached value after loadCachedPermission', async () => {
+      mockGetItem.mockResolvedValue('granted');
+      await loadCachedPermission();
+      expect(getCachedPermissionSync()).toBe('granted');
+    });
+
+    it('returns updated value after saveCachedPermission', async () => {
+      mockSetItem.mockResolvedValue(undefined);
+      await saveCachedPermission('denied');
+      expect(getCachedPermissionSync()).toBe('denied');
+    });
+  });
+
+  describe('resetCache', () => {
+    it('clears in-memory cache', async () => {
+      mockSetItem.mockResolvedValue(undefined);
+      await saveCachedPermission('granted');
+      expect(getCachedPermissionSync()).toBe('granted');
+      resetCache();
+      expect(getCachedPermissionSync()).toBeNull();
+    });
+  });
+});

--- a/src/services/cameraPermissionCache.ts
+++ b/src/services/cameraPermissionCache.ts
@@ -1,0 +1,68 @@
+/**
+ * Camera permission state persistence across sessions.
+ *
+ * Caches the last-known permission state to AsyncStorage so the UI can
+ * make instant decisions on mount (e.g., skip the permission prompt if
+ * already granted, or show fallback immediately if previously denied).
+ *
+ * The cached state is advisory — the actual permission is still checked
+ * via expo-camera's useCameraPermissions hook. This just eliminates
+ * the flash of loading UI for returning users.
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = '@cfutons/camera-permission';
+
+export type CachedPermissionState = 'granted' | 'denied' | 'undetermined';
+
+let _cached: CachedPermissionState | null = null;
+
+/**
+ * Load the cached permission state from AsyncStorage.
+ * Returns 'undetermined' if nothing is cached or storage is unavailable.
+ */
+export async function loadCachedPermission(): Promise<CachedPermissionState> {
+  if (_cached !== null) return _cached;
+
+  try {
+    const stored = await AsyncStorage.getItem(STORAGE_KEY);
+    if (stored === 'granted' || stored === 'denied') {
+      _cached = stored;
+      return stored;
+    }
+  } catch {
+    // AsyncStorage not available — operate without cache
+  }
+
+  _cached = 'undetermined';
+  return 'undetermined';
+}
+
+/**
+ * Persist the current permission state for next session.
+ */
+export async function saveCachedPermission(state: 'granted' | 'denied'): Promise<void> {
+  _cached = state;
+
+  try {
+    await AsyncStorage.setItem(STORAGE_KEY, state);
+  } catch {
+    // Silently fail — cache is advisory
+  }
+}
+
+/**
+ * Get the in-memory cached state synchronously.
+ * Returns null if loadCachedPermission() hasn't been called yet.
+ */
+export function getCachedPermissionSync(): CachedPermissionState | null {
+  return _cached;
+}
+
+/**
+ * Reset cached state. Used by tests.
+ */
+export function resetCache(): void {
+  _cached = null;
+}


### PR DESCRIPTION
## Summary
- Camera error handling with onMountError + fallback UI with retry button
- Permission state persistence via AsyncStorage cache (cameraPermissionCache service)
- Cached-state-aware loading screen for faster AR startup
- 25 new tests (16 cache service + 9 ARScreen), all 1113 tests passing

## Bead
cm--3m7

## Note
MR created by Witness after polecat session death. Branch was pushed by Witness recovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)