### PR TITLE
feat: useCartSync hook wires offline queue to Wix Cart API (cm-pkz)

### DIFF
--- a/src/hooks/__tests__/useCartSync.test.tsx
+++ b/src/hooks/__tests__/useCartSync.test.tsx
@@ -1,0 +1,195 @@
+/**
+ * Tests for useCartSync — wires useOfflineSync to replayOfflineQueue
+ * so cart mutations queued while offline are replayed against Wix
+ * when connectivity is restored.
+ */
+import { renderHook, act } from '@testing-library/react-native';
+
+// Mock useOfflineSync
+const mockSyncNow = jest.fn();
+let capturedOnSync: ((actions: unknown[]) => Promise<void>) | undefined;
+
+jest.mock('../useOfflineSync', () => ({
+  useOfflineSync: jest.fn((opts: { onSync?: (actions: unknown[]) => Promise<void> }) => {
+    capturedOnSync = opts?.onSync;
+    return {
+      pendingCount: 0,
+      isSyncing: false,
+      queueAction: jest.fn(),
+      syncNow: mockSyncNow,
+    };
+  }),
+}));
+
+// Mock replayOfflineQueue
+const mockReplayOfflineQueue = jest.fn();
+jest.mock('@/services/wix/replayOfflineQueue', () => ({
+  replayOfflineQueue: (...args: unknown[]) => mockReplayOfflineQueue(...args),
+}));
+
+// Mock useWixClient
+const mockWixClient = {
+  addToCart: jest.fn(),
+  removeCartLineItems: jest.fn(),
+  updateCartLineItems: jest.fn(),
+};
+jest.mock('@/services/wix/wixProvider', () => ({
+  useWixClient: () => mockWixClient,
+}));
+
+import { useCartSync } from '../useCartSync';
+import type { QueuedAction } from '@/services/offlineQueue';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  capturedOnSync = undefined;
+});
+
+describe('useCartSync', () => {
+  it('returns pendingCount, isSyncing, queueAction, syncNow, and lastReplayResult', () => {
+    const { result } = renderHook(() => useCartSync({ cartId: 'cart-1' }));
+
+    expect(result.current).toEqual(
+      expect.objectContaining({
+        pendingCount: expect.any(Number),
+        isSyncing: expect.any(Boolean),
+        queueAction: expect.any(Function),
+        syncNow: expect.any(Function),
+        lastReplayResult: null,
+      }),
+    );
+  });
+
+  it('passes replayOfflineQueue as the onSync handler to useOfflineSync', () => {
+    renderHook(() => useCartSync({ cartId: 'cart-1' }));
+    expect(capturedOnSync).toBeDefined();
+  });
+
+  it('onSync calls replayOfflineQueue with actions, cartId, and wixClient', async () => {
+    mockReplayOfflineQueue.mockResolvedValue({
+      succeeded: 2,
+      failed: 0,
+      skipped: 0,
+      errors: [],
+    });
+
+    const { result } = renderHook(() => useCartSync({ cartId: 'cart-1' }));
+
+    const actions: QueuedAction[] = [
+      {
+        id: 'oq-1',
+        timestamp: Date.now(),
+        domain: 'cart',
+        action: 'ADD_ITEM',
+        payload: { productId: 'p1', quantity: 1 },
+      },
+      {
+        id: 'oq-2',
+        timestamp: Date.now(),
+        domain: 'cart',
+        action: 'REMOVE_ITEM',
+        payload: { itemId: 'li-1' },
+      },
+    ];
+
+    await act(async () => {
+      await capturedOnSync!(actions);
+    });
+
+    expect(mockReplayOfflineQueue).toHaveBeenCalledWith(actions, 'cart-1', mockWixClient);
+    expect(result.current.lastReplayResult).toEqual({
+      succeeded: 2,
+      failed: 0,
+      skipped: 0,
+      errors: [],
+    });
+  });
+
+  it('does not call replayOfflineQueue when cartId is not provided', async () => {
+    renderHook(() => useCartSync({}));
+
+    const actions: QueuedAction[] = [
+      {
+        id: 'oq-1',
+        timestamp: Date.now(),
+        domain: 'cart',
+        action: 'ADD_ITEM',
+        payload: { productId: 'p1', quantity: 1 },
+      },
+    ];
+
+    await act(async () => {
+      await capturedOnSync!(actions);
+    });
+
+    expect(mockReplayOfflineQueue).not.toHaveBeenCalled();
+  });
+
+  it('stores replay errors in lastReplayResult', async () => {
+    const replayError = new Error('Wix API failed');
+    mockReplayOfflineQueue.mockResolvedValue({
+      succeeded: 1,
+      failed: 1,
+      skipped: 0,
+      errors: [{ action: { id: 'oq-2' }, error: replayError }],
+    });
+
+    const { result } = renderHook(() => useCartSync({ cartId: 'cart-1' }));
+
+    await act(async () => {
+      await capturedOnSync!([
+        {
+          id: 'oq-1',
+          timestamp: Date.now(),
+          domain: 'cart',
+          action: 'ADD_ITEM',
+          payload: { productId: 'p1', quantity: 1 },
+        },
+      ]);
+    });
+
+    expect(result.current.lastReplayResult?.failed).toBe(1);
+    expect(result.current.lastReplayResult?.errors).toHaveLength(1);
+  });
+
+  it('handles replayOfflineQueue throwing by not crashing', async () => {
+    mockReplayOfflineQueue.mockRejectedValue(new Error('Network error'));
+
+    renderHook(() => useCartSync({ cartId: 'cart-1' }));
+
+    // Should not throw
+    await act(async () => {
+      await capturedOnSync!([
+        {
+          id: 'oq-1',
+          timestamp: Date.now(),
+          domain: 'cart',
+          action: 'ADD_ITEM',
+          payload: { productId: 'p1', quantity: 1 },
+        },
+      ]);
+    });
+  });
+
+  it('updates lastReplayResult on each sync', async () => {
+    mockReplayOfflineQueue
+      .mockResolvedValueOnce({ succeeded: 1, failed: 0, skipped: 0, errors: [] })
+      .mockResolvedValueOnce({ succeeded: 3, failed: 0, skipped: 1, errors: [] });
+
+    const { result } = renderHook(() => useCartSync({ cartId: 'cart-1' }));
+
+    await act(async () => {
+      await capturedOnSync!([
+        { id: 'oq-1', timestamp: Date.now(), domain: 'cart', action: 'ADD_ITEM', payload: {} },
+      ]);
+    });
+    expect(result.current.lastReplayResult?.succeeded).toBe(1);
+
+    await act(async () => {
+      await capturedOnSync!([
+        { id: 'oq-2', timestamp: Date.now(), domain: 'cart', action: 'ADD_ITEM', payload: {} },
+      ]);
+    });
+    expect(result.current.lastReplayResult?.succeeded).toBe(3);
+  });
+});

--- a/src/hooks/useCartSync.ts
+++ b/src/hooks/useCartSync.ts
@@ -1,0 +1,48 @@
+/**
+ * @module useCartSync
+ *
+ * Bridges the offline action queue to Wix eCommerce Cart REST API.
+ * Uses useOfflineSync for connectivity-aware queueing and draining,
+ * and replayOfflineQueue to dispatch queued cart mutations to Wix
+ * when the device comes back online.
+ */
+import { useState, useCallback, useRef } from 'react';
+import { useOfflineSync } from './useOfflineSync';
+import { useWixClient } from '@/services/wix/wixProvider';
+import { replayOfflineQueue, type ReplayResult } from '@/services/wix/replayOfflineQueue';
+import type { QueuedAction } from '@/services/offlineQueue';
+
+interface UseCartSyncOptions {
+  cartId?: string;
+}
+
+export function useCartSync(options: UseCartSyncOptions) {
+  const { cartId } = options;
+  const client = useWixClient();
+  const [lastReplayResult, setLastReplayResult] = useState<ReplayResult | null>(null);
+  const cartIdRef = useRef(cartId);
+  cartIdRef.current = cartId;
+
+  const onSync = useCallback(
+    async (actions: QueuedAction[]) => {
+      if (!cartIdRef.current) return;
+      try {
+        const result = await replayOfflineQueue(actions, cartIdRef.current, client);
+        setLastReplayResult(result);
+      } catch {
+        // replayOfflineQueue itself threw — don't crash the sync
+      }
+    },
+    [client],
+  );
+
+  const { pendingCount, isSyncing, queueAction, syncNow } = useOfflineSync({ onSync });
+
+  return {
+    pendingCount,
+    isSyncing,
+    queueAction,
+    syncNow,
+    lastReplayResult,
+  };
+}

--- a/src/services/wix/__tests__/replayOfflineQueue.integration.test.ts
+++ b/src/services/wix/__tests__/replayOfflineQueue.integration.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Integration test: offlineQueue → drain → replayOfflineQueue → WixClient
+ *
+ * Verifies the full chain from enqueuing actions while offline
+ * through draining and replaying them against WixClient cart methods.
+ * WixClient.post is mocked at the HTTP level; everything else is real.
+ */
+import { enqueue, drain, _resetForTesting } from '@/services/offlineQueue';
+import { replayOfflineQueue } from '../replayOfflineQueue';
+import { WixClient } from '../wixClient';
+
+// Mock fetch at the global level
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  _resetForTesting();
+  mockFetch.mockReset();
+});
+
+function mockSuccessResponse(cartId: string) {
+  return {
+    ok: true,
+    status: 200,
+    json: async () => ({ cart: { id: cartId } }),
+  };
+}
+
+describe('offline queue → replay → WixClient integration', () => {
+  const client = new WixClient({
+    apiKey: 'test-key',
+    siteId: 'test-site',
+  });
+
+  it('enqueues ADD_ITEM, drains, and replays against WixClient.addToCart', async () => {
+    mockFetch.mockResolvedValue(mockSuccessResponse('cart-1'));
+
+    enqueue('cart', 'ADD_ITEM', {
+      productId: 'futon-asheville',
+      quantity: 2,
+    });
+
+    const actions = drain();
+    expect(actions).toHaveLength(1);
+
+    const result = await replayOfflineQueue(actions, 'cart-1', client);
+
+    expect(result.succeeded).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain('/ecom/v1/carts/cart-1/add-to-cart');
+    const body = JSON.parse(opts.body);
+    expect(body.lineItems[0].catalogReference.catalogItemId).toBe('futon-asheville');
+    expect(body.lineItems[0].quantity).toBe(2);
+  });
+
+  it('enqueues REMOVE_ITEM, drains, and replays against WixClient.removeCartLineItems', async () => {
+    mockFetch.mockResolvedValue(mockSuccessResponse('cart-1'));
+
+    enqueue('cart', 'REMOVE_ITEM', { lineItemIds: ['li-42'] });
+
+    const actions = drain();
+    const result = await replayOfflineQueue(actions, 'cart-1', client);
+
+    expect(result.succeeded).toBe(1);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain('/ecom/v1/carts/cart-1/remove-line-items');
+    expect(JSON.parse(opts.body).lineItemIds).toEqual(['li-42']);
+  });
+
+  it('enqueues UPDATE_QUANTITY, drains, and replays against WixClient.updateCartLineItems', async () => {
+    mockFetch.mockResolvedValue(mockSuccessResponse('cart-1'));
+
+    enqueue('cart', 'UPDATE_QUANTITY', { lineItemId: 'li-7', quantity: 5 });
+
+    const actions = drain();
+    const result = await replayOfflineQueue(actions, 'cart-1', client);
+
+    expect(result.succeeded).toBe(1);
+    const [url, opts] = mockFetch.mock.calls[0];
+    expect(url).toContain('/ecom/v1/carts/cart-1/update-line-items');
+    const body = JSON.parse(opts.body);
+    expect(body.lineItems[0].id).toBe('li-7');
+    expect(body.lineItems[0].quantity).toBe(5);
+  });
+
+  it('replays a mixed queue in order, skipping wishlist actions', async () => {
+    mockFetch.mockResolvedValue(mockSuccessResponse('cart-1'));
+
+    enqueue('cart', 'ADD_ITEM', { productId: 'p1', quantity: 1 });
+    enqueue('wishlist', 'ADD', { productId: 'p2' });
+    enqueue('cart', 'REMOVE_ITEM', { itemId: 'li-1' });
+    enqueue('cart', 'UPDATE_QUANTITY', { lineItemId: 'li-3', quantity: 3 });
+
+    const actions = drain();
+    expect(actions).toHaveLength(4);
+
+    const result = await replayOfflineQueue(actions, 'cart-1', client);
+
+    expect(result.succeeded).toBe(3);
+    expect(result.skipped).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(mockFetch).toHaveBeenCalledTimes(3);
+  });
+
+  it('continues after a failed action and reports errors', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: false, status: 400, json: async () => ({ message: 'Bad request' }) })
+      .mockResolvedValueOnce(mockSuccessResponse('cart-1'));
+
+    enqueue('cart', 'ADD_ITEM', { productId: 'p1', quantity: 1 });
+    enqueue('cart', 'ADD_ITEM', { productId: 'p2', quantity: 1 });
+
+    const actions = drain();
+    const result = await replayOfflineQueue(actions, 'cart-1', client);
+
+    expect(result.succeeded).toBe(1);
+    expect(result.failed).toBe(1);
+    expect(result.errors).toHaveLength(1);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('draining empties the queue so re-drain returns nothing', () => {
+    enqueue('cart', 'ADD_ITEM', { productId: 'p1', quantity: 1 });
+    const first = drain();
+    expect(first).toHaveLength(1);
+
+    const second = drain();
+    expect(second).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `useCartSync` hook that bridges `useOfflineSync` with `replayOfflineQueue`, enabling cart mutations queued while offline to replay against Wix eCommerce Cart REST API on reconnect
- Adds integration tests verifying the full chain: `offlineQueue.enqueue` → `drain` → `replayOfflineQueue` → `WixClient` HTTP calls
- Depends on PR #56 (`cm-8ul-offline-queue-replay`)

## Files
- `src/hooks/useCartSync.ts` — new hook (45 LOC)
- `src/hooks/__tests__/useCartSync.test.tsx` — 7 unit tests
- `src/services/wix/__tests__/replayOfflineQueue.integration.test.ts` — 6 integration tests

## Test plan
- [x] 7 unit tests: hook shape, onSync wiring, cartId guard, error handling, result updates
- [x] 6 integration tests: ADD_ITEM/REMOVE_ITEM/UPDATE_QUANTITY replay, mixed queue, error continuation, drain idempotency
- [x] Full suite: 160 suites, 2511 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)