### PR TITLE
refactor(OrderScreens): replace MOCK_ORDERS/FUTON_MODELS with hooks (cm-dy0)

### DIFF
--- a/src/screens/OrderDetailScreen.tsx
+++ b/src/screens/OrderDetailScreen.tsx
@@ -10,9 +10,10 @@ import {
 } from 'react-native';
 import * as Haptics from 'expo-haptics';
 import { useTheme } from '@/theme';
-import { MOCK_ORDERS, ORDER_STATUS_CONFIG, type Order } from '@/data/orders';
+import { ORDER_STATUS_CONFIG, type Order } from '@/data/orders';
 import { useCart } from '@/hooks/useCart';
-import { FUTON_MODELS, FABRICS } from '@/data/futons';
+import { useOrders } from '@/hooks/useOrders';
+import { useFutonModels } from '@/hooks/useFutonModels';
 import { formatPrice } from '@/utils';
 
 interface Props {
@@ -35,9 +36,12 @@ export function OrderDetailScreen({
   const orderId = orderIdProp ?? route?.params?.orderId ?? '';
   const { colors, spacing, borderRadius, shadows } = useTheme();
   const { addItem } = useCart();
+  const { getOrder, orders: hookOrders } = useOrders();
+  const { getModel, getFabric } = useFutonModels();
 
-  const allOrders = ordersProp ?? MOCK_ORDERS;
-  const order = allOrders.find((o) => o.id === orderId);
+  const order = ordersProp
+    ? ordersProp.find((o) => o.id === orderId)
+    : getOrder(orderId);
 
   const formatDate = useCallback((iso: string) => {
     const d = new Date(iso);
@@ -59,8 +63,8 @@ export function OrderDetailScreen({
     if (!order) return;
     let added = 0;
     for (const item of order.items) {
-      const model = FUTON_MODELS.find((m) => m.id === item.modelId);
-      const fabric = FABRICS.find((f) => f.id === item.fabricId);
+      const model = getModel(item.modelId);
+      const fabric = getFabric(item.fabricId);
       if (model && fabric) {
         addItem(model, fabric, item.quantity);
         added++;
@@ -70,7 +74,7 @@ export function OrderDetailScreen({
       Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
     }
     onReorderSuccess?.();
-  }, [order, addItem, onReorderSuccess]);
+  }, [order, addItem, onReorderSuccess, getModel, getFabric]);
 
   if (!order) {
     return (

--- a/src/screens/OrderHistoryScreen.tsx
+++ b/src/screens/OrderHistoryScreen.tsx
@@ -2,7 +2,8 @@ import React, { useState, useCallback } from 'react';
 import { StyleSheet, Text, View, FlatList, TouchableOpacity, RefreshControl } from 'react-native';
 import { useTheme } from '@/theme';
 import { EmptyState } from '@/components';
-import { MOCK_ORDERS, ORDER_STATUS_CONFIG, type Order } from '@/data/orders';
+import { ORDER_STATUS_CONFIG, type Order } from '@/data/orders';
+import { useOrders } from '@/hooks/useOrders';
 import { formatPrice } from '@/utils';
 
 interface Props {
@@ -20,11 +21,12 @@ export function OrderHistoryScreen({
 }: Props) {
   const { colors, spacing, borderRadius, shadows } = useTheme();
   const [refreshing, setRefreshing] = useState(false);
+  const { orders: hookOrders } = useOrders();
 
-  // Use prop orders or fall back to mock data
-  const orders = (ordersProp ?? MOCK_ORDERS)
-    .slice()
-    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime());
+  // Use prop orders or fall back to hook data (already sorted newest-first)
+  const orders = ordersProp
+    ? ordersProp.slice().sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+    : hookOrders;
 
   const handleRefresh = useCallback(() => {
     setRefreshing(true);

--- a/src/screens/__tests__/OrderDetailScreen.test.tsx
+++ b/src/screens/__tests__/OrderDetailScreen.test.tsx
@@ -239,4 +239,30 @@ describe('OrderDetailScreen', () => {
       expect(getByTestId('reorder-button').props.accessibilityLabel).toBe('Re-order these items');
     });
   });
+
+  describe('Hook Integration (useOrders / useFutonModels)', () => {
+    it('finds order via hook when no orders prop given', () => {
+      const { getByTestId } = renderOrderDetail({ orderId: 'ord-001' });
+      expect(getByTestId('order-detail-header').props.children).toBe('CF-2026-0147');
+    });
+
+    it('orders prop overrides hook data', () => {
+      const { getByTestId } = renderOrderDetail({
+        orderId: 'ord-001',
+        orders: MOCK_ORDERS,
+      });
+      expect(getByTestId('order-detail-header').props.children).toBe('CF-2026-0147');
+    });
+
+    it('reorder resolves model and fabric via useFutonModels hook', () => {
+      const onReorderSuccess = jest.fn();
+      const { getByTestId } = renderWithCartReader({
+        orderId: 'ord-001',
+        onReorderSuccess,
+      });
+      fireEvent.press(getByTestId('reorder-button'));
+      expect(getByTestId('cart-count').props.children).toBe(1);
+      expect(onReorderSuccess).toHaveBeenCalled();
+    });
+  });
 });

--- a/src/screens/__tests__/OrderHistoryScreen.test.tsx
+++ b/src/screens/__tests__/OrderHistoryScreen.test.tsx
@@ -123,6 +123,23 @@ describe('OrderHistoryScreen', () => {
     });
   });
 
+  describe('Hook Integration (useOrders)', () => {
+    it('renders mock orders from useOrders hook when no orders prop given', () => {
+      const { getByTestId } = renderOrderHistory();
+      // Should render orders from the hook (same as MOCK_ORDERS)
+      expect(getByTestId('order-list')).toBeTruthy();
+      expect(getByTestId('order-card-ord-001')).toBeTruthy();
+    });
+
+    it('orders prop overrides hook data', () => {
+      const { queryByTestId, getByTestId } = renderOrderHistory({
+        orders: [],
+      });
+      expect(getByTestId('orders-empty-state')).toBeTruthy();
+      expect(queryByTestId('order-card-ord-001')).toBeNull();
+    });
+  });
+
   describe('Custom orders prop', () => {
     const customOrders: Order[] = [
       {


### PR DESCRIPTION
## Summary
- Replaces `MOCK_ORDERS` import in OrderHistoryScreen with `useOrders()` hook
- Replaces `MOCK_ORDERS` + `FUTON_MODELS`/`FABRICS` imports in OrderDetailScreen with `useOrders()` + `useFutonModels()` hooks
- Both screens retain `orders` prop override for testing flexibility
- `useOrders()` provides sorted data (newest-first) and `getOrder()` lookup
- `useFutonModels()` provides `getModel()`/`getFabric()` for reorder functionality

## Test plan
- [x] 51 order screen tests pass (46 existing + 5 new hook integration)
- [x] Full suite: 1575 tests pass, 0 regressions
- [x] Reorder flow works via hook-based model/fabric resolution
- [x] Empty state works when orders prop is []
- [x] Orders prop correctly overrides hook data

**Note:** Supersedes Dallas's prior attempt on `cm-dy0-order-screens-refactor`. This version cherry-picks the hooks from `cm-wix-data-integration` and follows the same pattern as cm-0xx (PR #24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)