### PR TITLE
feat(illustrations): upgrade all 8 empty states to 5-layer C-bezier depth

### DIFF
--- a/src/components/illustrations/CartIllustration.tsx
+++ b/src/components/illustrations/CartIllustration.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
-import Svg, { Defs, LinearGradient, Stop, Rect, Path, Circle } from 'react-native-svg';
+import Svg, { Defs, LinearGradient, Stop, Rect, Path, Circle, Line } from 'react-native-svg';
 import { colors } from '@/theme/tokens';
+import { buildSmallMountainPath } from './shared';
 
 interface Props {
   width?: number;
@@ -8,41 +9,44 @@ interface Props {
   testID?: string;
 }
 
-export function CartIllustration({ width = 280, height = 200, testID }: Props) {
+const VBW = 280;
+const VBH = 200;
+
+export function CartIllustration({ width = VBW, height = VBH, testID }: Props) {
   return (
-    <Svg width={width} height={height} viewBox="0 0 280 200" testID={testID}>
+    <Svg width={width} height={height} viewBox={`0 0 ${VBW} ${VBH}`} testID={testID}>
       <Defs>
         <LinearGradient id="cart-sky" x1="0" y1="0" x2="0" y2="1">
-          <Stop offset="0%" stopColor={colors.sunsetCoral} stopOpacity={0.4} />
-          <Stop offset="60%" stopColor={colors.sandBase} stopOpacity={0.6} />
+          <Stop offset="0%" stopColor={colors.skyGradientTop} stopOpacity={0.8} />
+          <Stop offset="25%" stopColor={colors.mountainBlueLight} stopOpacity={0.6} />
+          <Stop offset="50%" stopColor={colors.sunsetCoralLight} stopOpacity={0.4} />
+          <Stop offset="75%" stopColor={colors.sandLight} stopOpacity={0.6} />
           <Stop offset="100%" stopColor={colors.offWhite} />
         </LinearGradient>
       </Defs>
-      <Rect width={280} height={200} fill="url(#cart-sky)" />
+      <Rect width={VBW} height={VBH} fill="url(#cart-sky)" />
+      {/* Sun */}
+      <Circle cx={200} cy={50} r={22} fill={colors.sunsetCoralLight} opacity={0.7} />
+      <Circle cx={200} cy={50} r={15} fill={colors.sunsetCoral} opacity={0.5} />
+      {/* 5 mountain layers */}
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.55, 42)} fill={colors.mountainBlueDark} opacity={0.2} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.62, 17)} fill={colors.mountainBlue} opacity={0.3} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.70, 73)} fill={colors.espresso} opacity={0.35} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.78, 29)} fill={colors.espressoLight} opacity={0.4} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.85, 61)} fill={colors.sandDark} opacity={0.5} />
+      {/* Trail marker posts */}
+      <Line x1={80} y1={158} x2={80} y2={145} stroke={colors.espresso} strokeWidth={1.5} opacity={0.5} />
+      <Line x1={78} y1={145} x2={82} y2={145} stroke={colors.espresso} strokeWidth={1} opacity={0.5} />
+      <Line x1={180} y1={162} x2={180} y2={150} stroke={colors.espresso} strokeWidth={1.5} opacity={0.4} />
+      <Line x1={178} y1={150} x2={182} y2={150} stroke={colors.espresso} strokeWidth={1} opacity={0.4} />
+      {/* Small footpath */}
       <Path
-        d="M0 140 Q30 110 70 120 Q110 95 140 105 Q180 80 220 100 Q260 90 280 110 L280 200 L0 200Z"
-        fill={colors.mountainBlueDark}
-        opacity={0.3}
-      />
-      <Path
-        d="M0 155 Q40 130 80 140 Q120 120 160 135 Q200 115 240 130 Q270 125 280 135 L280 200 L0 200Z"
-        fill={colors.mountainBlue}
+        d="M60 190 Q100 178 140 180 Q180 176 220 185 Q250 182 270 190"
+        fill="none"
+        stroke={colors.sandBase}
+        strokeWidth={1.5}
         opacity={0.4}
       />
-      <Path
-        d="M0 170 Q50 160 100 165 Q140 155 180 162 Q220 158 280 165 L280 200 L0 200Z"
-        fill={colors.sandDark}
-        opacity={0.5}
-      />
-      <Path
-        d="M120 200 Q125 175 130 170 Q140 165 150 170 Q155 175 160 200"
-        fill={colors.espressoLight}
-        opacity={0.5}
-        stroke={colors.espresso}
-        strokeWidth={0.5}
-      />
-      <Circle cx={200} cy={55} r={22} fill={colors.sunsetCoralLight} opacity={0.7} />
-      <Circle cx={200} cy={55} r={15} fill={colors.sunsetCoral} opacity={0.5} />
     </Svg>
   );
 }

--- a/src/components/illustrations/CategoryIllustration.tsx
+++ b/src/components/illustrations/CategoryIllustration.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Svg, { Defs, LinearGradient, Stop, Rect, Path, Ellipse } from 'react-native-svg';
 import { colors } from '@/theme/tokens';
+import { buildSmallMountainPath } from './shared';
 
 interface Props {
   width?: number;
@@ -8,55 +9,50 @@ interface Props {
   testID?: string;
 }
 
-export function CategoryIllustration({ width = 280, height = 200, testID }: Props) {
+const VBW = 280;
+const VBH = 200;
+
+export function CategoryIllustration({ width = VBW, height = VBH, testID }: Props) {
   return (
-    <Svg width={width} height={height} viewBox="0 0 280 200" testID={testID}>
+    <Svg width={width} height={height} viewBox={`0 0 ${VBW} ${VBH}`} testID={testID}>
       <Defs>
         <LinearGradient id="cat-sky" x1="0" y1="0" x2="0" y2="1">
-          <Stop offset="0%" stopColor={colors.skyGradientTop} stopOpacity={0.4} />
-          <Stop offset="100%" stopColor={colors.sandLight} />
+          <Stop offset="0%" stopColor={colors.skyGradientTop} stopOpacity={0.5} />
+          <Stop offset="25%" stopColor={colors.mountainBlueLight} stopOpacity={0.4} />
+          <Stop offset="55%" stopColor={colors.skyGradientBottom} stopOpacity={0.3} />
+          <Stop offset="80%" stopColor={colors.sandLight} stopOpacity={0.6} />
+          <Stop offset="100%" stopColor={colors.offWhite} />
         </LinearGradient>
       </Defs>
-      <Rect width={280} height={200} fill="url(#cat-sky)" />
+      <Rect width={VBW} height={VBH} fill="url(#cat-sky)" />
+      {/* 5 mountain layers */}
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.55, 48)} fill={colors.mountainBlueDark} opacity={0.2} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.63, 22)} fill={colors.mountainBlue} opacity={0.3} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.70, 67)} fill={colors.espresso} opacity={0.35} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.78, 35)} fill={colors.espressoLight} opacity={0.4} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.85, 84)} fill={colors.sandDark} opacity={0.45} />
+      {/* Trees with trunk + canopy */}
+      <Path d="M35 165 L35 125 Q42 100 49 125 L49 165" fill={colors.mountainBlueDark} opacity={0.6} />
+      <Path d="M26 135 Q42 108 58 135" fill={colors.mountainBlue} opacity={0.35} />
+      <Path d="M28 145 Q42 120 56 145" fill={colors.mountainBlue} opacity={0.25} />
+      <Path d="M75 163 L75 128 Q81 105 87 128 L87 163" fill={colors.mountainBlueDark} opacity={0.55} />
+      <Path d="M67 138 Q81 112 95 138" fill={colors.mountainBlue} opacity={0.3} />
+      <Path d="M69 148 Q81 125 93 148" fill={colors.mountainBlue} opacity={0.22} />
+      <Path d="M195 163 L195 122 Q202 96 209 122 L209 163" fill={colors.mountainBlueDark} opacity={0.6} />
+      <Path d="M187 132 Q202 104 217 132" fill={colors.mountainBlue} opacity={0.35} />
+      <Path d="M240 165 L240 132 Q245 115 250 132 L250 165" fill={colors.mountainBlueDark} opacity={0.5} />
+      <Path d="M233 142 Q245 120 257 142" fill={colors.mountainBlue} opacity={0.3} />
+      {/* Forest path */}
       <Path
-        d="M0 150 Q70 130 140 140 Q210 128 280 142 L280 200 L0 200Z"
-        fill={colors.sandDark}
-        opacity={0.4}
-      />
-      <Path
-        d="M30 160 L30 110 Q40 80 50 110 L50 160"
-        fill={colors.mountainBlueDark}
-        opacity={0.6}
-      />
-      <Path d="M20 125 Q40 95 60 125" fill={colors.mountainBlue} opacity={0.35} />
-      <Path
-        d="M70 158 L70 120 Q78 95 86 120 L86 158"
-        fill={colors.mountainBlueDark}
-        opacity={0.55}
-      />
-      <Path d="M62 130 Q78 105 94 130" fill={colors.mountainBlue} opacity={0.3} />
-      <Path
-        d="M190 158 L190 115 Q198 88 206 115 L206 158"
-        fill={colors.mountainBlueDark}
-        opacity={0.6}
-      />
-      <Path d="M182 128 Q198 98 214 128" fill={colors.mountainBlue} opacity={0.35} />
-      <Path
-        d="M235 160 L235 125 Q241 105 247 125 L247 160"
-        fill={colors.mountainBlueDark}
-        opacity={0.5}
-      />
-      <Path d="M228 135 Q241 112 254 135" fill={colors.mountainBlue} opacity={0.3} />
-      <Path
-        d="M110 200 Q125 160 140 155 Q155 160 170 200"
+        d="M110 200 Q125 168 140 162 Q155 168 170 200"
         fill={colors.sandBase}
         opacity={0.5}
         stroke={colors.espressoLight}
         strokeWidth={0.5}
       />
-      <Ellipse cx={140} cy={165} rx={8} ry={3} fill={colors.sunsetCoral} opacity={0.4} />
-      <Ellipse cx={125} cy={172} rx={5} ry={2} fill={colors.sunsetCoralLight} opacity={0.3} />
-      <Ellipse cx={155} cy={170} rx={6} ry={2} fill={colors.sunsetCoralLight} opacity={0.3} />
+      <Ellipse cx={140} cy={170} rx={8} ry={3} fill={colors.sunsetCoral} opacity={0.4} />
+      <Ellipse cx={125} cy={178} rx={5} ry={2} fill={colors.sunsetCoralLight} opacity={0.3} />
+      <Ellipse cx={155} cy={175} rx={6} ry={2} fill={colors.sunsetCoralLight} opacity={0.3} />
     </Svg>
   );
 }

--- a/src/components/illustrations/ErrorIllustration.tsx
+++ b/src/components/illustrations/ErrorIllustration.tsx
@@ -10,6 +10,7 @@ import Svg, {
   Circle,
 } from 'react-native-svg';
 import { colors } from '@/theme/tokens';
+import { buildSmallMountainPath } from './shared';
 
 interface Props {
   width?: number;
@@ -17,13 +18,18 @@ interface Props {
   testID?: string;
 }
 
-export function ErrorIllustration({ width = 280, height = 200, testID }: Props) {
+const VBW = 280;
+const VBH = 200;
+
+export function ErrorIllustration({ width = VBW, height = VBH, testID }: Props) {
   return (
-    <Svg width={width} height={height} viewBox="0 0 280 200" testID={testID}>
+    <Svg width={width} height={height} viewBox={`0 0 ${VBW} ${VBH}`} testID={testID}>
       <Defs>
         <LinearGradient id="err-sky" x1="0" y1="0" x2="0" y2="1">
-          <Stop offset="0%" stopColor={colors.espresso} stopOpacity={0.4} />
-          <Stop offset="60%" stopColor={colors.mountainBlueDark} stopOpacity={0.3} />
+          <Stop offset="0%" stopColor={colors.espresso} stopOpacity={0.5} />
+          <Stop offset="30%" stopColor={colors.mountainBlueDark} stopOpacity={0.4} />
+          <Stop offset="60%" stopColor={colors.espressoLight} stopOpacity={0.3} />
+          <Stop offset="85%" stopColor={colors.sandDark} stopOpacity={0.4} />
           <Stop offset="100%" stopColor={colors.sandDark} stopOpacity={0.5} />
         </LinearGradient>
         <RadialGradient id="err-lightning" cx="50%" cy="40%">
@@ -31,34 +37,41 @@ export function ErrorIllustration({ width = 280, height = 200, testID }: Props) 
           <Stop offset="100%" stopColor={colors.sunsetCoral} stopOpacity={0} />
         </RadialGradient>
       </Defs>
-      <Rect width={280} height={200} fill="url(#err-sky)" />
-      <Ellipse cx={90} cy={50} rx={60} ry={25} fill={colors.espressoLight} opacity={0.5} />
-      <Ellipse cx={130} cy={45} rx={50} ry={22} fill={colors.espresso} opacity={0.4} />
-      <Ellipse cx={180} cy={55} rx={55} ry={20} fill={colors.espressoLight} opacity={0.45} />
-      <Ellipse cx={160} cy={40} rx={45} ry={18} fill={colors.espresso} opacity={0.35} />
+      <Rect width={VBW} height={VBH} fill="url(#err-sky)" />
+      {/* Storm clouds — darker layers */}
+      <Ellipse cx={80} cy={45} rx={65} ry={26} fill={colors.espressoLight} opacity={0.5} />
+      <Ellipse cx={130} cy={40} rx={55} ry={24} fill={colors.espresso} opacity={0.45} />
+      <Ellipse cx={185} cy={48} rx={58} ry={22} fill={colors.espressoLight} opacity={0.4} />
+      <Ellipse cx={160} cy={35} rx={48} ry={20} fill={colors.espresso} opacity={0.38} />
+      {/* Lightning bolts */}
       <Path
-        d="M145 65 L148 85 L142 85 L146 105"
+        d="M145 62 L148 82 L142 82 L146 102"
         stroke={colors.sunsetCoral}
         strokeWidth={2}
         fill="none"
         opacity={0.6}
       />
-      <Circle cx={146} cy={75} r={25} fill="url(#err-lightning)" />
       <Path
-        d="M0 140 L50 105 L100 125 L140 95 L190 115 L240 100 L280 120 L280 200 L0 200Z"
-        fill={colors.espresso}
-        opacity={0.3}
-      />
-      <Path
-        d="M0 165 Q70 150 140 158 Q210 148 280 160 L280 200 L0 200Z"
-        fill={colors.espressoLight}
-        opacity={0.35}
-      />
-      <Path
-        d="M0 180 Q70 172 140 176 Q210 170 280 178 L280 200 L0 200Z"
-        fill={colors.sandDark}
+        d="M100 55 L103 72 L98 72 L101 88"
+        stroke={colors.sunsetCoral}
+        strokeWidth={1.5}
+        fill="none"
         opacity={0.4}
       />
+      <Path
+        d="M200 58 L202 70 L198 70 L201 84"
+        stroke={colors.sunsetCoralLight}
+        strokeWidth={1.2}
+        fill="none"
+        opacity={0.35}
+      />
+      <Circle cx={146} cy={72} r={25} fill="url(#err-lightning)" />
+      {/* 5 mountain layers */}
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.55, 42)} fill={colors.espresso} opacity={0.25} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.63, 17)} fill={colors.espresso} opacity={0.3} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.72, 73)} fill={colors.espressoLight} opacity={0.35} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.80, 29)} fill={colors.espressoLight} opacity={0.4} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.88, 61)} fill={colors.sandDark} opacity={0.45} />
     </Svg>
   );
 }

--- a/src/components/illustrations/NotFoundIllustration.tsx
+++ b/src/components/illustrations/NotFoundIllustration.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Svg, { Defs, LinearGradient, Stop, Rect, Path, Ellipse } from 'react-native-svg';
 import { colors } from '@/theme/tokens';
+import { buildSmallMountainPath } from './shared';
 
 interface Props {
   width?: number;
@@ -8,12 +9,18 @@ interface Props {
   testID?: string;
 }
 
-export function NotFoundIllustration({ width = 280, height = 200, testID }: Props) {
+const VBW = 280;
+const VBH = 200;
+
+export function NotFoundIllustration({ width = VBW, height = VBH, testID }: Props) {
   return (
-    <Svg width={width} height={height} viewBox="0 0 280 200" testID={testID}>
+    <Svg width={width} height={height} viewBox={`0 0 ${VBW} ${VBH}`} testID={testID}>
       <Defs>
         <LinearGradient id="nf-sky" x1="0" y1="0" x2="0" y2="1">
-          <Stop offset="0%" stopColor={colors.mountainBlueLight} stopOpacity={0.4} />
+          <Stop offset="0%" stopColor={colors.mountainBlueLight} stopOpacity={0.5} />
+          <Stop offset="25%" stopColor={colors.skyGradientTop} stopOpacity={0.4} />
+          <Stop offset="55%" stopColor={colors.mountainBlueLight} stopOpacity={0.3} />
+          <Stop offset="80%" stopColor={colors.sandLight} stopOpacity={0.5} />
           <Stop offset="100%" stopColor={colors.offWhite} />
         </LinearGradient>
         <LinearGradient id="nf-fog" x1="0" y1="0" x2="1" y2="0">
@@ -23,25 +30,33 @@ export function NotFoundIllustration({ width = 280, height = 200, testID }: Prop
           <Stop offset="100%" stopColor={colors.offWhite} stopOpacity={0} />
         </LinearGradient>
       </Defs>
-      <Rect width={280} height={200} fill="url(#nf-sky)" />
+      <Rect width={VBW} height={VBH} fill="url(#nf-sky)" />
+      {/* 5 mountain layers */}
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.45, 36)} fill={colors.mountainBlue} opacity={0.15} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.53, 58)} fill={colors.mountainBlue} opacity={0.2} />
+      {/* Deep fog layers */}
+      <Rect y={95} width={VBW} height={35} fill="url(#nf-fog)" />
+      <Ellipse cx={100} cy={115} rx={65} ry={14} fill={colors.offWhite} opacity={0.6} />
+      <Ellipse cx={210} cy={120} rx={55} ry={12} fill={colors.offWhite} opacity={0.5} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.62, 81)} fill={colors.mountainBlueDark} opacity={0.25} />
+      <Rect y={130} width={VBW} height={25} fill="url(#nf-fog)" />
+      <Ellipse cx={160} cy={140} rx={50} ry={10} fill={colors.offWhite} opacity={0.45} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.72, 19)} fill={colors.espressoLight} opacity={0.3} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.82, 47)} fill={colors.sandLight} opacity={0.4} />
+      {/* Faint trail disappearing into fog */}
       <Path
-        d="M0 110 L40 75 L80 95 L130 55 L180 85 L230 60 L280 90 L280 200 L0 200Z"
-        fill={colors.mountainBlue}
-        opacity={0.25}
+        d="M120 200 Q130 185 140 180 Q150 175 160 180 Q170 185 175 195"
+        fill="none"
+        stroke={colors.sandDark}
+        strokeWidth={1.2}
+        opacity={0.3}
       />
-      <Rect y={95} width={280} height={40} fill="url(#nf-fog)" />
       <Path
-        d="M0 140 L60 120 L120 135 L180 115 L240 130 L280 122 L280 200 L0 200Z"
-        fill={colors.mountainBlueDark}
-        opacity={0.2}
-      />
-      <Rect y={130} width={280} height={25} fill="url(#nf-fog)" />
-      <Ellipse cx={100} cy={120} rx={60} ry={12} fill={colors.offWhite} opacity={0.6} />
-      <Ellipse cx={200} cy={140} rx={50} ry={10} fill={colors.offWhite} opacity={0.5} />
-      <Path
-        d="M0 170 Q70 162 140 166 Q210 160 280 168 L280 200 L0 200Z"
-        fill={colors.sandLight}
-        opacity={0.5}
+        d="M138 180 Q140 170 142 165"
+        fill="none"
+        stroke={colors.sandDark}
+        strokeWidth={0.8}
+        opacity={0.15}
       />
     </Svg>
   );

--- a/src/components/illustrations/ReviewsIllustration.tsx
+++ b/src/components/illustrations/ReviewsIllustration.tsx
@@ -7,8 +7,10 @@ import Svg, {
   Rect,
   Circle,
   Path,
+  Line,
 } from 'react-native-svg';
 import { colors } from '@/theme/tokens';
+import { buildSmallMountainPath } from './shared';
 
 interface Props {
   width?: number;
@@ -16,38 +18,42 @@ interface Props {
   testID?: string;
 }
 
-export function ReviewsIllustration({ width = 280, height = 200, testID }: Props) {
+const VBW = 280;
+const VBH = 200;
+
+export function ReviewsIllustration({ width = VBW, height = VBH, testID }: Props) {
   return (
-    <Svg width={width} height={height} viewBox="0 0 280 200" testID={testID}>
+    <Svg width={width} height={height} viewBox={`0 0 ${VBW} ${VBH}`} testID={testID}>
       <Defs>
-        <RadialGradient id="rev-sun" cx="50%" cy="65%" r="40%">
+        <RadialGradient id="rev-sun" cx="50%" cy="55%" r="45%">
           <Stop offset="0%" stopColor={colors.skyGradientBottom} stopOpacity={0.8} />
-          <Stop offset="50%" stopColor={colors.sunsetCoral} stopOpacity={0.4} />
-          <Stop offset="100%" stopColor={colors.sunsetCoralDark} stopOpacity={0.1} />
+          <Stop offset="40%" stopColor={colors.sunsetCoral} stopOpacity={0.4} />
+          <Stop offset="70%" stopColor={colors.sunsetCoralLight} stopOpacity={0.2} />
+          <Stop offset="100%" stopColor={colors.sunsetCoralDark} stopOpacity={0} />
         </RadialGradient>
         <LinearGradient id="rev-sky" x1="0" y1="0" x2="0" y2="1">
           <Stop offset="0%" stopColor={colors.mountainBlue} stopOpacity={0.3} />
-          <Stop offset="50%" stopColor={colors.sunsetCoralLight} stopOpacity={0.4} />
+          <Stop offset="30%" stopColor={colors.skyGradientTop} stopOpacity={0.4} />
+          <Stop offset="55%" stopColor={colors.sunsetCoralLight} stopOpacity={0.4} />
+          <Stop offset="80%" stopColor={colors.sandLight} stopOpacity={0.6} />
           <Stop offset="100%" stopColor={colors.sandBase} />
         </LinearGradient>
       </Defs>
-      <Rect width={280} height={200} fill="url(#rev-sky)" />
-      <Circle cx={140} cy={120} r={70} fill="url(#rev-sun)" />
-      <Path
-        d="M0 135 L40 95 L80 120 L120 75 L160 110 L200 80 L240 105 L280 90 L280 200 L0 200Z"
-        fill={colors.espresso}
-        opacity={0.35}
-      />
-      <Path
-        d="M0 155 L50 125 L100 145 L140 115 L180 140 L220 120 L280 140 L280 200 L0 200Z"
-        fill={colors.espressoLight}
-        opacity={0.4}
-      />
-      <Path
-        d="M0 175 Q70 165 140 170 Q210 163 280 172 L280 200 L0 200Z"
-        fill={colors.sandDark}
-        opacity={0.5}
-      />
+      <Rect width={VBW} height={VBH} fill="url(#rev-sky)" />
+      {/* Sun glow */}
+      <Circle cx={140} cy={110} r={70} fill="url(#rev-sun)" />
+      {/* Sun rays */}
+      <Line x1={140} y1={50} x2={140} y2={30} stroke={colors.sunsetCoralLight} strokeWidth={1} opacity={0.3} />
+      <Line x1={170} y1={55} x2={185} y2={38} stroke={colors.sunsetCoralLight} strokeWidth={0.8} opacity={0.25} />
+      <Line x1={110} y1={55} x2={95} y2={38} stroke={colors.sunsetCoralLight} strokeWidth={0.8} opacity={0.25} />
+      <Line x1={190} y1={70} x2={210} y2={60} stroke={colors.sunsetCoralLight} strokeWidth={0.6} opacity={0.2} />
+      <Line x1={90} y1={70} x2={70} y2={60} stroke={colors.sunsetCoralLight} strokeWidth={0.6} opacity={0.2} />
+      {/* 5 mountain layers */}
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.52, 42)} fill={colors.espresso} opacity={0.2} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.60, 17)} fill={colors.espresso} opacity={0.3} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.68, 73)} fill={colors.espressoLight} opacity={0.35} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.76, 29)} fill={colors.espressoLight} opacity={0.4} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.84, 61)} fill={colors.sandDark} opacity={0.5} />
     </Svg>
   );
 }

--- a/src/components/illustrations/SearchIllustration.tsx
+++ b/src/components/illustrations/SearchIllustration.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Svg, { Defs, LinearGradient, Stop, Rect, Path, Ellipse } from 'react-native-svg';
 import { colors } from '@/theme/tokens';
+import { buildSmallMountainPath } from './shared';
 
 interface Props {
   width?: number;
@@ -8,39 +9,40 @@ interface Props {
   testID?: string;
 }
 
-export function SearchIllustration({ width = 280, height = 200, testID }: Props) {
+const VBW = 280;
+const VBH = 200;
+
+export function SearchIllustration({ width = VBW, height = VBH, testID }: Props) {
   return (
-    <Svg width={width} height={height} viewBox="0 0 280 200" testID={testID}>
+    <Svg width={width} height={height} viewBox={`0 0 ${VBW} ${VBH}`} testID={testID}>
       <Defs>
         <LinearGradient id="search-sky" x1="0" y1="0" x2="0" y2="1">
-          <Stop offset="0%" stopColor={colors.skyGradientTop} />
+          <Stop offset="0%" stopColor={colors.skyGradientTop} stopOpacity={0.9} />
+          <Stop offset="30%" stopColor={colors.mountainBlueLight} stopOpacity={0.7} />
+          <Stop offset="60%" stopColor={colors.skyGradientBottom} stopOpacity={0.5} />
+          <Stop offset="85%" stopColor={colors.sandLight} stopOpacity={0.6} />
           <Stop offset="100%" stopColor={colors.offWhite} />
         </LinearGradient>
-        <LinearGradient id="search-mist" x1="0" y1="0" x2="1" y2="0">
-          <Stop offset="0%" stopColor={colors.offWhite} stopOpacity={0} />
-          <Stop offset="50%" stopColor={colors.offWhite} stopOpacity={0.7} />
-          <Stop offset="100%" stopColor={colors.offWhite} stopOpacity={0} />
-        </LinearGradient>
       </Defs>
-      <Rect width={280} height={200} fill="url(#search-sky)" />
+      <Rect width={VBW} height={VBH} fill="url(#search-sky)" />
+      {/* 5 mountain layers */}
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.50, 33)} fill={colors.mountainBlueDark} opacity={0.2} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.58, 51)} fill={colors.mountainBlue} opacity={0.3} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.66, 14)} fill={colors.mountainBlue} opacity={0.4} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.75, 77)} fill={colors.espressoLight} opacity={0.45} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.83, 92)} fill={colors.sandDark} opacity={0.5} />
+      {/* Fog wisps */}
+      <Ellipse cx={70} cy={130} rx={55} ry={10} fill={colors.offWhite} opacity={0.5} />
+      <Ellipse cx={200} cy={125} rx={45} ry={8} fill={colors.offWhite} opacity={0.4} />
+      <Ellipse cx={140} cy={145} rx={60} ry={9} fill={colors.offWhite} opacity={0.35} />
+      {/* Distant bird */}
       <Path
-        d="M0 130 L60 70 L100 110 L150 55 L200 100 L250 65 L280 95 L280 200 L0 200Z"
-        fill={colors.mountainBlueDark}
-        opacity={0.35}
+        d="M190 40 C193 37 196 36 199 38 C202 36 205 37 208 40"
+        fill="none"
+        stroke={colors.espresso}
+        strokeWidth={0.8}
+        opacity={0.3}
       />
-      <Path
-        d="M0 150 L50 100 L90 130 L140 80 L190 120 L230 90 L280 120 L280 200 L0 200Z"
-        fill={colors.mountainBlue}
-        opacity={0.45}
-      />
-      <Rect y={110} width={280} height={30} fill="url(#search-mist)" />
-      <Path
-        d="M0 165 Q60 155 120 160 Q180 150 240 158 Q265 155 280 160 L280 200 L0 200Z"
-        fill={colors.sandLight}
-        opacity={0.6}
-      />
-      <Ellipse cx={70} cy={135} rx={50} ry={10} fill={colors.offWhite} opacity={0.5} />
-      <Ellipse cx={210} cy={128} rx={40} ry={8} fill={colors.offWhite} opacity={0.4} />
     </Svg>
   );
 }

--- a/src/components/illustrations/StreamIllustration.tsx
+++ b/src/components/illustrations/StreamIllustration.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Svg, { Defs, LinearGradient, Stop, Rect, Path, Ellipse, Circle } from 'react-native-svg';
 import { colors } from '@/theme/tokens';
+import { buildSmallMountainPath } from './shared';
 
 interface Props {
   width?: number;
@@ -8,47 +9,49 @@ interface Props {
   testID?: string;
 }
 
-export function StreamIllustration({ width = 280, height = 200, testID }: Props) {
+const VBW = 280;
+const VBH = 200;
+
+export function StreamIllustration({ width = VBW, height = VBH, testID }: Props) {
   return (
-    <Svg width={width} height={height} viewBox="0 0 280 200" testID={testID}>
+    <Svg width={width} height={height} viewBox={`0 0 ${VBW} ${VBH}`} testID={testID}>
       <Defs>
         <LinearGradient id="sc-sky" x1="0" y1="0" x2="0" y2="1">
-          <Stop offset="0%" stopColor={colors.skyGradientTop} stopOpacity={0.3} />
+          <Stop offset="0%" stopColor={colors.skyGradientTop} stopOpacity={0.4} />
+          <Stop offset="25%" stopColor={colors.mountainBlueLight} stopOpacity={0.3} />
+          <Stop offset="55%" stopColor={colors.skyGradientBottom} stopOpacity={0.3} />
+          <Stop offset="80%" stopColor={colors.sandLight} stopOpacity={0.5} />
           <Stop offset="100%" stopColor={colors.sandLight} />
         </LinearGradient>
         <LinearGradient id="sc-water" x1="0" y1="0" x2="1" y2="1">
           <Stop offset="0%" stopColor={colors.mountainBlueLight} stopOpacity={0.6} />
+          <Stop offset="50%" stopColor={colors.mountainBlue} stopOpacity={0.5} />
           <Stop offset="100%" stopColor={colors.mountainBlue} stopOpacity={0.4} />
         </LinearGradient>
       </Defs>
-      <Rect width={280} height={200} fill="url(#sc-sky)" />
-      <Path
-        d="M0 130 Q70 115 140 125 Q210 110 280 122 L280 200 L0 200Z"
-        fill={colors.sandDark}
-        opacity={0.35}
-      />
-      <Path d="M100 200 Q110 170 125 155 Q140 145 155 155 Q170 170 180 200" fill="url(#sc-water)" />
-      <Path
-        d="M115 165 Q140 155 165 165"
-        fill="none"
-        stroke={colors.offWhite}
-        strokeWidth={1}
-        opacity={0.5}
-      />
-      <Path
-        d="M108 178 Q140 168 172 178"
-        fill="none"
-        stroke={colors.offWhite}
-        strokeWidth={0.8}
-        opacity={0.4}
-      />
-      <Ellipse cx={85} cy={165} rx={18} ry={10} fill={colors.espressoLight} opacity={0.4} />
-      <Ellipse cx={195} cy={162} rx={15} ry={8} fill={colors.espressoLight} opacity={0.35} />
+      <Rect width={VBW} height={VBH} fill="url(#sc-sky)" />
+      {/* 5 mountain layers */}
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.50, 39)} fill={colors.mountainBlueDark} opacity={0.2} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.58, 56)} fill={colors.mountainBlue} opacity={0.25} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.65, 12)} fill={colors.espresso} opacity={0.3} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.73, 78)} fill={colors.espressoLight} opacity={0.35} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.80, 95)} fill={colors.sandDark} opacity={0.4} />
+      {/* Stream channel */}
+      <Path d="M100 200 Q110 172 125 158 Q140 148 155 158 Q170 172 180 200" fill="url(#sc-water)" />
+      {/* Water ripples */}
+      <Path d="M115 168 Q140 158 165 168" fill="none" stroke={colors.offWhite} strokeWidth={1} opacity={0.5} />
+      <Path d="M108 180 Q140 170 172 180" fill="none" stroke={colors.offWhite} strokeWidth={0.8} opacity={0.4} />
+      <Circle cx={130} cy={163} r={2} fill={colors.offWhite} opacity={0.6} />
+      <Circle cx={150} cy={166} r={1.5} fill={colors.offWhite} opacity={0.5} />
+      <Circle cx={140} cy={175} r={1.8} fill={colors.offWhite} opacity={0.4} />
+      {/* Rocks */}
+      <Ellipse cx={85} cy={168} rx={18} ry={10} fill={colors.espressoLight} opacity={0.4} />
+      <Ellipse cx={90} cy={165} rx={12} ry={7} fill={colors.espresso} opacity={0.3} />
+      <Ellipse cx={195} cy={165} rx={15} ry={8} fill={colors.espressoLight} opacity={0.35} />
       <Ellipse cx={210} cy={172} rx={10} ry={6} fill={colors.espresso} opacity={0.25} />
-      <Path d="M0 155 Q30 148 60 152 Q80 150 85 155" fill={colors.sandBase} opacity={0.4} />
-      <Path d="M195 155 Q220 148 250 152 Q270 150 280 155" fill={colors.sandBase} opacity={0.4} />
-      <Circle cx={130} cy={160} r={2} fill={colors.offWhite} opacity={0.6} />
-      <Circle cx={150} cy={163} r={1.5} fill={colors.offWhite} opacity={0.5} />
+      {/* Bank paths */}
+      <Path d="M0 158 Q30 150 60 155 Q80 152 85 158" fill={colors.sandBase} opacity={0.4} />
+      <Path d="M195 158 Q220 150 250 155 Q270 152 280 158" fill={colors.sandBase} opacity={0.4} />
     </Svg>
   );
 }

--- a/src/components/illustrations/WishlistIllustration.tsx
+++ b/src/components/illustrations/WishlistIllustration.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Svg, { Defs, LinearGradient, Stop, Rect, Path, Polygon, Circle } from 'react-native-svg';
 import { colors } from '@/theme/tokens';
+import { buildSmallMountainPath } from './shared';
 
 interface Props {
   width?: number;
@@ -8,53 +9,54 @@ interface Props {
   testID?: string;
 }
 
-export function WishlistIllustration({ width = 280, height = 200, testID }: Props) {
+const VBW = 280;
+const VBH = 200;
+
+export function WishlistIllustration({ width = VBW, height = VBH, testID }: Props) {
   return (
-    <Svg width={width} height={height} viewBox="0 0 280 200" testID={testID}>
+    <Svg width={width} height={height} viewBox={`0 0 ${VBW} ${VBH}`} testID={testID}>
       <Defs>
         <LinearGradient id="wish-sky" x1="0" y1="0" x2="0" y2="1">
-          <Stop offset="0%" stopColor={colors.skyGradientTop} stopOpacity={0.5} />
-          <Stop offset="100%" stopColor={colors.sandLight} />
+          <Stop offset="0%" stopColor={colors.skyGradientTop} stopOpacity={0.6} />
+          <Stop offset="25%" stopColor={colors.mountainBlueLight} stopOpacity={0.5} />
+          <Stop offset="55%" stopColor={colors.skyGradientBottom} stopOpacity={0.4} />
+          <Stop offset="80%" stopColor={colors.sandLight} stopOpacity={0.7} />
+          <Stop offset="100%" stopColor={colors.offWhite} />
         </LinearGradient>
       </Defs>
-      <Rect width={280} height={200} fill="url(#wish-sky)" />
+      <Rect width={VBW} height={VBH} fill="url(#wish-sky)" />
+      {/* 5 mountain layers */}
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.52, 44)} fill={colors.mountainBlueDark} opacity={0.2} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.60, 18)} fill={colors.mountainBlue} opacity={0.3} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.68, 75)} fill={colors.espresso} opacity={0.35} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.76, 31)} fill={colors.espressoLight} opacity={0.4} />
+      <Path d={buildSmallMountainPath(VBW, VBH, 0.84, 63)} fill={colors.sandDark} opacity={0.45} />
+      {/* Cabin */}
+      <Polygon points="140,100 118,130 162,130" fill={colors.espresso} opacity={0.8} />
+      <Rect x={122} y={130} width={36} height={28} fill={colors.espressoLight} />
+      <Rect x={133} y={140} width={14} height={18} fill={colors.sandBase} />
+      {/* Chimney smoke */}
       <Path
-        d="M0 140 Q70 100 140 115 Q210 95 280 120 L280 200 L0 200Z"
-        fill={colors.mountainBlue}
+        d="M155 100 C157 90 152 82 155 74 C158 66 153 58 156 50"
+        fill="none"
+        stroke={colors.espressoLight}
+        strokeWidth={1.2}
         opacity={0.3}
       />
       <Path
-        d="M0 165 Q70 150 140 155 Q210 148 280 158 L280 200 L0 200Z"
-        fill={colors.sandDark}
-        opacity={0.4}
-      />
-      <Polygon points="140,95 115,130 165,130" fill={colors.espresso} opacity={0.8} />
-      <Rect x={122} y={130} width={36} height={30} fill={colors.espressoLight} />
-      <Rect x={133} y={140} width={14} height={20} fill={colors.sandBase} />
-      <Polygon
-        points="140,88 108,128 172,128"
+        d="M155 74 C159 68 155 62 158 56"
         fill="none"
-        stroke={colors.espresso}
-        strokeWidth={1.5}
-        opacity={0.5}
+        stroke={colors.espressoLight}
+        strokeWidth={0.8}
+        opacity={0.2}
       />
-      <Path
-        d="M60 160 L60 130 Q65 110 70 130 L70 160"
-        fill={colors.mountainBlueDark}
-        opacity={0.5}
-      />
-      <Path d="M55 140 Q65 125 75 140" fill={colors.mountainBlue} opacity={0.3} />
-      <Path
-        d="M200 158 L200 125 Q205 105 210 125 L210 158"
-        fill={colors.mountainBlueDark}
-        opacity={0.5}
-      />
-      <Path d="M195 138 Q205 120 215 138" fill={colors.mountainBlue} opacity={0.3} />
-      <Path
-        d="M230 160 L230 135 Q233 120 236 135 L236 160"
-        fill={colors.mountainBlueDark}
-        opacity={0.4}
-      />
+      {/* Trees with more detail */}
+      <Path d="M60 160 L60 130 Q65 110 70 130 L70 160" fill={colors.mountainBlueDark} opacity={0.5} />
+      <Path d="M55 140 Q65 122 75 140" fill={colors.mountainBlue} opacity={0.35} />
+      <Path d="M53 148 Q65 130 77 148" fill={colors.mountainBlue} opacity={0.25} />
+      <Path d="M200 158 L200 125 Q205 105 210 125 L210 158" fill={colors.mountainBlueDark} opacity={0.5} />
+      <Path d="M195 138 Q205 118 215 138" fill={colors.mountainBlue} opacity={0.35} />
+      <Path d="M193 146 Q205 128 217 146" fill={colors.mountainBlue} opacity={0.25} />
       <Circle cx={155} cy={120} r={3} fill={colors.sunsetCoral} opacity={0.6} />
     </Svg>
   );

--- a/src/components/illustrations/__tests__/illustrations.test.tsx
+++ b/src/components/illustrations/__tests__/illustrations.test.tsx
@@ -53,5 +53,19 @@ describe('Blue Ridge Illustrations', () => {
       const { getByTestId } = render(<Component testID="test-illustration" />);
       expect(getByTestId('test-illustration')).toBeTruthy();
     });
+
+    it('has at least 5 Path elements for mountain depth', () => {
+      const { toJSON } = render(<Component />);
+      const json = JSON.stringify(toJSON());
+      const paths = json.match(/"type":"Path"/g) || [];
+      expect(paths.length).toBeGreaterThanOrEqual(5);
+    });
+
+    it('has at least 4 gradient stops for rich sky', () => {
+      const { toJSON } = render(<Component />);
+      const json = JSON.stringify(toJSON());
+      const stops = json.match(/"type":"Stop"/g) || [];
+      expect(stops.length).toBeGreaterThanOrEqual(4);
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Upgrades all 8 empty state illustrations (Cart, Search, Wishlist, Reviews, Category, Error, NotFound, Stream) to 5-layer C-curve bezier mountain depth using `buildSmallMountainPath()` from shared utilities
- Each illustration now has 4-5 stop gradients and scene-specific detail elements (trail markers, fog wisps, chimney smoke, lightning bolts, water ripples, etc.)
- Tests updated with depth-checking assertions (≥5 Path elements, ≥4 gradient stops)

## Test plan
- [x] All 56 illustration tests pass (renders, depth check, gradient check, testID)
- [x] Full suite: 144 suites passed, 2351 tests passed
- [ ] Visual verification on iOS Simulator
- [ ] Visual verification on Android Emulator
- [ ] Visual verification on Expo Web

Closes cm-0qn

🤖 Generated with [Claude Code](https://claude.com/claude-code)