### PR TITLE
test: add ForgotPasswordScreen + SignUpScreen coverage (cm-2r7, cm-5z6)

### DIFF
--- a/src/screens/__tests__/ForgotPasswordScreen.test.tsx
+++ b/src/screens/__tests__/ForgotPasswordScreen.test.tsx
@@ -1,0 +1,186 @@
+import React from 'react';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { ForgotPasswordScreen } from '../ForgotPasswordScreen';
+import { AuthProvider } from '@/hooks/useAuth';
+import { ThemeProvider } from '@/theme/ThemeProvider';
+
+const mockAuthService = {
+  restoreSession: jest.fn().mockResolvedValue(false),
+  getCurrentMember: jest.fn().mockResolvedValue(null),
+  loginWithEmail: jest.fn(),
+  register: jest.fn(),
+  loginWithOAuth: jest.fn(),
+  sendPasswordReset: jest.fn(),
+  logout: jest.fn().mockResolvedValue(undefined),
+  isLoggedIn: jest.fn().mockReturnValue(false),
+  refreshSession: jest.fn(),
+};
+
+jest.mock('@/services/wix/wixAuth', () => ({
+  WixAuthService: jest.fn(() => mockAuthService),
+}));
+
+function renderScreen(props: Partial<React.ComponentProps<typeof ForgotPasswordScreen>> = {}) {
+  return render(
+    <ThemeProvider>
+      <AuthProvider>
+        <ForgotPasswordScreen {...props} />
+      </AuthProvider>
+    </ThemeProvider>,
+  );
+}
+
+describe('ForgotPasswordScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthService.restoreSession.mockResolvedValue(false);
+    mockAuthService.getCurrentMember.mockResolvedValue(null);
+    mockAuthService.sendPasswordReset.mockResolvedValue({ success: true });
+  });
+
+  describe('Rendering', () => {
+    it('renders with default testID', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('forgot-password-screen')).toBeTruthy());
+    });
+
+    it('renders custom testID', async () => {
+      const { getByTestId } = renderScreen({ testID: 'custom-forgot' });
+      await waitFor(() => expect(getByTestId('custom-forgot')).toBeTruthy());
+    });
+
+    it('shows title', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('forgot-title')).toBeTruthy());
+    });
+
+    it('renders email input', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('forgot-email-input')).toBeTruthy());
+    });
+
+    it('renders submit button', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('forgot-submit-button')).toBeTruthy());
+    });
+  });
+
+  describe('Back navigation', () => {
+    it('renders back button when onBack provided', async () => {
+      const { getByTestId } = renderScreen({ onBack: jest.fn() });
+      await waitFor(() => expect(getByTestId('forgot-back-button')).toBeTruthy());
+    });
+
+    it('does not render back button when onBack is undefined', async () => {
+      const { queryByTestId } = renderScreen();
+      await waitFor(() => expect(queryByTestId('forgot-title')).toBeTruthy());
+      expect(queryByTestId('forgot-back-button')).toBeNull();
+    });
+
+    it('calls onBack when back button pressed', async () => {
+      const onBack = jest.fn();
+      const { getByTestId } = renderScreen({ onBack });
+      await waitFor(() => expect(getByTestId('forgot-back-button')).toBeTruthy());
+      fireEvent.press(getByTestId('forgot-back-button'));
+      expect(onBack).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Form validation', () => {
+    it('shows email error for empty email', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('forgot-submit-button')).toBeTruthy());
+      fireEvent.press(getByTestId('forgot-submit-button'));
+      expect(getByTestId('forgot-email-error')).toBeTruthy();
+    });
+
+    it('shows email error for invalid email', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('forgot-email-input')).toBeTruthy());
+      fireEvent.changeText(getByTestId('forgot-email-input'), 'notanemail');
+      fireEvent.press(getByTestId('forgot-submit-button'));
+      expect(getByTestId('forgot-email-error')).toBeTruthy();
+    });
+
+    it('clears email error when typing', async () => {
+      const { getByTestId, queryByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('forgot-submit-button')).toBeTruthy());
+      fireEvent.press(getByTestId('forgot-submit-button'));
+      expect(getByTestId('forgot-email-error')).toBeTruthy();
+      fireEvent.changeText(getByTestId('forgot-email-input'), 'a');
+      expect(queryByTestId('forgot-email-error')).toBeNull();
+    });
+
+    it('does not call resetPassword with invalid email', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('forgot-submit-button')).toBeTruthy());
+      fireEvent.press(getByTestId('forgot-submit-button'));
+      expect(mockAuthService.sendPasswordReset).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Success state', () => {
+    it('shows success screen after valid submission', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('forgot-email-input')).toBeTruthy());
+      fireEvent.changeText(getByTestId('forgot-email-input'), 'user@example.com');
+      fireEvent.press(getByTestId('forgot-submit-button'));
+      await waitFor(() => {
+        expect(getByTestId('reset-success-title')).toBeTruthy();
+      });
+    });
+
+    it('shows back to login button on success', async () => {
+      const onBack = jest.fn();
+      const { getByTestId } = renderScreen({ onBack });
+      await waitFor(() => expect(getByTestId('forgot-email-input')).toBeTruthy());
+      fireEvent.changeText(getByTestId('forgot-email-input'), 'user@example.com');
+      fireEvent.press(getByTestId('forgot-submit-button'));
+      await waitFor(() => {
+        expect(getByTestId('back-to-login-button')).toBeTruthy();
+      });
+      fireEvent.press(getByTestId('back-to-login-button'));
+      expect(onBack).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Submission', () => {
+    it('calls sendPasswordReset with the entered email', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('forgot-email-input')).toBeTruthy());
+      fireEvent.changeText(getByTestId('forgot-email-input'), 'user@test.com');
+      fireEvent.press(getByTestId('forgot-submit-button'));
+      await waitFor(() => {
+        expect(mockAuthService.sendPasswordReset).toHaveBeenCalledWith('user@test.com');
+      });
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('email input has accessibility label', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('forgot-email-input')).toBeTruthy());
+      expect(getByTestId('forgot-email-input').props.accessibilityLabel).toBe('Email address');
+    });
+
+    it('submit button has accessibility role', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('forgot-submit-button')).toBeTruthy());
+      expect(getByTestId('forgot-submit-button').props.accessibilityRole).toBe('button');
+    });
+
+    it('submit button shows disabled state when loading', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('forgot-submit-button')).toBeTruthy());
+      expect(getByTestId('forgot-submit-button').props.accessibilityState).toEqual({
+        disabled: false,
+      });
+    });
+
+    it('title has header role', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('forgot-title')).toBeTruthy());
+      expect(getByTestId('forgot-title').props.accessibilityRole).toBe('header');
+    });
+  });
+});

--- a/src/screens/__tests__/SignUpScreen.test.tsx
+++ b/src/screens/__tests__/SignUpScreen.test.tsx
@@ -1,0 +1,244 @@
+import React from 'react';
+import { Platform } from 'react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { SignUpScreen } from '../SignUpScreen';
+import { AuthProvider } from '@/hooks/useAuth';
+import { ThemeProvider } from '@/theme/ThemeProvider';
+
+const mockAuthService = {
+  restoreSession: jest.fn().mockResolvedValue(false),
+  getCurrentMember: jest.fn().mockResolvedValue(null),
+  loginWithEmail: jest.fn(),
+  register: jest.fn(),
+  loginWithOAuth: jest.fn(),
+  sendPasswordReset: jest.fn(),
+  logout: jest.fn().mockResolvedValue(undefined),
+  isLoggedIn: jest.fn().mockReturnValue(false),
+  refreshSession: jest.fn(),
+};
+
+jest.mock('@/services/wix/wixAuth', () => ({
+  WixAuthService: jest.fn(() => mockAuthService),
+}));
+
+function renderScreen(props: Partial<React.ComponentProps<typeof SignUpScreen>> = {}) {
+  return render(
+    <ThemeProvider>
+      <AuthProvider>
+        <SignUpScreen {...props} />
+      </AuthProvider>
+    </ThemeProvider>,
+  );
+}
+
+describe('SignUpScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuthService.restoreSession.mockResolvedValue(false);
+    mockAuthService.getCurrentMember.mockResolvedValue(null);
+    mockAuthService.register.mockResolvedValue({ success: true });
+  });
+
+  describe('Rendering', () => {
+    it('renders with default testID', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-screen')).toBeTruthy());
+    });
+
+    it('renders custom testID', async () => {
+      const { getByTestId } = renderScreen({ testID: 'custom-signup' });
+      await waitFor(() => expect(getByTestId('custom-signup')).toBeTruthy());
+    });
+
+    it('shows title', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-title')).toBeTruthy());
+    });
+
+    it('renders name input', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-name-input')).toBeTruthy());
+    });
+
+    it('renders email input', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-email-input')).toBeTruthy());
+    });
+
+    it('renders password input', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-password-input')).toBeTruthy());
+    });
+
+    it('renders submit button', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-submit-button')).toBeTruthy());
+    });
+
+    it('renders Google sign up button', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('google-signup-button')).toBeTruthy());
+    });
+
+    it('renders login link', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('login-link')).toBeTruthy());
+    });
+  });
+
+  describe('Form validation — empty fields', () => {
+    it('shows name error for empty name', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-submit-button')).toBeTruthy());
+      fireEvent.press(getByTestId('signup-submit-button'));
+      expect(getByTestId('signup-name-error')).toBeTruthy();
+    });
+
+    it('shows email error for empty email', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-submit-button')).toBeTruthy());
+      fireEvent.changeText(getByTestId('signup-name-input'), 'Test User');
+      fireEvent.press(getByTestId('signup-submit-button'));
+      expect(getByTestId('signup-email-error')).toBeTruthy();
+    });
+
+    it('shows password error for empty password', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-submit-button')).toBeTruthy());
+      fireEvent.changeText(getByTestId('signup-name-input'), 'Test User');
+      fireEvent.changeText(getByTestId('signup-email-input'), 'test@test.com');
+      fireEvent.press(getByTestId('signup-submit-button'));
+      expect(getByTestId('signup-password-error')).toBeTruthy();
+    });
+
+    it('shows all errors at once when all fields empty', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-submit-button')).toBeTruthy());
+      fireEvent.press(getByTestId('signup-submit-button'));
+      expect(getByTestId('signup-name-error')).toBeTruthy();
+      expect(getByTestId('signup-email-error')).toBeTruthy();
+      expect(getByTestId('signup-password-error')).toBeTruthy();
+    });
+  });
+
+  describe('Form validation — invalid input', () => {
+    it('shows email error for invalid email format', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-email-input')).toBeTruthy());
+      fireEvent.changeText(getByTestId('signup-name-input'), 'Test User');
+      fireEvent.changeText(getByTestId('signup-email-input'), 'notanemail');
+      fireEvent.changeText(getByTestId('signup-password-input'), 'Pass1234');
+      fireEvent.press(getByTestId('signup-submit-button'));
+      expect(getByTestId('signup-email-error')).toBeTruthy();
+    });
+
+    it('does not call signUp when validation fails', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-submit-button')).toBeTruthy());
+      fireEvent.press(getByTestId('signup-submit-button'));
+      expect(mockAuthService.register).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Error clearing', () => {
+    it('clears name error when typing', async () => {
+      const { getByTestId, queryByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-submit-button')).toBeTruthy());
+      fireEvent.press(getByTestId('signup-submit-button'));
+      expect(getByTestId('signup-name-error')).toBeTruthy();
+      fireEvent.changeText(getByTestId('signup-name-input'), 'a');
+      expect(queryByTestId('signup-name-error')).toBeNull();
+    });
+
+    it('clears email error when typing', async () => {
+      const { getByTestId, queryByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-submit-button')).toBeTruthy());
+      fireEvent.press(getByTestId('signup-submit-button'));
+      expect(getByTestId('signup-email-error')).toBeTruthy();
+      fireEvent.changeText(getByTestId('signup-email-input'), 'a');
+      expect(queryByTestId('signup-email-error')).toBeNull();
+    });
+
+    it('clears password error when typing', async () => {
+      const { getByTestId, queryByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-submit-button')).toBeTruthy());
+      fireEvent.press(getByTestId('signup-submit-button'));
+      expect(getByTestId('signup-password-error')).toBeTruthy();
+      fireEvent.changeText(getByTestId('signup-password-input'), 'a');
+      expect(queryByTestId('signup-password-error')).toBeNull();
+    });
+  });
+
+  describe('Auth errors', () => {
+    it('shows error banner when signUp fails', async () => {
+      mockAuthService.register.mockResolvedValue({
+        success: false,
+        error: 'Email already in use',
+      });
+
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-name-input')).toBeTruthy());
+      fireEvent.changeText(getByTestId('signup-name-input'), 'Test User');
+      fireEvent.changeText(getByTestId('signup-email-input'), 'taken@test.com');
+      fireEvent.changeText(getByTestId('signup-password-input'), 'Pass1234');
+      fireEvent.press(getByTestId('signup-submit-button'));
+      await waitFor(() => {
+        expect(getByTestId('signup-error')).toBeTruthy();
+      });
+    });
+  });
+
+  describe('Navigation', () => {
+    it('calls onLogin when login link pressed', async () => {
+      const onLogin = jest.fn();
+      const { getByTestId } = renderScreen({ onLogin });
+      await waitFor(() => expect(getByTestId('login-link')).toBeTruthy());
+      fireEvent.press(getByTestId('login-link'));
+      expect(onLogin).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Social sign up', () => {
+    it('calls signInWithGoogle when Google button pressed', async () => {
+      mockAuthService.loginWithOAuth.mockResolvedValue({ success: true });
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('google-signup-button')).toBeTruthy());
+      fireEvent.press(getByTestId('google-signup-button'));
+      await waitFor(() => {
+        expect(mockAuthService.loginWithOAuth).toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('name input has accessibility label', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-name-input')).toBeTruthy());
+      expect(getByTestId('signup-name-input').props.accessibilityLabel).toBe('Full name');
+    });
+
+    it('email input has accessibility label', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-email-input')).toBeTruthy());
+      expect(getByTestId('signup-email-input').props.accessibilityLabel).toBe('Email address');
+    });
+
+    it('password input has accessibility label', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-password-input')).toBeTruthy());
+      expect(getByTestId('signup-password-input').props.accessibilityLabel).toBe('Password');
+    });
+
+    it('submit button has accessibility role', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-submit-button')).toBeTruthy());
+      expect(getByTestId('signup-submit-button').props.accessibilityRole).toBe('button');
+    });
+
+    it('title has header role', async () => {
+      const { getByTestId } = renderScreen();
+      await waitFor(() => expect(getByTestId('signup-title')).toBeTruthy());
+      expect(getByTestId('signup-title').props.accessibilityRole).toBe('header');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add comprehensive test suites for ForgotPasswordScreen (19 tests) and SignUpScreen (26 tests)
- Both screens had zero test coverage — now fully covered
- Tests cover: rendering, form validation (empty + invalid), error clearing, navigation callbacks, social auth, accessibility, success states

## Test plan
- [x] ForgotPasswordScreen: 19 tests passing
- [x] SignUpScreen: 26 tests passing
- [x] Full test suite verified — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)