### PR TITLE
feat(offline): cart persistence + offline sync queue (cm--2ij)

### DIFF
--- a/src/hooks/__tests__/useOfflineSync.test.tsx
+++ b/src/hooks/__tests__/useOfflineSync.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { render, fireEvent, act, waitFor } from '@testing-library/react-native';
+import { ConnectivityProvider } from '../useConnectivity';
+import { useOfflineSync, type SyncHandler } from '../useOfflineSync';
+import { _resetForTesting, getQueueLength, enqueue } from '@/services/offlineQueue';
+import { useConnectivity } from '../useConnectivity';
+
+beforeEach(() => {
+  _resetForTesting();
+});
+
+function SyncHarness({ onSync }: { onSync?: SyncHandler }) {
+  const { pendingCount, isSyncing, queueAction, syncNow } = useOfflineSync({ onSync });
+  const { isOnline, setOnline } = useConnectivity();
+
+  return (
+    <View>
+      <Text testID="pending">{pendingCount}</Text>
+      <Text testID="syncing">{String(isSyncing)}</Text>
+      <Text testID="online">{String(isOnline)}</Text>
+      <TouchableOpacity
+        testID="queue-cart-action"
+        onPress={() => queueAction('cart', 'ADD_ITEM', { itemId: 'test-1' })}
+      />
+      <TouchableOpacity
+        testID="queue-wishlist-action"
+        onPress={() => queueAction('wishlist', 'ADD', { productId: 'p-1' })}
+      />
+      <TouchableOpacity testID="sync-now" onPress={() => syncNow()} />
+      <TouchableOpacity testID="go-offline" onPress={() => setOnline(false)} />
+      <TouchableOpacity testID="go-online" onPress={() => setOnline(true)} />
+    </View>
+  );
+}
+
+function renderSync(initialOnline = true, onSync?: SyncHandler) {
+  return render(
+    <ConnectivityProvider initialOnline={initialOnline}>
+      <SyncHarness onSync={onSync} />
+    </ConnectivityProvider>,
+  );
+}
+
+describe('useOfflineSync', () => {
+  it('starts with zero pending count', async () => {
+    const { getByTestId } = renderSync();
+    await waitFor(() => {
+      expect(getByTestId('pending').props.children).toBe(0);
+    });
+  });
+
+  it('increments pending count when queueing actions', async () => {
+    const { getByTestId } = renderSync();
+    await act(async () => {
+      fireEvent.press(getByTestId('queue-cart-action'));
+    });
+    expect(getByTestId('pending').props.children).toBe(1);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('queue-wishlist-action'));
+    });
+    expect(getByTestId('pending').props.children).toBe(2);
+  });
+
+  it('drains queue on manual syncNow', async () => {
+    const onSync = jest.fn();
+    const { getByTestId } = renderSync(true, onSync);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('queue-cart-action'));
+      fireEvent.press(getByTestId('queue-cart-action'));
+    });
+    expect(getByTestId('pending').props.children).toBe(2);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('sync-now'));
+    });
+
+    expect(onSync).toHaveBeenCalledTimes(1);
+    expect(onSync).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ domain: 'cart', action: 'ADD_ITEM' }),
+      ]),
+    );
+    expect(getByTestId('pending').props.children).toBe(0);
+  });
+
+  it('auto-syncs when transitioning from offline to online', async () => {
+    const onSync = jest.fn();
+    const { getByTestId } = renderSync(false, onSync);
+
+    // Queue actions while offline
+    await act(async () => {
+      fireEvent.press(getByTestId('queue-cart-action'));
+      fireEvent.press(getByTestId('queue-wishlist-action'));
+    });
+    expect(getByTestId('pending').props.children).toBe(2);
+
+    // Go online → should trigger sync
+    await act(async () => {
+      fireEvent.press(getByTestId('go-online'));
+    });
+
+    await waitFor(() => {
+      expect(onSync).toHaveBeenCalledTimes(1);
+      expect(getByTestId('pending').props.children).toBe(0);
+    });
+  });
+
+  it('does not sync when already online and staying online', async () => {
+    const onSync = jest.fn();
+    renderSync(true, onSync);
+    // No transition, no sync
+    expect(onSync).not.toHaveBeenCalled();
+  });
+
+  it('does not sync on offline→offline', async () => {
+    const onSync = jest.fn();
+    const { getByTestId } = renderSync(false, onSync);
+    await act(async () => {
+      fireEvent.press(getByTestId('queue-cart-action'));
+    });
+    // Stay offline — no sync
+    expect(onSync).not.toHaveBeenCalled();
+  });
+
+  it('does not call onSync when queue is empty on reconnect', async () => {
+    const onSync = jest.fn();
+    const { getByTestId } = renderSync(false, onSync);
+
+    // Go online with empty queue
+    await act(async () => {
+      fireEvent.press(getByTestId('go-online'));
+    });
+
+    expect(onSync).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/useCart.tsx
+++ b/src/hooks/useCart.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useContext, useReducer, useCallback, useMemo } from 'react';
+import React, { createContext, useContext, useReducer, useCallback, useMemo, useEffect } from 'react';
 import type { FutonModel, Fabric } from '@/data/futons';
 
 export interface CartItem {
@@ -17,7 +17,8 @@ type CartAction =
   | { type: 'ADD_ITEM'; model: FutonModel; fabric: Fabric; quantity: number }
   | { type: 'REMOVE_ITEM'; itemId: string }
   | { type: 'UPDATE_QUANTITY'; itemId: string; quantity: number }
-  | { type: 'CLEAR' };
+  | { type: 'CLEAR' }
+  | { type: 'LOAD'; items: CartItem[] };
 
 function cartReducer(state: CartState, action: CartAction): CartState {
   switch (action.type) {
@@ -59,6 +60,8 @@ function cartReducer(state: CartState, action: CartAction): CartState {
     }
     case 'CLEAR':
       return { items: [] };
+    case 'LOAD':
+      return { items: action.items };
     default:
       return state;
   }
@@ -76,8 +79,44 @@ interface CartContextValue {
 
 const CartContext = createContext<CartContextValue | null>(null);
 
+const CART_STORAGE_KEY = 'cfutons_cart';
+
 export function CartProvider({ children }: { children: React.ReactNode }) {
   const [state, dispatch] = useReducer(cartReducer, { items: [] });
+
+  // Load from AsyncStorage on mount
+  useEffect(() => {
+    (async () => {
+      try {
+        const AsyncStorage = await import('@react-native-async-storage/async-storage').then(
+          (m) => m.default,
+        );
+        const stored = await AsyncStorage.getItem(CART_STORAGE_KEY);
+        if (stored) {
+          const parsed = JSON.parse(stored) as CartItem[];
+          if (Array.isArray(parsed) && parsed.length > 0) {
+            dispatch({ type: 'LOAD', items: parsed });
+          }
+        }
+      } catch {
+        // AsyncStorage not available — operate in-memory
+      }
+    })();
+  }, []);
+
+  // Persist to AsyncStorage whenever items change
+  useEffect(() => {
+    (async () => {
+      try {
+        const AsyncStorage = await import('@react-native-async-storage/async-storage').then(
+          (m) => m.default,
+        );
+        await AsyncStorage.setItem(CART_STORAGE_KEY, JSON.stringify(state.items));
+      } catch {
+        // no-op
+      }
+    })();
+  }, [state.items]);
 
   const addItem = useCallback((model: FutonModel, fabric: Fabric, quantity: number) => {
     dispatch({ type: 'ADD_ITEM', model, fabric, quantity });

--- a/src/hooks/useOfflineSync.tsx
+++ b/src/hooks/useOfflineSync.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useRef, useCallback, useState } from 'react';
+import { useConnectivity } from './useConnectivity';
+import { drain, loadQueue, getQueueLength, enqueue } from '@/services/offlineQueue';
+import type { QueuedAction } from '@/services/offlineQueue';
+
+export interface SyncHandler {
+  (actions: QueuedAction[]): Promise<void> | void;
+}
+
+interface UseOfflineSyncOptions {
+  /** Handler called with queued actions when coming back online */
+  onSync?: SyncHandler;
+  /** Whether to auto-load queue on mount (default: true) */
+  autoLoad?: boolean;
+}
+
+interface UseOfflineSyncResult {
+  /** Number of actions pending in the queue */
+  pendingCount: number;
+  /** Whether a sync is currently in progress */
+  isSyncing: boolean;
+  /** Enqueue an action (when offline) */
+  queueAction: (
+    domain: QueuedAction['domain'],
+    action: string,
+    payload: Record<string, unknown>,
+  ) => void;
+  /** Manually trigger a sync */
+  syncNow: () => Promise<void>;
+}
+
+/**
+ * Hook that manages offline action queueing and sync-on-reconnect.
+ *
+ * - Loads persisted queue on mount
+ * - Watches connectivity; when transitioning offline→online, drains queue and calls onSync
+ * - Provides queueAction for components to enqueue mutations while offline
+ */
+export function useOfflineSync(options: UseOfflineSyncOptions = {}): UseOfflineSyncResult {
+  const { onSync, autoLoad = true } = options;
+  const { isOnline } = useConnectivity();
+  const wasOnline = useRef(isOnline);
+  const [pendingCount, setPendingCount] = useState(0);
+  const [isSyncing, setIsSyncing] = useState(false);
+  const onSyncRef = useRef(onSync);
+  onSyncRef.current = onSync;
+
+  // Load queue on mount
+  useEffect(() => {
+    if (autoLoad) {
+      loadQueue().then((q) => setPendingCount(q.length));
+    }
+  }, [autoLoad]);
+
+  const syncNow = useCallback(async () => {
+    const actions = drain();
+    if (actions.length === 0) return;
+    setIsSyncing(true);
+    try {
+      if (onSyncRef.current) {
+        await onSyncRef.current(actions);
+      }
+    } finally {
+      setIsSyncing(false);
+      setPendingCount(getQueueLength());
+    }
+  }, []);
+
+  // Watch for offline→online transition
+  useEffect(() => {
+    if (!wasOnline.current && isOnline) {
+      syncNow();
+    }
+    wasOnline.current = isOnline;
+  }, [isOnline, syncNow]);
+
+  const queueAction = useCallback(
+    (
+      domain: QueuedAction['domain'],
+      action: string,
+      payload: Record<string, unknown>,
+    ) => {
+      enqueue(domain, action, payload);
+      setPendingCount(getQueueLength());
+    },
+    [],
+  );
+
+  return { pendingCount, isSyncing, queueAction, syncNow };
+}

--- a/src/services/__tests__/offlineQueue.test.ts
+++ b/src/services/__tests__/offlineQueue.test.ts
@@ -1,0 +1,106 @@
+import {
+  enqueue,
+  getQueue,
+  getQueueLength,
+  dequeue,
+  drain,
+  clearQueue,
+  _resetForTesting,
+} from '../offlineQueue';
+
+beforeEach(() => {
+  _resetForTesting();
+});
+
+describe('offlineQueue', () => {
+  describe('enqueue', () => {
+    it('adds an action to the queue', () => {
+      const action = enqueue('cart', 'ADD_ITEM', { itemId: 'foo' });
+      expect(action.domain).toBe('cart');
+      expect(action.action).toBe('ADD_ITEM');
+      expect(action.payload).toEqual({ itemId: 'foo' });
+      expect(action.id).toMatch(/^oq-/);
+      expect(action.timestamp).toBeGreaterThan(0);
+    });
+
+    it('assigns unique ids', () => {
+      const a1 = enqueue('cart', 'ADD_ITEM', {});
+      const a2 = enqueue('cart', 'ADD_ITEM', {});
+      expect(a1.id).not.toBe(a2.id);
+    });
+
+    it('increments queue length', () => {
+      expect(getQueueLength()).toBe(0);
+      enqueue('cart', 'ADD_ITEM', {});
+      expect(getQueueLength()).toBe(1);
+      enqueue('wishlist', 'ADD', {});
+      expect(getQueueLength()).toBe(2);
+    });
+  });
+
+  describe('getQueue', () => {
+    it('returns all actions when no domain specified', () => {
+      enqueue('cart', 'ADD_ITEM', {});
+      enqueue('wishlist', 'ADD', {});
+      expect(getQueue()).toHaveLength(2);
+    });
+
+    it('filters by domain', () => {
+      enqueue('cart', 'ADD_ITEM', {});
+      enqueue('wishlist', 'ADD', {});
+      enqueue('cart', 'REMOVE_ITEM', {});
+      expect(getQueue('cart')).toHaveLength(2);
+      expect(getQueue('wishlist')).toHaveLength(1);
+    });
+
+    it('returns empty array when queue is empty', () => {
+      expect(getQueue()).toEqual([]);
+    });
+  });
+
+  describe('dequeue', () => {
+    it('removes a specific action by id', () => {
+      const a1 = enqueue('cart', 'ADD_ITEM', {});
+      enqueue('cart', 'REMOVE_ITEM', {});
+      expect(dequeue(a1.id)).toBe(true);
+      expect(getQueueLength()).toBe(1);
+    });
+
+    it('returns false for nonexistent id', () => {
+      expect(dequeue('nonexistent')).toBe(false);
+    });
+  });
+
+  describe('drain', () => {
+    it('returns and removes all actions', () => {
+      enqueue('cart', 'ADD_ITEM', {});
+      enqueue('wishlist', 'ADD', {});
+      const drained = drain();
+      expect(drained).toHaveLength(2);
+      expect(getQueueLength()).toBe(0);
+    });
+
+    it('drains only specified domain', () => {
+      enqueue('cart', 'ADD_ITEM', {});
+      enqueue('wishlist', 'ADD', {});
+      enqueue('cart', 'REMOVE_ITEM', {});
+      const drained = drain('cart');
+      expect(drained).toHaveLength(2);
+      expect(getQueueLength()).toBe(1);
+      expect(getQueue()[0].domain).toBe('wishlist');
+    });
+
+    it('returns empty array when queue is empty', () => {
+      expect(drain()).toEqual([]);
+    });
+  });
+
+  describe('clearQueue', () => {
+    it('empties the queue', () => {
+      enqueue('cart', 'ADD_ITEM', {});
+      enqueue('wishlist', 'ADD', {});
+      clearQueue();
+      expect(getQueueLength()).toBe(0);
+    });
+  });
+});

--- a/src/services/offlineQueue.ts
+++ b/src/services/offlineQueue.ts
@@ -1,0 +1,121 @@
+/**
+ * Offline action queue.
+ *
+ * Queues cart/wishlist mutations when offline, persists to AsyncStorage,
+ * and replays them when connectivity is restored.
+ */
+
+export interface QueuedAction {
+  id: string;
+  timestamp: number;
+  domain: 'cart' | 'wishlist';
+  action: string; // action type string (e.g. 'ADD_ITEM', 'REMOVE')
+  payload: Record<string, unknown>;
+}
+
+const QUEUE_KEY = 'cfutons_offline_queue';
+
+let queue: QueuedAction[] = [];
+let nextId = 1;
+
+/** Generate a unique action id */
+function generateId(): string {
+  return `oq-${Date.now()}-${nextId++}`;
+}
+
+/** Enqueue an action for later replay */
+export function enqueue(
+  domain: QueuedAction['domain'],
+  action: string,
+  payload: Record<string, unknown>,
+): QueuedAction {
+  const entry: QueuedAction = {
+    id: generateId(),
+    timestamp: Date.now(),
+    domain,
+    action,
+    payload,
+  };
+  queue.push(entry);
+  persistQueue();
+  return entry;
+}
+
+/** Get all queued actions (optionally filtered by domain) */
+export function getQueue(domain?: QueuedAction['domain']): QueuedAction[] {
+  if (domain) return queue.filter((a) => a.domain === domain);
+  return [...queue];
+}
+
+/** Get queue length */
+export function getQueueLength(): number {
+  return queue.length;
+}
+
+/** Remove a specific action from the queue */
+export function dequeue(id: string): boolean {
+  const before = queue.length;
+  queue = queue.filter((a) => a.id !== id);
+  if (queue.length !== before) {
+    persistQueue();
+    return true;
+  }
+  return false;
+}
+
+/** Drain all actions (optionally by domain), removing them from the queue */
+export function drain(domain?: QueuedAction['domain']): QueuedAction[] {
+  let drained: QueuedAction[];
+  if (domain) {
+    drained = queue.filter((a) => a.domain === domain);
+    queue = queue.filter((a) => a.domain !== domain);
+  } else {
+    drained = [...queue];
+    queue = [];
+  }
+  persistQueue();
+  return drained;
+}
+
+/** Clear the entire queue */
+export function clearQueue(): void {
+  queue = [];
+  persistQueue();
+}
+
+/** Load queue from AsyncStorage (call on app start) */
+export async function loadQueue(): Promise<QueuedAction[]> {
+  try {
+    const AsyncStorage = await import('@react-native-async-storage/async-storage').then(
+      (m) => m.default,
+    );
+    const stored = await AsyncStorage.getItem(QUEUE_KEY);
+    if (stored) {
+      const parsed = JSON.parse(stored);
+      if (Array.isArray(parsed)) {
+        queue = parsed;
+      }
+    }
+  } catch {
+    // AsyncStorage not available — operate in-memory only
+  }
+  return [...queue];
+}
+
+/** Persist queue to AsyncStorage */
+async function persistQueue(): Promise<void> {
+  try {
+    const AsyncStorage = await import('@react-native-async-storage/async-storage').then(
+      (m) => m.default,
+    );
+    await AsyncStorage.setItem(QUEUE_KEY, JSON.stringify(queue));
+  } catch {
+    // no-op
+  }
+}
+
+/** Reset internal state (for testing) */
+export function _resetForTesting(): void {
+  queue = [];
+  nextId = 1;
+}


### PR DESCRIPTION
## Summary
- **Cart persistence**: `useCart` now persists to AsyncStorage (same pattern as `useWishlist`). Cart survives app kills.
- **Offline action queue**: New `offlineQueue` service queues cart/wishlist mutations while offline, persists queue to AsyncStorage.
- **Sync-on-reconnect**: New `useOfflineSync` hook watches connectivity transitions; drains queue and replays actions when going offline→online.

## Files changed
- `src/hooks/useCart.tsx` — Added `LOAD` action, AsyncStorage load/save effects
- `src/services/offlineQueue.ts` — New queue service (enqueue, dequeue, drain, persist)
- `src/hooks/useOfflineSync.tsx` — New hook tying connectivity to queue replay
- `src/services/__tests__/offlineQueue.test.ts` — 12 tests
- `src/hooks/__tests__/useOfflineSync.test.tsx` — 7 tests

## Test plan
- [x] offlineQueue unit tests (enqueue, dequeue, drain, clear, filtering)
- [x] useOfflineSync integration tests (queue actions, manual sync, auto-sync on reconnect, edge cases)
- [x] Existing useCart tests still pass (no regressions)
- [x] Full suite: 63/64 suites, 1125 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)