### PR TITLE
feat(ar): ARWebScreen + navigation + web callback (cm-e7g step 4)

### DIFF
--- a/src/components/ModelViewerWeb.tsx
+++ b/src/components/ModelViewerWeb.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { View, Text, StyleSheet, Platform } from 'react-native';
+
+interface Props {
+  glbUrl: string;
+  usdzUrl?: string;
+  title?: string;
+  dimensions?: { width: number; depth: number; height: number };
+  testID?: string;
+}
+
+/**
+ * Web-only 3D model viewer using Google's <model-viewer> web component.
+ * Renders null on native platforms.
+ *
+ * Placeholder — full implementation with script injection and
+ * model-viewer attributes will be provided by the ModelViewerWeb PR.
+ */
+export function ModelViewerWeb({ glbUrl, usdzUrl, title, dimensions, testID }: Props) {
+  if (Platform.OS !== 'web') {
+    return null;
+  }
+
+  return (
+    <View style={styles.container} testID={testID ?? 'model-viewer-web'}>
+      <Text style={styles.placeholder}>3D Viewer: {title ?? 'Model'}</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#1A1410',
+  },
+  placeholder: {
+    color: '#F2E8D5',
+    fontSize: 16,
+  },
+});

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -14,6 +14,7 @@ import { NotificationPreferencesScreen } from '@/screens/NotificationPreferences
 import { WishlistScreen } from '@/screens/WishlistScreen';
 import { StoreLocatorScreen } from '@/screens/StoreLocatorScreen';
 import { StoreDetailScreen } from '@/screens/StoreDetailScreen';
+import { ARWebScreen, type ARWebScreenParams } from '@/screens/ARWebScreen';
 
 export type RootStackParamList = {
   Tabs: undefined;
@@ -30,6 +31,7 @@ export type RootStackParamList = {
   Wishlist: undefined;
   StoreLocator: undefined;
   StoreDetail: { storeId: string };
+  ARWeb: ARWebScreenParams;
 };
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
@@ -55,6 +57,11 @@ export function AppNavigator() {
       <Stack.Screen name="Wishlist" component={WishlistScreen} />
       <Stack.Screen name="StoreLocator" component={StoreLocatorScreen} />
       <Stack.Screen name="StoreDetail" component={StoreDetailScreen} />
+      <Stack.Screen
+        name="ARWeb"
+        component={ARWebScreen}
+        options={{ presentation: 'fullScreenModal', animation: 'fade' }}
+      />
     </Stack.Navigator>
   );
 }

--- a/src/screens/ARWebScreen.tsx
+++ b/src/screens/ARWebScreen.tsx
@@ -1,0 +1,92 @@
+import React, { useCallback } from 'react';
+import { StyleSheet, View, Text, TouchableOpacity } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { ModelViewerWeb } from '@/components/ModelViewerWeb';
+
+export interface ARWebScreenParams {
+  glbUrl: string;
+  usdzUrl: string;
+  title: string;
+  productId: string;
+}
+
+interface Props {
+  route: { params: ARWebScreenParams };
+  onClose?: () => void;
+  testID?: string;
+}
+
+/**
+ * Full-screen modal screen wrapping ModelViewerWeb for web platform.
+ * Shows a 3D model viewer with a header bar containing the product title and close button.
+ */
+export function ARWebScreen({ route, onClose, testID }: Props) {
+  const navigation = useNavigation();
+  const { glbUrl, usdzUrl, title } = route.params;
+
+  const handleClose = useCallback(() => {
+    if (onClose) return onClose();
+    navigation.goBack();
+  }, [onClose, navigation]);
+
+  return (
+    <View style={styles.container} testID={testID ?? 'ar-web-screen'}>
+      <View style={styles.header}>
+        <Text style={styles.title} numberOfLines={1}>
+          {title}
+        </Text>
+        <TouchableOpacity
+          onPress={handleClose}
+          style={styles.closeButton}
+          testID="ar-web-close"
+          accessibilityLabel="Close 3D viewer"
+          accessibilityRole="button"
+        >
+          <Text style={styles.closeButtonText}>✕</Text>
+        </TouchableOpacity>
+      </View>
+      <ModelViewerWeb
+        glbUrl={glbUrl}
+        usdzUrl={usdzUrl}
+        title={title}
+        testID="model-viewer-web"
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#1A1410',
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+    paddingHorizontal: 16,
+    paddingTop: 52,
+    paddingBottom: 12,
+    backgroundColor: '#1A1410',
+  },
+  title: {
+    color: '#F2E8D5',
+    fontSize: 18,
+    fontWeight: '700',
+    flex: 1,
+    marginRight: 12,
+  },
+  closeButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    backgroundColor: 'rgba(242, 232, 213, 0.15)',
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  closeButtonText: {
+    color: '#F2E8D5',
+    fontSize: 18,
+    fontWeight: '300',
+  },
+});

--- a/src/screens/__tests__/ARWebScreen.test.tsx
+++ b/src/screens/__tests__/ARWebScreen.test.tsx
@@ -1,0 +1,106 @@
+import React from 'react';
+import { render, fireEvent, act } from '@testing-library/react-native';
+import { Platform } from 'react-native';
+import { ARWebScreen } from '../ARWebScreen';
+
+// Mock navigation
+const mockGoBack = jest.fn();
+const mockNavigation = { goBack: mockGoBack };
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => mockNavigation,
+}));
+
+// Mock ModelViewerWeb so it renders on all platforms in tests
+jest.mock('@/components/ModelViewerWeb', () => ({
+  ModelViewerWeb: ({ testID, glbUrl, title }: any) => {
+    const { View, Text } = require('react-native');
+    return (
+      <View testID={testID ?? 'model-viewer-web'}>
+        <Text>{title}</Text>
+      </View>
+    );
+  },
+}));
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+const defaultRoute = {
+  params: {
+    glbUrl: 'https://cdn.example.com/model.glb',
+    usdzUrl: 'https://cdn.example.com/model.usdz',
+    title: 'The Asheville',
+    productId: 'prod-asheville-full',
+  },
+};
+
+describe('ARWebScreen', () => {
+  describe('Rendering', () => {
+    it('renders with ar-web-screen testID', () => {
+      const { getByTestId } = render(
+        <ARWebScreen route={defaultRoute as any} />,
+      );
+      expect(getByTestId('ar-web-screen')).toBeTruthy();
+    });
+
+    it('renders the product title', () => {
+      const { getAllByText } = render(
+        <ARWebScreen route={defaultRoute as any} />,
+      );
+      expect(getAllByText('The Asheville').length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('renders a close button', () => {
+      const { getByTestId } = render(
+        <ARWebScreen route={defaultRoute as any} />,
+      );
+      expect(getByTestId('ar-web-close')).toBeTruthy();
+    });
+
+    it('renders ModelViewerWeb with correct props', () => {
+      const { getByTestId } = render(
+        <ARWebScreen route={defaultRoute as any} />,
+      );
+      expect(getByTestId('model-viewer-web')).toBeTruthy();
+    });
+  });
+
+  describe('Interactions', () => {
+    it('calls navigation.goBack when close button pressed', () => {
+      const { getByTestId } = render(
+        <ARWebScreen route={defaultRoute as any} />,
+      );
+      fireEvent.press(getByTestId('ar-web-close'));
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose prop instead of goBack when provided', () => {
+      const onClose = jest.fn();
+      const { getByTestId } = render(
+        <ARWebScreen route={defaultRoute as any} onClose={onClose} />,
+      );
+      fireEvent.press(getByTestId('ar-web-close'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+      expect(mockGoBack).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('close button has accessibility label', () => {
+      const { getByTestId } = render(
+        <ARWebScreen route={defaultRoute as any} />,
+      );
+      const closeBtn = getByTestId('ar-web-close');
+      expect(closeBtn.props.accessibilityLabel).toBe('Close 3D viewer');
+    });
+
+    it('close button has button role', () => {
+      const { getByTestId } = render(
+        <ARWebScreen route={defaultRoute as any} />,
+      );
+      const closeBtn = getByTestId('ar-web-close');
+      expect(closeBtn.props.accessibilityRole).toBe('button');
+    });
+  });
+});

--- a/src/utils/__tests__/openARViewer.test.ts
+++ b/src/utils/__tests__/openARViewer.test.ts
@@ -107,9 +107,28 @@ describe('openARViewer', () => {
     });
   });
 
-  describe('Web / unsupported', () => {
-    it('shows alert on web platform', async () => {
+  describe('Web', () => {
+    beforeEach(() => {
       (Platform as any).OS = 'web';
+    });
+
+    it('calls onWebModelView callback on web platform', async () => {
+      const onWebModelView = jest.fn();
+      await openARViewer('asheville-full', 'The Asheville', { onWebModelView });
+      expect(Linking.openURL).not.toHaveBeenCalled();
+      expect(Alert.alert).not.toHaveBeenCalled();
+      expect(onWebModelView).toHaveBeenCalledTimes(1);
+      expect(onWebModelView).toHaveBeenCalledWith(
+        expect.objectContaining({
+          glbUrl: expect.any(String),
+          usdzUrl: expect.any(String),
+          modelId: 'asheville-full',
+          modelName: 'The Asheville',
+        }),
+      );
+    });
+
+    it('shows alert on web when no onWebModelView callback provided', async () => {
       await openARViewer('asheville-full', 'The Asheville');
       expect(Linking.openURL).not.toHaveBeenCalled();
       expect(Alert.alert).toHaveBeenCalledWith(

--- a/src/utils/openARViewer.ts
+++ b/src/utils/openARViewer.ts
@@ -16,6 +16,17 @@ export interface ARModelAssets {
   glbUrl: string; // Android Scene Viewer
 }
 
+export interface WebModelViewParams {
+  glbUrl: string;
+  usdzUrl: string;
+  modelId: string;
+  modelName: string;
+}
+
+export interface OpenARViewerOptions {
+  onWebModelView?: (params: WebModelViewParams) => void;
+}
+
 /**
  * Resolve AR asset URLs for a model ID (slug without `prod-` prefix).
  * Looks up the 3D model catalog first for pipeline-generated URLs;
@@ -53,7 +64,11 @@ export function buildSceneViewerUrl(glbUrl: string, title: string): string {
  * - iOS: Opens .usdz URL which triggers Apple Quick Look AR natively
  * - Android: Opens Scene Viewer intent with .glb model
  */
-export async function openARViewer(modelId: string, modelName: string): Promise<void> {
+export async function openARViewer(
+  modelId: string,
+  modelName: string,
+  options?: OpenARViewerOptions,
+): Promise<void> {
   const assets = getARModelAssets(modelId);
 
   if (Platform.OS === 'ios') {
@@ -90,6 +105,15 @@ export async function openARViewer(modelId: string, modelName: string): Promise<
       }
     }
   } else {
-    Alert.alert('AR Not Available', 'AR viewing is only available on mobile devices.');
+    if (options?.onWebModelView) {
+      options.onWebModelView({
+        glbUrl: assets.glbUrl,
+        usdzUrl: assets.usdzUrl,
+        modelId,
+        modelName,
+      });
+    } else {
+      Alert.alert('AR Not Available', 'AR viewing is only available on mobile devices.');
+    }
   }
 }


### PR DESCRIPTION
## Summary
- **ARWebScreen**: Full-screen modal screen wrapping ModelViewerWeb for web platform 3D viewing
- **AppNavigator**: Added `ARWeb` route with `fullScreenModal` presentation
- **openARViewer**: Web branch now accepts `onWebModelView` callback instead of showing "not available" alert; falls back to alert when no callback provided
- **ModelViewerWeb**: Placeholder component (bishop's Step 3 PR will replace with full `<model-viewer>` implementation)

## Test plan
- [x] ARWebScreen renders with title, close button, ModelViewerWeb
- [x] Close button calls navigation.goBack or onClose prop
- [x] Accessibility labels on close button
- [x] openARViewer calls onWebModelView callback on web with correct params
- [x] openARViewer still shows alert on web when no callback provided
- [x] All existing openARViewer iOS/Android tests still pass
- [x] Full test suite: 75 suites pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)