### PR TITLE
fix(reliability): mount ErrorBoundary in App.tsx

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -21,6 +21,7 @@ import { ConnectivityProvider } from '@/hooks/useConnectivity';
 import { NotificationProvider } from '@/hooks/useNotifications';
 import { AppNavigator, linkingConfig } from '@/navigation';
 import { OfflineBanner } from '@/components/OfflineBanner';
+import { ErrorBoundary } from '@/components/ErrorBoundary';
 
 SplashScreen.preventAutoHideAsync();
 
@@ -55,10 +56,12 @@ export default function App() {
             <CartProvider>
               <WishlistProvider>
                 <NotificationProvider>
-                  <NavigationContainer linking={linkingConfig}>
-                    <OfflineBanner />
-                    <AppNavigator />
-                  </NavigationContainer>
+                  <ErrorBoundary>
+                    <NavigationContainer linking={linkingConfig}>
+                      <OfflineBanner />
+                      <AppNavigator />
+                    </NavigationContainer>
+                  </ErrorBoundary>
                 </NotificationProvider>
               </WishlistProvider>
             </CartProvider>


### PR DESCRIPTION
## Summary
- ErrorBoundary component existed but was never mounted — unhandled render errors crashed the whole app
- Now wraps NavigationContainer + AppNavigator inside the provider stack
- On crash: brand-consistent fallback UI with retry button + crash reporting

## Test plan
- [x] Full suite regression: 96 passed, 1770 tests — all green
- [x] ErrorBoundary already has dedicated test suite covering catch, fallback, retry, crash reporting
- [ ] Manual: verify ErrorBoundary renders fallback on simulated render error

Part of cfutons_mobile-ec9 (Production hardening epic)

🤖 Generated with [Claude Code](https://claude.com/claude-code)