### PR TITLE
ci: nightly CI/CD workflow (cm-rcy)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,166 @@
+name: Nightly Integration
+
+on:
+  schedule:
+    - cron: '0 4 * * *' # 4 AM UTC daily
+  workflow_dispatch: # Allow manual trigger
+
+concurrency:
+  group: nightly-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests with coverage
+        run: npx jest --ci --coverage --coverageReporters=text --coverageReporters=lcov
+
+      - name: Upload coverage
+        if: matrix.node-version == 20
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 7
+
+  typecheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Type check
+        run: npx tsc --noEmit
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: ESLint
+        run: npx eslint src/ --ext .ts,.tsx
+
+  catalog-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Verify 3D catalog sync
+        run: npx tsx scripts/sync-3d-catalog.ts --check
+
+  build-web:
+    runs-on: ubuntu-latest
+    needs: [test, typecheck, lint]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Export web bundle
+        run: npx expo export --platform web
+
+      - name: Upload web bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: web-bundle
+          path: dist/
+          retention-days: 7
+
+  build-ios:
+    runs-on: macos-latest
+    needs: [test, typecheck, lint]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prebuild iOS
+        run: npx expo prebuild --platform ios --no-install
+
+      - name: Install CocoaPods
+        run: cd ios && pod install
+
+      - name: Build iOS (Release, no codesign)
+        run: |
+          xcodebuild -workspace ios/*.xcworkspace \
+            -scheme "Carolina Futons" \
+            -configuration Release \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+            CODE_SIGNING_ALLOWED=NO \
+            build 2>&1 | tail -40
+
+  build-android:
+    runs-on: ubuntu-latest
+    needs: [test, typecheck, lint]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Prebuild Android
+        run: npx expo prebuild --platform android --no-install
+
+      - name: Build Android (Release)
+        run: cd android && ./gradlew assembleRelease --no-daemon 2>&1 | tail -40


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/nightly.yml` — comprehensive nightly integration pipeline
- Scheduled at 4 AM UTC daily with manual `workflow_dispatch` trigger
- Test matrix: Node 18 + 20 with coverage upload (7-day retention)
- Quality gates: typecheck (`tsc --noEmit`), lint (`eslint`), catalog-sync check
- Platform builds gate on quality jobs: web export, iOS xcodebuild (macos runner, simulator), Android gradle (Java 17)
- Build artifacts retained 7 days

## Test plan
- [x] YAML lint passes
- [x] Existing test suite unaffected (143/144 pass, 1 pre-existing timeout in useAuth)
- [ ] Trigger manual workflow_dispatch run after merge to verify end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)