### PR TITLE
fix(design): align tokens, badge colors, and hard-coded styles with web

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -21,7 +21,7 @@ export function ProductCard({ product, onPress, onLongPress, testID }: Props) {
       : product.badge === 'New'
         ? colors.mountainBlue
         : product.badge === 'Bestseller'
-          ? colors.success
+          ? colors.mountainBlue
           : colors.espressoLight;
 
   return (

--- a/src/components/ViewInRoomButton.tsx
+++ b/src/components/ViewInRoomButton.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback } from 'react';
 import { StyleSheet, Text, TouchableOpacity, View, Platform } from 'react-native';
 import * as Haptics from 'expo-haptics';
+import { useTheme } from '@/theme';
 import { events } from '@/services/analytics';
 import type { Product } from '@/data/products';
 
@@ -25,6 +26,8 @@ export function ViewInRoomButton({
   disabled = false,
   testID = 'view-in-room-btn',
 }: Props) {
+  const { colors, borderRadius } = useTheme();
+
   const handlePress = useCallback(() => {
     if (disabled) return;
 
@@ -46,7 +49,16 @@ export function ViewInRoomButton({
 
   return (
     <TouchableOpacity
-      style={[styles.button, isCompact && styles.buttonCompact, disabled && styles.buttonDisabled]}
+      style={[
+        styles.button,
+        {
+          backgroundColor: `${colors.sunsetCoral}1F`,
+          borderColor: colors.sunsetCoral,
+          borderRadius: borderRadius.lg,
+        },
+        isCompact && { ...styles.buttonCompact, borderRadius: borderRadius.md },
+        disabled && styles.buttonDisabled,
+      ]}
       onPress={handlePress}
       disabled={disabled}
       testID={testID}
@@ -60,7 +72,9 @@ export function ViewInRoomButton({
         <Text style={[styles.icon, isCompact && styles.iconCompact]}>{'\u{1F4F7}'}</Text>
       </View>
       {!isCompact && (
-        <Text style={[styles.label, disabled && styles.labelDisabled]}>View in Your Room</Text>
+        <Text style={[styles.label, { color: colors.sunsetCoral }, disabled && styles.labelDisabled]}>
+          View in Your Room
+        </Text>
       )}
     </TouchableOpacity>
   );
@@ -70,10 +84,7 @@ const styles = StyleSheet.create({
   button: {
     flexDirection: 'row',
     alignItems: 'center',
-    backgroundColor: 'rgba(232, 132, 92, 0.12)',
     borderWidth: 1,
-    borderColor: '#E8845C',
-    borderRadius: 10,
     paddingHorizontal: 16,
     paddingVertical: 10,
     gap: 8,
@@ -81,7 +92,6 @@ const styles = StyleSheet.create({
   buttonCompact: {
     paddingHorizontal: 10,
     paddingVertical: 8,
-    borderRadius: 8,
   },
   buttonDisabled: {
     opacity: 0.4,
@@ -97,11 +107,10 @@ const styles = StyleSheet.create({
     fontSize: 16,
   },
   label: {
-    color: '#E8845C',
     fontSize: 14,
     fontWeight: '600',
   },
   labelDisabled: {
-    color: 'rgba(232, 132, 92, 0.5)',
+    opacity: 0.5,
   },
 });

--- a/src/components/__tests__/ViewInRoomButton.test.tsx
+++ b/src/components/__tests__/ViewInRoomButton.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { Platform } from 'react-native';
+import { ThemeProvider } from '@/theme/ThemeProvider';
 import { type Product } from '@/data/products';
 import { type FutonModel } from '@/data/futons';
 
@@ -106,6 +107,10 @@ try {
   ViewInRoomButton = null;
 }
 
+function renderWithTheme(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
 const describeIfImplemented = ViewInRoomButton ? describe : describe.skip;
 
 describeIfImplemented('ViewInRoomButton', () => {
@@ -124,41 +129,41 @@ describeIfImplemented('ViewInRoomButton', () => {
   // ==========================================================================
   describe('Rendering', () => {
     it('renders for futon products', () => {
-      const { getByTestId } = render(<ViewInRoomButton {...defaultProps} />);
+      const { getByTestId } = renderWithTheme(<ViewInRoomButton {...defaultProps} />);
       expect(getByTestId('view-in-room-btn')).toBeTruthy();
     });
 
     it('renders for frame products', () => {
-      const { getByTestId } = render(<ViewInRoomButton {...defaultProps} product={frameProduct} />);
+      const { getByTestId } = renderWithTheme(<ViewInRoomButton {...defaultProps} product={frameProduct} />);
       expect(getByTestId('view-in-room-btn')).toBeTruthy();
     });
 
     it('does NOT render for non-AR categories (covers)', () => {
-      const { queryByTestId } = render(
+      const { queryByTestId } = renderWithTheme(
         <ViewInRoomButton {...defaultProps} product={coverProduct} />,
       );
       expect(queryByTestId('view-in-room-btn')).toBeNull();
     });
 
     it('does NOT render for out-of-stock products', () => {
-      const { queryByTestId } = render(
+      const { queryByTestId } = renderWithTheme(
         <ViewInRoomButton {...defaultProps} product={outOfStockFuton} />,
       );
       expect(queryByTestId('view-in-room-btn')).toBeNull();
     });
 
     it('shows "View in Your Room" text', () => {
-      const { getByText } = render(<ViewInRoomButton {...defaultProps} />);
+      const { getByText } = renderWithTheme(<ViewInRoomButton {...defaultProps} />);
       expect(getByText('View in Your Room')).toBeTruthy();
     });
 
     it('shows camera icon', () => {
-      const { getByTestId } = render(<ViewInRoomButton {...defaultProps} />);
+      const { getByTestId } = renderWithTheme(<ViewInRoomButton {...defaultProps} />);
       expect(getByTestId('view-in-room-camera-icon')).toBeTruthy();
     });
 
     it('renders with custom testID', () => {
-      const { getByTestId } = render(<ViewInRoomButton {...defaultProps} testID="custom-ar-btn" />);
+      const { getByTestId } = renderWithTheme(<ViewInRoomButton {...defaultProps} testID="custom-ar-btn" />);
       expect(getByTestId('custom-ar-btn')).toBeTruthy();
     });
   });
@@ -169,26 +174,26 @@ describeIfImplemented('ViewInRoomButton', () => {
   describe('Interaction', () => {
     it('calls onPress with product when tapped', () => {
       const onPress = jest.fn();
-      const { getByTestId } = render(<ViewInRoomButton {...defaultProps} onPress={onPress} />);
+      const { getByTestId } = renderWithTheme(<ViewInRoomButton {...defaultProps} onPress={onPress} />);
       fireEvent.press(getByTestId('view-in-room-btn'));
       expect(onPress).toHaveBeenCalledTimes(1);
       expect(onPress).toHaveBeenCalledWith(futonProduct);
     });
 
     it('does not crash when onPress is not provided', () => {
-      const { getByTestId } = render(<ViewInRoomButton product={futonProduct} />);
+      const { getByTestId } = renderWithTheme(<ViewInRoomButton product={futonProduct} />);
       fireEvent.press(getByTestId('view-in-room-btn'));
     });
 
     it('fires haptic feedback on press', () => {
       const Haptics = require('expo-haptics');
-      const { getByTestId } = render(<ViewInRoomButton {...defaultProps} />);
+      const { getByTestId } = renderWithTheme(<ViewInRoomButton {...defaultProps} />);
       fireEvent.press(getByTestId('view-in-room-btn'));
       expect(Haptics.impactAsync).toHaveBeenCalled();
     });
 
     it('tracks analytics event on press', () => {
-      const { getByTestId } = render(<ViewInRoomButton {...defaultProps} />);
+      const { getByTestId } = renderWithTheme(<ViewInRoomButton {...defaultProps} />);
       fireEvent.press(getByTestId('view-in-room-btn'));
       expect(mockArViewInRoomTap).toHaveBeenCalledWith(futonProduct.id, futonProduct.category);
     });
@@ -199,7 +204,7 @@ describeIfImplemented('ViewInRoomButton', () => {
   // ==========================================================================
   describe('Accessibility', () => {
     it('has correct accessibility label', () => {
-      const { getByTestId } = render(<ViewInRoomButton {...defaultProps} />);
+      const { getByTestId } = renderWithTheme(<ViewInRoomButton {...defaultProps} />);
       const btn = getByTestId('view-in-room-btn');
       expect(btn.props.accessibilityLabel).toBe(
         'View The Asheville Full Futon in your room using AR camera',
@@ -207,12 +212,12 @@ describeIfImplemented('ViewInRoomButton', () => {
     });
 
     it('has button accessibility role', () => {
-      const { getByTestId } = render(<ViewInRoomButton {...defaultProps} />);
+      const { getByTestId } = renderWithTheme(<ViewInRoomButton {...defaultProps} />);
       expect(getByTestId('view-in-room-btn').props.accessibilityRole).toBe('button');
     });
 
     it('has descriptive accessibility hint', () => {
-      const { getByTestId } = render(<ViewInRoomButton {...defaultProps} />);
+      const { getByTestId } = renderWithTheme(<ViewInRoomButton {...defaultProps} />);
       const btn = getByTestId('view-in-room-btn');
       expect(btn.props.accessibilityHint).toContain('camera');
     });
@@ -223,23 +228,23 @@ describeIfImplemented('ViewInRoomButton', () => {
   // ==========================================================================
   describe('Size Variants', () => {
     it('renders compact size variant (for ProductCard)', () => {
-      const { getByTestId } = render(<ViewInRoomButton {...defaultProps} size="compact" />);
+      const { getByTestId } = renderWithTheme(<ViewInRoomButton {...defaultProps} size="compact" />);
       expect(getByTestId('view-in-room-btn')).toBeTruthy();
     });
 
     it('renders full size variant (for ProductDetailScreen)', () => {
-      const { getByTestId } = render(<ViewInRoomButton {...defaultProps} size="full" />);
+      const { getByTestId } = renderWithTheme(<ViewInRoomButton {...defaultProps} size="full" />);
       expect(getByTestId('view-in-room-btn')).toBeTruthy();
     });
 
     it('defaults to full size', () => {
-      const { getByTestId } = render(<ViewInRoomButton {...defaultProps} />);
+      const { getByTestId } = renderWithTheme(<ViewInRoomButton {...defaultProps} />);
       // Full variant shows the text label
       expect(getByTestId('view-in-room-btn')).toBeTruthy();
     });
 
     it('compact variant still shows icon', () => {
-      const { getByTestId } = render(<ViewInRoomButton {...defaultProps} size="compact" />);
+      const { getByTestId } = renderWithTheme(<ViewInRoomButton {...defaultProps} size="compact" />);
       expect(getByTestId('view-in-room-camera-icon')).toBeTruthy();
     });
   });
@@ -250,7 +255,7 @@ describeIfImplemented('ViewInRoomButton', () => {
   describe('Disabled State', () => {
     it('can be explicitly disabled', () => {
       const onPress = jest.fn();
-      const { getByTestId } = render(
+      const { getByTestId } = renderWithTheme(
         <ViewInRoomButton {...defaultProps} onPress={onPress} disabled />,
       );
       fireEvent.press(getByTestId('view-in-room-btn'));
@@ -258,7 +263,7 @@ describeIfImplemented('ViewInRoomButton', () => {
     });
 
     it('shows disabled accessibility state when disabled', () => {
-      const { getByTestId } = render(<ViewInRoomButton {...defaultProps} disabled />);
+      const { getByTestId } = renderWithTheme(<ViewInRoomButton {...defaultProps} disabled />);
       expect(getByTestId('view-in-room-btn').props.accessibilityState).toEqual(
         expect.objectContaining({ disabled: true }),
       );

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -11,7 +11,7 @@ interface Props {
 }
 
 export function HomeScreen({ onOpenAR, onOpenShop }: Props) {
-  const { colors, spacing, typography } = useTheme();
+  const { colors, spacing, typography, shadows, borderRadius } = useTheme();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
 
   const handleOpenAR = useCallback(() => {
@@ -52,7 +52,7 @@ export function HomeScreen({ onOpenAR, onOpenShop }: Props) {
 
       {/* AR CTA */}
       <TouchableOpacity
-        style={[styles.ctaButton, { backgroundColor: colors.sunsetCoral }]}
+        style={[styles.ctaButton, shadows.cardHover, { backgroundColor: colors.sunsetCoral, borderRadius: borderRadius.xl }]}
         onPress={handleOpenAR}
         testID="home-ar-button"
         accessibilityLabel="Try futons in your room with AR camera"
@@ -67,7 +67,7 @@ export function HomeScreen({ onOpenAR, onOpenShop }: Props) {
 
       {/* Shop CTA */}
       <TouchableOpacity
-        style={[styles.ctaButton, { backgroundColor: colors.mountainBlue }]}
+        style={[styles.ctaButton, shadows.cardHover, { backgroundColor: colors.mountainBlue, borderRadius: borderRadius.xl }]}
         onPress={handleOpenShop}
         testID="home-shop-button"
         accessibilityLabel="Browse our products"
@@ -103,13 +103,7 @@ const styles = StyleSheet.create({
     marginTop: 16,
     paddingHorizontal: 24,
     paddingVertical: 16,
-    borderRadius: 16,
     gap: 14,
-    shadowColor: '#3A2518',
-    shadowOffset: { width: 0, height: 4 },
-    shadowOpacity: 0.15,
-    shadowRadius: 12,
-    elevation: 4,
   },
   ctaIcon: {
     fontSize: 28,

--- a/src/theme/__tests__/tokens.test.ts
+++ b/src/theme/__tests__/tokens.test.ts
@@ -18,7 +18,12 @@ describe('Design Tokens', () => {
       expect(colors.success).toBeDefined();
       expect(colors.error).toBeDefined();
       expect(colors.muted).toBeDefined();
+      expect(colors.offWhite).toBeDefined();
       expect(colors.white).toBeDefined();
+    });
+
+    it('has correct offWhite token matching web sharedTokens', () => {
+      expect(colors.offWhite).toBe('#FAF7F2');
     });
 
     it('uses valid hex color format for solid colors', () => {

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -19,6 +19,7 @@ export const colors = {
   mauve: '#C9A0A0',
   skyGradientTop: '#B8D4E3',
   skyGradientBottom: '#F0C87A',
+  offWhite: '#FAF7F2',
   white: '#FFFFFF',
   overlay: 'rgba(58, 37, 24, 0.6)',
   // Semantic / status


### PR DESCRIPTION
## Summary
- Add missing `offWhite` (#FAF7F2) color token to match web `sharedTokens.js`
- Refactor `ViewInRoomButton` to use `useTheme()` hook instead of hard-coded `rgba(232,132,92,0.12)` / `#E8845C`
- Refactor `HomeScreen` ctaButton to use `shadows.cardHover` + `borderRadius.xl` from theme instead of hard-coded shadow
- Change Bestseller badge color from `success` (green) to `mountainBlue` (#5B8FA8) to match web

## Test plan
- [x] 87/88 test suites passing, 1657 tests green
- [x] ViewInRoomButton tests updated to use ThemeProvider wrapper
- [x] New test: offWhite token exists with correct hex value
- [x] No visual regressions in existing tests

Addresses melania's design alignment audit (3 gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)