### PR TITLE
fix: add /store-locator route alias to linking config (cm-tl5)

### DIFF
--- a/src/navigation/__tests__/linking.test.ts
+++ b/src/navigation/__tests__/linking.test.ts
@@ -141,6 +141,10 @@ describe('SUPPORTED_PATHS', () => {
   it('includes stores', () => {
     expect(SUPPORTED_PATHS).toContain('stores');
   });
+
+  it('includes store-locator', () => {
+    expect(SUPPORTED_PATHS).toContain('store-locator');
+  });
 });
 
 describe('deep link route resolution (getStateFromPath)', () => {
@@ -213,6 +217,10 @@ describe('deep link route resolution (getStateFromPath)', () => {
   describe('store pages', () => {
     it('resolves /stores to StoreLocator', () => {
       expect(getScreen('stores')).toBe('StoreLocator');
+    });
+
+    it('resolves /store-locator to StoreLocator', () => {
+      expect(getScreen('store-locator')).toBe('StoreLocator');
     });
 
     it('resolves /stores/:storeId to StoreDetail', () => {

--- a/src/navigation/linking.ts
+++ b/src/navigation/linking.ts
@@ -15,6 +15,8 @@
  *   carolinafutons://account           → AccountScreen (via Tabs)
  *   carolinafutons://shop              → ShopScreen (via Tabs)
  *   carolinafutons://home              → HomeScreen (via Tabs)
+ *   carolinafutons://stores             → StoreLocatorScreen
+ *   carolinafutons://store-locator      → StoreLocatorScreen (alias)
  *   carolinafutons://ar                → ARScreen (modal)
  */
 
@@ -27,7 +29,8 @@ const normalizePathForLinking: NonNullable<LinkingOptions<RootStackParamList>['g
   path,
   options,
 ) => {
-  const normalized = path.replace(/^\/products\//, '/product/');
+  let normalized = path.replace(/^\/products\//, '/product/');
+  normalized = normalized.replace(/^\/?store-locator(\/|$)/, '/stores$1');
   return getStateFromPath(normalized, options);
 };
 
@@ -82,5 +85,6 @@ export const SUPPORTED_PATHS = [
   'ar',
   'wishlist',
   'stores',
+  'store-locator',
   'collections',
 ] as const;


### PR DESCRIPTION
## Summary
- Add path normalization for `/store-locator` → `/stores` in the linking config's `getStateFromPath`
- `/store-locator` was unrecognized and fell through to `/home` on web
- Add `store-locator` to `SUPPORTED_PATHS` array

## Test plan
- [x] New test: `/store-locator` resolves to `StoreLocator` screen
- [x] New test: `SUPPORTED_PATHS` includes `store-locator`
- [x] Existing `/stores` and `/stores/:storeId` routes unaffected
- [x] Full test suite passes (144 suites, 2353 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)