### PR TITLE
refactor(ProductDetailScreen): replace PRODUCTS/FUTON_MODELS with hooks (cm-0xx)

### DIFF
--- a/src/screens/ProductDetailScreen.tsx
+++ b/src/screens/ProductDetailScreen.tsx
@@ -12,10 +12,11 @@ import {
 import * as Haptics from 'expo-haptics';
 import { useNavigation } from '@react-navigation/native';
 import { useTheme } from '@/theme';
-import { FUTON_MODELS, type FutonModel, type Fabric, inchesToFeetDisplay } from '@/data/futons';
+import { type FutonModel, type Fabric, inchesToFeetDisplay } from '@/data/futons';
 import { formatPrice, openARViewer } from '@/utils';
 import { WishlistButton } from '@/components/WishlistButton';
-import { PRODUCTS } from '@/data/products';
+import { useFutonModels } from '@/hooks/useFutonModels';
+import { useProduct } from '@/hooks/useProduct';
 import { ReviewCard } from '@/components/ReviewCard';
 import { ReviewSummary } from '@/components/ReviewSummary';
 import { ReviewForm } from '@/components/ReviewForm';
@@ -45,8 +46,10 @@ export function ProductDetailScreen({
 }: Props) {
   const { colors, spacing, borderRadius, shadows } = useTheme();
 
-  const model = FUTON_MODELS.find((m) => m.id === productId) ?? FUTON_MODELS[0];
-  const catalogProduct = PRODUCTS.find((p) => p.id === productId) ?? PRODUCTS[0];
+  const { models, getModel } = useFutonModels();
+  const model = getModel(productId ?? '') ?? models[0];
+  const catalogProductId = productId ? `prod-${productId}` : '';
+  const { product: catalogProduct } = useProduct(catalogProductId);
   const [selectedFabric, setSelectedFabric] = useState<Fabric>(model.fabrics[0]);
   const [quantity, setQuantity] = useState(1);
   const [activeGalleryIndex, setActiveGalleryIndex] = useState(0);
@@ -102,11 +105,11 @@ export function ProductDetailScreen({
           glbUrl: params.glbUrl,
           usdzUrl: params.usdzUrl,
           title: params.modelName,
-          productId: catalogProduct.id,
+          productId: catalogProduct?.id ?? `prod-${model.id}`,
         });
       },
     });
-  }, [model.id, model.name, catalogProduct.id, onOpenAR, navigation]);
+  }, [model.id, model.name, catalogProduct?.id, onOpenAR, navigation]);
 
   const onGalleryScroll = useCallback((e: { nativeEvent: { contentOffset: { x: number } } }) => {
     const index = Math.round(e.nativeEvent.contentOffset.x / SCREEN_WIDTH);
@@ -152,9 +155,11 @@ export function ProductDetailScreen({
         )}
 
         {/* Wishlist button */}
-        <View style={styles.wishlistButtonContainer}>
-          <WishlistButton product={catalogProduct} size="lg" testID="detail-wishlist-button" />
-        </View>
+        {catalogProduct && (
+          <View style={styles.wishlistButtonContainer}>
+            <WishlistButton product={catalogProduct} size="lg" testID="detail-wishlist-button" />
+          </View>
+        )}
 
         {/* Image Gallery */}
         <FlatList

--- a/src/screens/__tests__/ProductDetailScreen.test.tsx
+++ b/src/screens/__tests__/ProductDetailScreen.test.tsx
@@ -5,6 +5,7 @@ import { ProductDetailScreen } from '../ProductDetailScreen';
 import { ThemeProvider } from '@/theme/ThemeProvider';
 import { WishlistProvider } from '@/hooks/useWishlist';
 import { FUTON_MODELS, FABRICS } from '@/data/futons';
+import { PRODUCTS } from '@/data/products';
 
 const mockNavigate = jest.fn();
 jest.mock('@react-navigation/native', () => ({
@@ -591,6 +592,52 @@ describe('ProductDetailScreen', () => {
       const { getByTestId } = renderDetail({ productId: 'asheville-full' });
       fireEvent.press(getByTestId('detail-ar-button'));
       expect(mockNavigate).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Hook Integration (useProduct / useFutonModels)', () => {
+    it('resolves catalog product via prod- prefix convention', () => {
+      // The screen should map futon model ID → product ID (prod-{modelId})
+      const { getByTestId } = renderDetail({ productId: 'asheville-full' });
+      // WishlistButton should receive the correct catalog product
+      expect(getByTestId('detail-wishlist-button')).toBeTruthy();
+    });
+
+    it('renders wishlist button for all valid futon model IDs', () => {
+      for (const model of FUTON_MODELS) {
+        const catalogProduct = PRODUCTS.find((p) => p.id === `prod-${model.id}`);
+        expect(catalogProduct).toBeTruthy();
+        const { getByTestId, unmount } = renderDetail({ productId: model.id });
+        expect(getByTestId('detail-wishlist-button')).toBeTruthy();
+        unmount();
+      }
+    });
+
+    it('hides wishlist button when catalog product not found', () => {
+      const { queryByTestId } = renderDetail({ productId: 'nonexistent' });
+      expect(queryByTestId('detail-wishlist-button')).toBeNull();
+    });
+
+    it('still renders model info when catalog product not found', () => {
+      // Unknown productId falls back to first futon model
+      const { getByTestId } = renderDetail({ productId: 'nonexistent' });
+      expect(getByTestId('product-name').props.children).toBe(asheville.name);
+      expect(getByTestId('total-price')).toBeTruthy();
+    });
+
+    it('AR button works even without catalog product', () => {
+      const onOpenAR = jest.fn();
+      const { getByTestId } = renderDetail({ productId: 'nonexistent', onOpenAR });
+      expect(() => fireEvent.press(getByTestId('detail-ar-button'))).not.toThrow();
+      expect(onOpenAR).toHaveBeenCalledWith('asheville-full'); // falls back to first model
+    });
+
+    it('AR web navigation uses catalog product ID when available', () => {
+      Object.defineProperty(Platform, 'OS', { value: 'web' });
+      const { getByTestId } = renderDetail({ productId: 'blue-ridge-queen' });
+      fireEvent.press(getByTestId('detail-ar-button'));
+      const navParams = mockNavigate.mock.calls[0][1];
+      expect(navParams.productId).toBe('prod-blue-ridge-queen');
     });
   });
 });


### PR DESCRIPTION
## Summary
- Replaces direct `PRODUCTS` and `FUTON_MODELS` imports in `ProductDetailScreen` with `useProduct()` and `useFutonModels()` hooks
- Maps futon model IDs to product IDs via `prod-` prefix convention (e.g., `asheville-full` → `prod-asheville-full`)
- Guards `WishlistButton` and AR navigation against null catalog product for unknown IDs
- Adds 6 TDD edge-case tests for hook integration (82 total tests, all pass)

## Test plan
- [x] All 82 ProductDetailScreen tests pass (76 existing + 6 new)
- [x] Full suite: 1576 tests pass, 0 regressions
- [x] Edge cases: unknown productId hides wishlist, AR still works with fallback
- [x] All valid futon model IDs correctly resolve catalog products

🤖 Generated with [Claude Code](https://claude.com/claude-code)