### PR TITLE
feat: onboarding flow — 3-slide carousel (cm-m2z)

### DIFF
--- a/__tests__/App.test.tsx
+++ b/__tests__/App.test.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
 
+// Mock AsyncStorage — returning user (skip onboarding)
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(() => Promise.resolve('true')),
+  setItem: jest.fn(() => Promise.resolve()),
+}));
+
 // Mock font packages
 jest.mock('expo-font', () => ({
   useFonts: () => [true],

--- a/src/hooks/__tests__/useOnboarding.test.ts
+++ b/src/hooks/__tests__/useOnboarding.test.ts
@@ -1,0 +1,82 @@
+import { renderHook, act } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useOnboarding } from '../useOnboarding';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+}));
+
+const mockGetItem = AsyncStorage.getItem as jest.Mock;
+const mockSetItem = AsyncStorage.setItem as jest.Mock;
+
+describe('useOnboarding', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns isLoading true initially', () => {
+    mockGetItem.mockReturnValue(new Promise(() => {})); // never resolves
+    const { result } = renderHook(() => useOnboarding());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('returns hasSeenOnboarding false for new users', async () => {
+    mockGetItem.mockResolvedValue(null);
+    const { result } = renderHook(() => useOnboarding());
+    await act(async () => {});
+    expect(result.current.hasSeenOnboarding).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('returns hasSeenOnboarding true for returning users', async () => {
+    mockGetItem.mockResolvedValue('true');
+    const { result } = renderHook(() => useOnboarding());
+    await act(async () => {});
+    expect(result.current.hasSeenOnboarding).toBe(true);
+  });
+
+  it('completeOnboarding sets flag in AsyncStorage', async () => {
+    mockGetItem.mockResolvedValue(null);
+    mockSetItem.mockResolvedValue(undefined);
+    const { result } = renderHook(() => useOnboarding());
+    await act(async () => {});
+
+    await act(async () => {
+      await result.current.completeOnboarding();
+    });
+
+    expect(mockSetItem).toHaveBeenCalledWith('@carolina_futons_onboarding_complete', 'true');
+    expect(result.current.hasSeenOnboarding).toBe(true);
+  });
+
+  it('handles AsyncStorage read errors gracefully', async () => {
+    mockGetItem.mockRejectedValue(new Error('Storage error'));
+    const { result } = renderHook(() => useOnboarding());
+    await act(async () => {});
+    // On error, default to showing onboarding (false)
+    expect(result.current.hasSeenOnboarding).toBe(false);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('handles AsyncStorage write errors gracefully', async () => {
+    mockGetItem.mockResolvedValue(null);
+    mockSetItem.mockRejectedValue(new Error('Write error'));
+    const { result } = renderHook(() => useOnboarding());
+    await act(async () => {});
+
+    // Should not throw
+    await act(async () => {
+      await result.current.completeOnboarding();
+    });
+    // Still marks as complete in memory even if storage fails
+    expect(result.current.hasSeenOnboarding).toBe(true);
+  });
+
+  it('reads from correct storage key', async () => {
+    mockGetItem.mockResolvedValue(null);
+    renderHook(() => useOnboarding());
+    await act(async () => {});
+    expect(mockGetItem).toHaveBeenCalledWith('@carolina_futons_onboarding_complete');
+  });
+});

--- a/src/hooks/useOnboarding.ts
+++ b/src/hooks/useOnboarding.ts
@@ -1,0 +1,39 @@
+import { useState, useEffect, useCallback } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+const STORAGE_KEY = '@carolina_futons_onboarding_complete';
+
+interface UseOnboardingReturn {
+  isLoading: boolean;
+  hasSeenOnboarding: boolean;
+  completeOnboarding: () => Promise<void>;
+}
+
+export function useOnboarding(): UseOnboardingReturn {
+  const [isLoading, setIsLoading] = useState(true);
+  const [hasSeenOnboarding, setHasSeenOnboarding] = useState(false);
+
+  useEffect(() => {
+    AsyncStorage.getItem(STORAGE_KEY)
+      .then((value) => {
+        setHasSeenOnboarding(value === 'true');
+      })
+      .catch(() => {
+        setHasSeenOnboarding(false);
+      })
+      .finally(() => {
+        setIsLoading(false);
+      });
+  }, []);
+
+  const completeOnboarding = useCallback(async () => {
+    try {
+      await AsyncStorage.setItem(STORAGE_KEY, 'true');
+    } catch {
+      // Storage write failed — still mark complete in memory
+    }
+    setHasSeenOnboarding(true);
+  }, []);
+
+  return { isLoading, hasSeenOnboarding, completeOnboarding };
+}

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -1,5 +1,7 @@
-import React from 'react';
+import React, { useCallback } from 'react';
+import { ActivityIndicator, View } from 'react-native';
 import { createNativeStackNavigator } from '@react-navigation/native-stack';
+import { CommonActions } from '@react-navigation/native';
 import { TabNavigator } from './TabNavigator';
 import { ARScreen } from '@/screens/ARScreen';
 import { ProductDetailScreen } from '@/screens/ProductDetailScreen';
@@ -15,8 +17,11 @@ import { WishlistScreen } from '@/screens/WishlistScreen';
 import { StoreLocatorScreen } from '@/screens/StoreLocatorScreen';
 import { StoreDetailScreen } from '@/screens/StoreDetailScreen';
 import { ARWebScreen, type ARWebScreenParams } from '@/screens/ARWebScreen';
+import { OnboardingScreen } from '@/screens/OnboardingScreen';
+import { useOnboarding } from '@/hooks/useOnboarding';
 
 export type RootStackParamList = {
+  Onboarding: undefined;
   Tabs: undefined;
   AR: { initialModelId?: string } | undefined;
   ProductDetail: { slug: string };
@@ -37,8 +42,34 @@ export type RootStackParamList = {
 const Stack = createNativeStackNavigator<RootStackParamList>();
 
 export function AppNavigator() {
+  const { isLoading, hasSeenOnboarding, completeOnboarding } = useOnboarding();
+
+  const handleOnboardingComplete = useCallback(() => {
+    completeOnboarding();
+  }, [completeOnboarding]);
+
+  if (isLoading) {
+    return (
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#E8D5B7' }} testID="onboarding-loading">
+        <ActivityIndicator size="large" color="#E8845C" />
+      </View>
+    );
+  }
+
   return (
-    <Stack.Navigator screenOptions={{ headerShown: false }}>
+    <Stack.Navigator screenOptions={{ headerShown: false }} initialRouteName={hasSeenOnboarding ? 'Tabs' : 'Onboarding'}>
+      <Stack.Screen name="Onboarding">
+        {({ navigation: nav }) => (
+          <OnboardingScreen
+            onComplete={() => {
+              handleOnboardingComplete();
+              nav.dispatch(
+                CommonActions.reset({ index: 0, routes: [{ name: 'Tabs' }] }),
+              );
+            }}
+          />
+        )}
+      </Stack.Screen>
       <Stack.Screen name="Tabs" component={TabNavigator} />
       <Stack.Screen
         name="AR"

--- a/src/screens/OnboardingScreen.tsx
+++ b/src/screens/OnboardingScreen.tsx
@@ -1,0 +1,220 @@
+import React, { useState } from 'react';
+import { StyleSheet, Text, View, TouchableOpacity, Dimensions } from 'react-native';
+import { useTheme } from '@/theme';
+
+const { width: SCREEN_WIDTH } = Dimensions.get('window');
+
+interface Slide {
+  title: string;
+  description: string;
+  emoji: string;
+}
+
+const SLIDES: Slide[] = [
+  {
+    title: 'Welcome to Carolina Futons',
+    description:
+      'Handcrafted comfort from the Blue Ridge Mountains, delivered to your door.',
+    emoji: '🛋️',
+  },
+  {
+    title: 'See It In Your Space',
+    description:
+      'Use AR to preview how our futons look in your room before you buy.',
+    emoji: '📱',
+  },
+  {
+    title: 'Shop With Confidence',
+    description:
+      'Free shipping, easy returns, and flexible payment options on every order.',
+    emoji: '✨',
+  },
+];
+
+interface Props {
+  onComplete: () => void;
+  testID?: string;
+}
+
+export function OnboardingScreen({ onComplete, testID }: Props) {
+  const { colors, spacing, borderRadius, typography, shadows } = useTheme();
+  const [currentIndex, setCurrentIndex] = useState(0);
+
+  const isLastSlide = currentIndex === SLIDES.length - 1;
+  const slide = SLIDES[currentIndex];
+
+  const handleNext = () => {
+    if (isLastSlide) return;
+    setCurrentIndex((i) => i + 1);
+  };
+
+  return (
+    <View
+      style={[styles.root, { backgroundColor: colors.sandBase }]}
+      testID={testID ?? 'onboarding-screen'}
+    >
+      {/* Skip button */}
+      {!isLastSlide && (
+        <TouchableOpacity
+          style={[styles.skipButton, { top: spacing.xxl }]}
+          onPress={onComplete}
+          testID="onboarding-skip-button"
+          accessibilityLabel="Skip onboarding"
+          accessibilityRole="button"
+        >
+          <Text style={[styles.skipText, { color: colors.muted }]}>Skip</Text>
+        </TouchableOpacity>
+      )}
+
+      {/* Slide content */}
+      <View style={styles.slideContainer}>
+        <Text style={styles.emoji}>{slide.emoji}</Text>
+        <Text
+          style={[
+            styles.title,
+            {
+              color: colors.espresso,
+              fontFamily: typography.headingFamily,
+            },
+          ]}
+        >
+          {slide.title}
+        </Text>
+        <Text
+          style={[
+            styles.description,
+            {
+              color: colors.espressoLight,
+              fontFamily: typography.bodyFamily,
+            },
+          ]}
+        >
+          {slide.description}
+        </Text>
+      </View>
+
+      {/* Pagination dots */}
+      <View style={styles.dotsContainer}>
+        {SLIDES.map((_, index) => (
+          <View
+            key={index}
+            testID={`onboarding-dot-${index}`}
+            style={[
+              styles.dot,
+              {
+                backgroundColor:
+                  index === currentIndex
+                    ? colors.sunsetCoral
+                    : colors.sandLight,
+                width: index === currentIndex ? 24 : 8,
+                borderRadius: borderRadius.pill,
+              },
+            ]}
+          />
+        ))}
+      </View>
+
+      {/* Action button */}
+      <View style={[styles.buttonContainer, { paddingHorizontal: spacing.lg }]}>
+        {isLastSlide ? (
+          <TouchableOpacity
+            style={[
+              styles.actionButton,
+              {
+                backgroundColor: colors.sunsetCoral,
+                borderRadius: borderRadius.button,
+              },
+              shadows.button,
+            ]}
+            onPress={onComplete}
+            testID="onboarding-get-started-button"
+            accessibilityLabel="Get started"
+            accessibilityRole="button"
+          >
+            <Text style={[styles.actionButtonText, { color: colors.white }]}>
+              Get Started
+            </Text>
+          </TouchableOpacity>
+        ) : (
+          <TouchableOpacity
+            style={[
+              styles.actionButton,
+              {
+                backgroundColor: colors.sunsetCoral,
+                borderRadius: borderRadius.button,
+              },
+              shadows.button,
+            ]}
+            onPress={handleNext}
+            testID="onboarding-next-button"
+            accessibilityLabel="Next slide"
+            accessibilityRole="button"
+          >
+            <Text style={[styles.actionButtonText, { color: colors.white }]}>
+              Next
+            </Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    justifyContent: 'center',
+  },
+  skipButton: {
+    position: 'absolute',
+    right: 24,
+    zIndex: 10,
+    padding: 8,
+  },
+  skipText: {
+    fontSize: 15,
+    fontWeight: '500',
+  },
+  slideContainer: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 32,
+  },
+  emoji: {
+    fontSize: 64,
+    marginBottom: 24,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: '700',
+    textAlign: 'center',
+    marginBottom: 16,
+  },
+  description: {
+    fontSize: 16,
+    textAlign: 'center',
+    lineHeight: 24,
+  },
+  dotsContainer: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'center',
+    gap: 8,
+    marginBottom: 32,
+  },
+  dot: {
+    height: 8,
+  },
+  buttonContainer: {
+    paddingBottom: 48,
+  },
+  actionButton: {
+    paddingVertical: 16,
+    alignItems: 'center',
+  },
+  actionButtonText: {
+    fontSize: 17,
+    fontWeight: '700',
+  },
+});

--- a/src/screens/__tests__/OnboardingScreen.test.tsx
+++ b/src/screens/__tests__/OnboardingScreen.test.tsx
@@ -1,0 +1,116 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { OnboardingScreen } from '../OnboardingScreen';
+
+// Mock useTheme
+jest.mock('@/theme', () => ({
+  useTheme: () => ({
+    colors: {
+      sandBase: '#E8D5B7',
+      sandLight: '#F2E8D5',
+      espresso: '#3A2518',
+      espressoLight: '#5C4033',
+      sunsetCoral: '#E8845C',
+      mountainBlue: '#5B8FA8',
+      white: '#FFFFFF',
+      muted: '#999999',
+    },
+    spacing: { xs: 4, sm: 8, md: 16, lg: 24, xl: 32, xxl: 48 },
+    borderRadius: { button: 8, pill: 9999 },
+    typography: {
+      headingFamily: 'PlayfairDisplay_700Bold',
+      bodyFamily: 'SourceSans3_400Regular',
+      heroTitle: { fontSize: 36, fontWeight: '700', lineHeight: 40 },
+      h2: { fontSize: 24, fontWeight: '700', lineHeight: 30 },
+      body: { fontSize: 15, fontWeight: '400', lineHeight: 22 },
+      button: { fontSize: 15, fontWeight: '600', lineHeight: 15, letterSpacing: 0.5 },
+    },
+    shadows: { button: {} },
+  }),
+}));
+
+describe('OnboardingScreen', () => {
+  const mockOnComplete = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('renders the first slide by default', () => {
+    const { getByTestId, getByText } = render(
+      <OnboardingScreen onComplete={mockOnComplete} />,
+    );
+    expect(getByTestId('onboarding-screen')).toBeTruthy();
+    expect(getByText('Welcome to Carolina Futons')).toBeTruthy();
+  });
+
+  it('renders pagination dots matching slide count', () => {
+    const { getAllByTestId } = render(
+      <OnboardingScreen onComplete={mockOnComplete} />,
+    );
+    const dots = getAllByTestId(/^onboarding-dot-/);
+    expect(dots.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('shows active dot for current slide', () => {
+    const { getByTestId } = render(
+      <OnboardingScreen onComplete={mockOnComplete} />,
+    );
+    expect(getByTestId('onboarding-dot-0')).toBeTruthy();
+  });
+
+  it('shows Next button on non-final slides', () => {
+    const { getByTestId } = render(
+      <OnboardingScreen onComplete={mockOnComplete} />,
+    );
+    expect(getByTestId('onboarding-next-button')).toBeTruthy();
+  });
+
+  it('advances to next slide when Next is pressed', () => {
+    const { getByTestId, getByText } = render(
+      <OnboardingScreen onComplete={mockOnComplete} />,
+    );
+    fireEvent.press(getByTestId('onboarding-next-button'));
+    // Should now show second slide content
+    expect(getByText('See It In Your Space')).toBeTruthy();
+  });
+
+  it('shows Get Started button on final slide', () => {
+    const { getByTestId } = render(
+      <OnboardingScreen onComplete={mockOnComplete} />,
+    );
+    // Navigate to last slide
+    fireEvent.press(getByTestId('onboarding-next-button'));
+    fireEvent.press(getByTestId('onboarding-next-button'));
+    expect(getByTestId('onboarding-get-started-button')).toBeTruthy();
+  });
+
+  it('calls onComplete when Get Started is pressed', () => {
+    const { getByTestId } = render(
+      <OnboardingScreen onComplete={mockOnComplete} />,
+    );
+    fireEvent.press(getByTestId('onboarding-next-button'));
+    fireEvent.press(getByTestId('onboarding-next-button'));
+    fireEvent.press(getByTestId('onboarding-get-started-button'));
+    expect(mockOnComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows Skip button that calls onComplete', () => {
+    const { getByTestId } = render(
+      <OnboardingScreen onComplete={mockOnComplete} />,
+    );
+    const skipButton = getByTestId('onboarding-skip-button');
+    expect(skipButton).toBeTruthy();
+    fireEvent.press(skipButton);
+    expect(mockOnComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not show Skip on final slide', () => {
+    const { getByTestId, queryByTestId } = render(
+      <OnboardingScreen onComplete={mockOnComplete} />,
+    );
+    fireEvent.press(getByTestId('onboarding-next-button'));
+    fireEvent.press(getByTestId('onboarding-next-button'));
+    expect(queryByTestId('onboarding-skip-button')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- **useOnboarding hook** — AsyncStorage-backed state for tracking whether user has completed onboarding (7 TDD tests)
- **OnboardingScreen** — 3-slide carousel (Welcome, AR preview, Shop with confidence) with Next/Skip/Get Started controls (9 TDD tests)
- **AppNavigator integration** — conditionally shows Onboarding or Tabs based on `hasSeenOnboarding`; resets nav stack on completion

## Test plan
- [x] useOnboarding: loading state, new/returning users, completeOnboarding, AsyncStorage read/write errors, correct storage key (7 tests)
- [x] OnboardingScreen: first slide render, pagination dots, active dot, Next/Skip/Get Started buttons, slide navigation, onComplete callback (9 tests)
- [x] App integration: returning users skip onboarding and see HomeScreen (3 existing tests pass with AsyncStorage mock)
- [x] Full suite: 90/91 suites, 1700 tests passing (1 skipped: useAuth pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)