### PR TITLE
refactor(stores): hooks replace direct STORES imports (cm-a7m)

### DIFF
--- a/src/hooks/__tests__/useStores.test.ts
+++ b/src/hooks/__tests__/useStores.test.ts
@@ -1,0 +1,64 @@
+import { renderHook } from '@testing-library/react-native';
+import { useStores, useStoreById } from '../useStores';
+import { STORES } from '@/data/stores';
+
+describe('useStores', () => {
+  it('returns all stores', () => {
+    const { result } = renderHook(() => useStores());
+    expect(result.current.stores).toEqual(STORES);
+  });
+
+  it('returns isLoading as false (static data)', () => {
+    const { result } = renderHook(() => useStores());
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('returns error as null', () => {
+    const { result } = renderHook(() => useStores());
+    expect(result.current.error).toBeNull();
+  });
+
+  it('provides getStoreById that finds a store', () => {
+    const { result } = renderHook(() => useStores());
+    const store = result.current.getStoreById('store-asheville');
+    expect(store).toBeDefined();
+    expect(store?.name).toBe('Carolina Futons — Asheville');
+  });
+
+  it('getStoreById returns undefined for unknown id', () => {
+    const { result } = renderHook(() => useStores());
+    expect(result.current.getStoreById('nonexistent')).toBeUndefined();
+  });
+
+  it('returns stable references across re-renders', () => {
+    const { result, rerender } = renderHook(() => useStores());
+    const first = result.current;
+    rerender({});
+    expect(result.current.stores).toBe(first.stores);
+    expect(result.current.getStoreById).toBe(first.getStoreById);
+  });
+});
+
+describe('useStoreById', () => {
+  it('returns matching store', () => {
+    const { result } = renderHook(() => useStoreById('store-charlotte'));
+    expect(result.current.store).toBeDefined();
+    expect(result.current.store?.city).toBe('Charlotte');
+  });
+
+  it('returns null for unknown store id', () => {
+    const { result } = renderHook(() => useStoreById('bad-id'));
+    expect(result.current.store).toBeNull();
+  });
+
+  it('returns null when id is undefined', () => {
+    const { result } = renderHook(() => useStoreById(undefined));
+    expect(result.current.store).toBeNull();
+  });
+
+  it('returns isLoading false and error null', () => {
+    const { result } = renderHook(() => useStoreById('store-asheville'));
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/src/hooks/useStores.ts
+++ b/src/hooks/useStores.ts
@@ -1,0 +1,42 @@
+import { useMemo, useCallback } from 'react';
+import { STORES, type Store } from '@/data/stores';
+
+interface UseStoresReturn {
+  stores: Store[];
+  isLoading: boolean;
+  error: Error | null;
+  getStoreById: (id: string) => Store | undefined;
+}
+
+/**
+ * Provides store/showroom data for locator and detail screens.
+ * Uses static data now; designed for drop-in Wix CMS API replacement.
+ */
+export function useStores(): UseStoresReturn {
+  const stores = useMemo(() => STORES, []);
+
+  const getStoreById = useCallback(
+    (id: string) => stores.find((s) => s.id === id),
+    [stores],
+  );
+
+  return { stores, isLoading: false, error: null, getStoreById };
+}
+
+interface UseStoreByIdReturn {
+  store: Store | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Looks up a single store by ID.
+ */
+export function useStoreById(storeId: string | undefined): UseStoreByIdReturn {
+  const store = useMemo(() => {
+    if (!storeId) return null;
+    return STORES.find((s) => s.id === storeId) ?? null;
+  }, [storeId]);
+
+  return { store, isLoading: false, error: null };
+}

--- a/src/screens/StoreDetailScreen.tsx
+++ b/src/screens/StoreDetailScreen.tsx
@@ -11,13 +11,13 @@ import {
 } from 'react-native';
 import { useTheme } from '@/theme';
 import {
-  STORES,
   type Store,
   type AppointmentType,
   APPOINTMENT_TYPES,
   isStoreOpen,
   formatPhone,
 } from '@/data/stores';
+import { useStoreById } from '@/hooks/useStores';
 import { Button } from '@/components/Button';
 
 interface Props {
@@ -28,7 +28,11 @@ interface Props {
 
 export function StoreDetailScreen({ storeId, store: storeProp, testID }: Props) {
   const { colors, spacing, borderRadius, shadows } = useTheme();
-  const store = storeProp ?? STORES.find((s) => s.id === storeId);
+
+  // Data from hook — replaces direct STORES import
+  const { store: hookStore, isLoading, error } = useStoreById(storeId);
+  const store = storeProp ?? hookStore;
+
   const [selectedAppointment, setSelectedAppointment] = useState<AppointmentType | null>(null);
   const [bookingConfirmed, setBookingConfirmed] = useState(false);
 
@@ -55,6 +59,37 @@ export function StoreDetailScreen({ storeId, store: storeProp, testID }: Props) 
     if (!selectedAppointment) return;
     setBookingConfirmed(true);
   }, [selectedAppointment]);
+
+  // Loading state
+  if (isLoading && !storeProp) {
+    return (
+      <View
+        style={[styles.container, { backgroundColor: colors.sandBase }]}
+        testID="store-loading"
+      >
+        <Text style={[styles.errorText, { color: colors.espressoLight }]}>
+          Loading store details...
+        </Text>
+      </View>
+    );
+  }
+
+  // Error state
+  if (error && !storeProp) {
+    return (
+      <View
+        style={[styles.container, { backgroundColor: colors.sandBase }]}
+        testID="store-error"
+      >
+        <Text style={[styles.errorText, { color: colors.espressoLight }]}>
+          We couldn't load this store
+        </Text>
+        <Text style={[styles.errorDetail, { color: colors.espressoLight }]}>
+          {error.message}
+        </Text>
+      </View>
+    );
+  }
 
   if (!store) {
     return (
@@ -377,5 +412,11 @@ const styles = StyleSheet.create({
     fontSize: 16,
     textAlign: 'center',
     marginTop: 40,
+  },
+  errorDetail: {
+    fontSize: 14,
+    textAlign: 'center',
+    marginTop: 8,
+    opacity: 0.7,
   },
 });

--- a/src/screens/StoreLocatorScreen.tsx
+++ b/src/screens/StoreLocatorScreen.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useCallback, useMemo } from 'react';
 import { StyleSheet, View, Text, FlatList } from 'react-native';
 import { useTheme } from '@/theme';
-import { STORES, type Store, calculateDistance } from '@/data/stores';
+import { type Store, calculateDistance } from '@/data/stores';
+import { useStores } from '@/hooks/useStores';
 import { StoreCard } from '@/components/StoreCard';
 import { EmptyState } from '@/components/EmptyState';
 import { SearchBar } from '@/components/SearchBar';
@@ -17,8 +18,11 @@ export function StoreLocatorScreen({ onStorePress, userLatitude, userLongitude, 
   const { colors, spacing } = useTheme();
   const [searchQuery, setSearchQuery] = useState('');
 
+  // Data from hook — replaces direct STORES import
+  const { stores, isLoading, error } = useStores();
+
   const storesWithDistance = useMemo(() => {
-    return STORES.map((store) => ({
+    return stores.map((store) => ({
       store,
       distance:
         userLatitude != null && userLongitude != null
@@ -30,7 +34,7 @@ export function StoreLocatorScreen({ onStorePress, userLatitude, userLongitude, 
       if (b.distance != null) return 1;
       return 0;
     });
-  }, [userLatitude, userLongitude]);
+  }, [stores, userLatitude, userLongitude]);
 
   const filtered = useMemo(() => {
     if (!searchQuery.trim()) return storesWithDistance;
@@ -72,6 +76,47 @@ export function StoreLocatorScreen({ onStorePress, userLatitude, userLongitude, 
     [searchQuery],
   );
 
+  // Loading state
+  if (isLoading) {
+    return (
+      <View
+        style={[styles.container, { backgroundColor: colors.sandBase }]}
+        testID="stores-loading"
+      >
+        <View style={[styles.header, { paddingHorizontal: spacing.md }]}>
+          <Text style={[styles.title, { color: colors.espresso }]}>Find a Showroom</Text>
+        </View>
+        <View style={styles.centeredMessage}>
+          <Text style={[styles.messageText, { color: colors.espressoLight }]}>
+            Loading showrooms...
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <View
+        style={[styles.container, { backgroundColor: colors.sandBase }]}
+        testID="stores-error"
+      >
+        <View style={[styles.header, { paddingHorizontal: spacing.md }]}>
+          <Text style={[styles.title, { color: colors.espresso }]}>Find a Showroom</Text>
+        </View>
+        <View style={styles.centeredMessage}>
+          <Text style={[styles.messageText, { color: colors.espressoLight }]}>
+            We couldn't load showroom locations
+          </Text>
+          <Text style={[styles.errorDetail, { color: colors.espressoLight }]}>
+            {error.message}
+          </Text>
+        </View>
+      </View>
+    );
+  }
+
   return (
     <View
       style={[styles.container, { backgroundColor: colors.sandBase }]}
@@ -80,7 +125,7 @@ export function StoreLocatorScreen({ onStorePress, userLatitude, userLongitude, 
       <View style={[styles.header, { paddingHorizontal: spacing.md }]}>
         <Text style={[styles.title, { color: colors.espresso }]}>Find a Showroom</Text>
         <Text style={[styles.subtitle, { color: colors.espressoLight }]}>
-          {STORES.length} locations across the Carolinas
+          {stores.length} locations across the Carolinas
         </Text>
       </View>
 
@@ -127,5 +172,21 @@ const styles = StyleSheet.create({
   listContent: {
     flexGrow: 1,
     paddingBottom: 24,
+  },
+  centeredMessage: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 24,
+  },
+  messageText: {
+    fontSize: 16,
+    textAlign: 'center',
+  },
+  errorDetail: {
+    fontSize: 14,
+    textAlign: 'center',
+    marginTop: 8,
+    opacity: 0.7,
   },
 });

--- a/src/screens/__tests__/StoreDetailScreen.refactor.test.tsx
+++ b/src/screens/__tests__/StoreDetailScreen.refactor.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Tests for StoreDetailScreen refactor: verifying it uses useStoreById hook
+ * instead of importing STORES directly.
+ */
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { StoreDetailScreen } from '../StoreDetailScreen';
+import { ThemeProvider } from '@/theme/ThemeProvider';
+import { STORES } from '@/data/stores';
+
+const mockUseStoreById = jest.fn();
+jest.mock('@/hooks/useStores', () => ({
+  useStoreById: (...args: any[]) => mockUseStoreById(...args),
+}));
+
+function renderScreen(props: Partial<React.ComponentProps<typeof StoreDetailScreen>> = {}) {
+  return render(
+    <ThemeProvider>
+      <StoreDetailScreen {...props} />
+    </ThemeProvider>,
+  );
+}
+
+describe('StoreDetailScreen hook integration', () => {
+  const ashevilleStore = STORES[0];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseStoreById.mockReturnValue({
+      store: ashevilleStore,
+      isLoading: false,
+      error: null,
+    });
+  });
+
+  it('calls useStoreById with the store id', () => {
+    renderScreen({ storeId: 'store-asheville' });
+    expect(mockUseStoreById).toHaveBeenCalledWith('store-asheville');
+  });
+
+  it('renders normally when hook returns store', () => {
+    const { getByTestId } = renderScreen({ storeId: 'store-asheville' });
+    expect(getByTestId('store-detail-screen')).toBeTruthy();
+    expect(getByTestId('store-detail-name')).toBeTruthy();
+  });
+
+  it('shows loading state when store is loading', () => {
+    mockUseStoreById.mockReturnValue({
+      store: null,
+      isLoading: true,
+      error: null,
+    });
+
+    const { getByTestId, getByText } = renderScreen({ storeId: 'store-asheville' });
+    expect(getByTestId('store-loading')).toBeTruthy();
+    expect(getByText(/loading/i)).toBeTruthy();
+  });
+
+  it('shows error state when store fails to load', () => {
+    mockUseStoreById.mockReturnValue({
+      store: null,
+      isLoading: false,
+      error: new Error('Network error'),
+    });
+
+    const { getByTestId, getByText } = renderScreen({ storeId: 'store-asheville' });
+    expect(getByTestId('store-error')).toBeTruthy();
+    expect(getByText(/couldn't load/i)).toBeTruthy();
+  });
+
+  it('shows not-found when hook returns null store without error', () => {
+    mockUseStoreById.mockReturnValue({
+      store: null,
+      isLoading: false,
+      error: null,
+    });
+
+    const { getByText } = renderScreen({ storeId: 'nonexistent' });
+    expect(getByText('Store not found')).toBeTruthy();
+  });
+
+  it('prefers store prop over hook when provided', () => {
+    const { getByTestId } = renderScreen({ store: ashevilleStore });
+    expect(getByTestId('store-detail-name').props.children).toBe(ashevilleStore.name);
+  });
+});

--- a/src/screens/__tests__/StoreLocatorScreen.refactor.test.tsx
+++ b/src/screens/__tests__/StoreLocatorScreen.refactor.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Tests for StoreLocatorScreen refactor: verifying it uses useStores hook
+ * instead of importing STORES directly.
+ */
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { StoreLocatorScreen } from '../StoreLocatorScreen';
+import { ThemeProvider } from '@/theme/ThemeProvider';
+import { STORES } from '@/data/stores';
+
+const mockUseStores = jest.fn();
+jest.mock('@/hooks/useStores', () => ({
+  useStores: (...args: any[]) => mockUseStores(...args),
+}));
+
+function renderScreen(props: Partial<React.ComponentProps<typeof StoreLocatorScreen>> = {}) {
+  return render(
+    <ThemeProvider>
+      <StoreLocatorScreen {...props} />
+    </ThemeProvider>,
+  );
+}
+
+describe('StoreLocatorScreen hook integration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseStores.mockReturnValue({
+      stores: STORES,
+      isLoading: false,
+      error: null,
+      getStoreById: (id: string) => STORES.find((s) => s.id === id),
+    });
+  });
+
+  it('calls useStores to get store data', () => {
+    renderScreen();
+    expect(mockUseStores).toHaveBeenCalled();
+  });
+
+  it('renders normally when hook returns data', () => {
+    const { getByTestId } = renderScreen();
+    expect(getByTestId('store-locator-screen')).toBeTruthy();
+    expect(getByTestId('store-list')).toBeTruthy();
+  });
+
+  it('shows loading state when stores are loading', () => {
+    mockUseStores.mockReturnValue({
+      stores: [],
+      isLoading: true,
+      error: null,
+      getStoreById: () => undefined,
+    });
+
+    const { getByTestId, getByText } = renderScreen();
+    expect(getByTestId('stores-loading')).toBeTruthy();
+    expect(getByText(/loading/i)).toBeTruthy();
+  });
+
+  it('shows error state when stores fail to load', () => {
+    mockUseStores.mockReturnValue({
+      stores: [],
+      isLoading: false,
+      error: new Error('Failed to fetch'),
+      getStoreById: () => undefined,
+    });
+
+    const { getByTestId, getByText } = renderScreen();
+    expect(getByTestId('stores-error')).toBeTruthy();
+    expect(getByText(/couldn't load/i)).toBeTruthy();
+  });
+
+  it('uses hook data for store count subtitle', () => {
+    const { getByText } = renderScreen();
+    expect(getByText(`${STORES.length} locations across the Carolinas`)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary
- StoreLocatorScreen + StoreDetailScreen now get store data through `useStores()`/`useStoreById()` hooks instead of importing `STORES` directly
- Added loading and error UI states for async hook lifecycle
- New `useStores` and `useStoreById` hooks (static data, designed for drop-in Wix CMS API replacement)

## Changes
- `src/hooks/useStores.ts` — new hooks wrapping store data
- `src/hooks/__tests__/useStores.test.ts` — 10 tests for hook behavior
- `src/screens/StoreLocatorScreen.tsx` — replaced STORES import with useStores(), added loading/error states
- `src/screens/StoreDetailScreen.tsx` — replaced STORES import with useStoreById(), added loading/error states
- `src/screens/__tests__/StoreLocatorScreen.refactor.test.tsx` — 5 tests verifying hook integration
- `src/screens/__tests__/StoreDetailScreen.refactor.test.tsx` — 6 tests verifying hook integration

## Test plan
- [x] `useStores` hook: returns stores, getStoreById, stable refs (10 tests)
- [x] `useStoreById` hook: lookup, null/undefined handling
- [x] StoreLocatorScreen integration: hook calls, loading, error, store count (5 tests)
- [x] StoreDetailScreen integration: hook calls, loading, error, not-found, prop priority (6 tests)
- [x] All 1537 existing tests pass without modification

🤖 Generated with [Claude Code](https://claude.com/claude-code)