### PR TITLE
feat: offline mode — order cache + OfflineBanner (cm-rqd)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -18,7 +18,9 @@ import { AuthProvider } from '@/hooks/useAuth';
 import { CartProvider } from '@/hooks/useCart';
 import { WishlistProvider } from '@/hooks/useWishlist';
 import { ConnectivityProvider } from '@/hooks/useConnectivity';
+import { NotificationProvider } from '@/hooks/useNotifications';
 import { AppNavigator, linkingConfig } from '@/navigation';
+import { OfflineBanner } from '@/components/OfflineBanner';
 
 SplashScreen.preventAutoHideAsync();
 
@@ -52,9 +54,12 @@ export default function App() {
           <AuthProvider>
             <CartProvider>
               <WishlistProvider>
-                <NavigationContainer linking={linkingConfig}>
-                  <AppNavigator />
-                </NavigationContainer>
+                <NotificationProvider>
+                  <NavigationContainer linking={linkingConfig}>
+                    <OfflineBanner />
+                    <AppNavigator />
+                  </NavigationContainer>
+                </NotificationProvider>
               </WishlistProvider>
             </CartProvider>
           </AuthProvider>

--- a/src/hooks/__tests__/useOrderCache.test.ts
+++ b/src/hooks/__tests__/useOrderCache.test.ts
@@ -1,0 +1,111 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  cacheOrders,
+  loadCachedOrders,
+  clearOrderCache,
+  ORDER_CACHE_KEY,
+} from '@/services/orderCache';
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn(),
+  setItem: jest.fn(),
+  removeItem: jest.fn(),
+}));
+
+const mockGetItem = AsyncStorage.getItem as jest.Mock;
+const mockSetItem = AsyncStorage.setItem as jest.Mock;
+const mockRemoveItem = AsyncStorage.removeItem as jest.Mock;
+
+const SAMPLE_ORDERS = [
+  {
+    id: 'order-1',
+    status: 'delivered',
+    createdAt: '2026-02-20T12:00:00Z',
+    items: [{ productId: 'prod-1', quantity: 1, price: 499 }],
+    total: 499,
+  },
+  {
+    id: 'order-2',
+    status: 'shipped',
+    createdAt: '2026-02-25T14:00:00Z',
+    items: [{ productId: 'prod-2', quantity: 2, price: 299 }],
+    total: 598,
+  },
+];
+
+describe('orderCache', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('cacheOrders', () => {
+    it('stores orders to AsyncStorage', async () => {
+      mockSetItem.mockResolvedValue(undefined);
+      await cacheOrders(SAMPLE_ORDERS as any);
+      expect(mockSetItem).toHaveBeenCalledWith(
+        ORDER_CACHE_KEY,
+        expect.any(String),
+      );
+      const stored = JSON.parse(mockSetItem.mock.calls[0][1]);
+      expect(stored.orders).toHaveLength(2);
+      expect(stored.cachedAt).toBeDefined();
+    });
+
+    it('handles storage write errors gracefully', async () => {
+      mockSetItem.mockRejectedValue(new Error('disk full'));
+      // Should not throw
+      await expect(cacheOrders(SAMPLE_ORDERS as any)).resolves.not.toThrow();
+    });
+  });
+
+  describe('loadCachedOrders', () => {
+    it('returns cached orders when available', async () => {
+      const cached = JSON.stringify({
+        orders: SAMPLE_ORDERS,
+        cachedAt: new Date().toISOString(),
+      });
+      mockGetItem.mockResolvedValue(cached);
+      const result = await loadCachedOrders();
+      expect(result).not.toBeNull();
+      expect(result!.orders).toHaveLength(2);
+      expect(result!.orders[0].id).toBe('order-1');
+    });
+
+    it('returns null when no cache exists', async () => {
+      mockGetItem.mockResolvedValue(null);
+      const result = await loadCachedOrders();
+      expect(result).toBeNull();
+    });
+
+    it('returns null for corrupted cache data', async () => {
+      mockGetItem.mockResolvedValue('not-json{{{');
+      const result = await loadCachedOrders();
+      expect(result).toBeNull();
+    });
+
+    it('handles storage read errors gracefully', async () => {
+      mockGetItem.mockRejectedValue(new Error('Storage error'));
+      const result = await loadCachedOrders();
+      expect(result).toBeNull();
+    });
+
+    it('returns null for cache missing orders field', async () => {
+      mockGetItem.mockResolvedValue(JSON.stringify({ cachedAt: 'now' }));
+      const result = await loadCachedOrders();
+      expect(result).toBeNull();
+    });
+  });
+
+  describe('clearOrderCache', () => {
+    it('removes order cache from AsyncStorage', async () => {
+      mockRemoveItem.mockResolvedValue(undefined);
+      await clearOrderCache();
+      expect(mockRemoveItem).toHaveBeenCalledWith(ORDER_CACHE_KEY);
+    });
+
+    it('handles removal errors gracefully', async () => {
+      mockRemoveItem.mockRejectedValue(new Error('fail'));
+      await expect(clearOrderCache()).resolves.not.toThrow();
+    });
+  });
+});

--- a/src/services/orderCache.ts
+++ b/src/services/orderCache.ts
@@ -1,0 +1,41 @@
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import type { Order } from '@/data/orders';
+
+export const ORDER_CACHE_KEY = 'cfutons_order_history';
+
+interface CachedOrderData {
+  orders: Order[];
+  cachedAt: string;
+}
+
+export async function cacheOrders(orders: Order[]): Promise<void> {
+  try {
+    const data: CachedOrderData = {
+      orders,
+      cachedAt: new Date().toISOString(),
+    };
+    await AsyncStorage.setItem(ORDER_CACHE_KEY, JSON.stringify(data));
+  } catch {
+    // Storage write failed — silent
+  }
+}
+
+export async function loadCachedOrders(): Promise<CachedOrderData | null> {
+  try {
+    const stored = await AsyncStorage.getItem(ORDER_CACHE_KEY);
+    if (!stored) return null;
+    const parsed = JSON.parse(stored);
+    if (!parsed.orders || !Array.isArray(parsed.orders)) return null;
+    return parsed as CachedOrderData;
+  } catch {
+    return null;
+  }
+}
+
+export async function clearOrderCache(): Promise<void> {
+  try {
+    await AsyncStorage.removeItem(ORDER_CACHE_KEY);
+  } catch {
+    // Removal failed — silent
+  }
+}


### PR DESCRIPTION
## Summary
- **orderCache service** — `cacheOrders()`, `loadCachedOrders()`, `clearOrderCache()` for AsyncStorage-backed order history persistence (9 TDD tests)
- **OfflineBanner wired into App.tsx** — shows "You're offline" banner at top of app when connectivity drops (component + tests already existed, just needed integration)
- Cart, wishlist, and product catalog already persist via AsyncStorage (useCart, useWishlist, productCache)

## Test plan
- [x] orderCache: store orders, handle write errors, load cached orders, handle read errors, corrupted data, missing fields, clear cache (9 tests)
- [x] OfflineBanner: renders when offline, hidden when online (pre-existing tests)
- [x] Full suite: 89/90 suites, 1693 tests passing (1 skipped: useAuth pre-existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)