### PR TITLE
fix(auth): harden all async auth callbacks with try/catch (cm-44h)

### DIFF
--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -139,7 +139,7 @@ interface AuthContextValue {
   signInWithApple: () => Promise<void>;
   resetPassword: (email: string) => Promise<void>;
   updateProfile: (data: UpdateProfileData) => Promise<void>;
-  signOut: () => void;
+  signOut: () => Promise<void>;
   clearError: () => void;
 }
 
@@ -221,16 +221,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const signIn = useCallback(
     async (email: string, password: string) => {
       dispatch({ type: 'AUTH_START' });
-      const result = await authService.loginWithEmail(email, password);
-      if (!result.success) {
-        dispatch({ type: 'AUTH_ERROR', error: result.error });
-        return;
-      }
-      const member = await authService.getCurrentMember();
-      if (member) {
-        dispatch({ type: 'AUTH_SUCCESS', user: member });
-      } else {
-        dispatch({ type: 'AUTH_ERROR', error: 'Login failed' });
+      try {
+        const result = await authService.loginWithEmail(email, password);
+        if (!result.success) {
+          dispatch({ type: 'AUTH_ERROR', error: result.error });
+          return;
+        }
+        const member = await authService.getCurrentMember();
+        if (member) {
+          dispatch({ type: 'AUTH_SUCCESS', user: member });
+        } else {
+          dispatch({ type: 'AUTH_ERROR', error: 'Login failed' });
+        }
+      } catch (err) {
+        dispatch({ type: 'AUTH_ERROR', error: (err as Error).message });
       }
     },
     [authService],
@@ -239,16 +243,20 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const signUp = useCallback(
     async (email: string, password: string, displayName: string) => {
       dispatch({ type: 'AUTH_START' });
-      const result = await authService.register(email, password, displayName);
-      if (!result.success) {
-        dispatch({ type: 'AUTH_ERROR', error: result.error });
-        return;
-      }
-      const member = await authService.getCurrentMember();
-      if (member) {
-        dispatch({ type: 'AUTH_SUCCESS', user: member });
-      } else {
-        dispatch({ type: 'AUTH_ERROR', error: 'Registration failed' });
+      try {
+        const result = await authService.register(email, password, displayName);
+        if (!result.success) {
+          dispatch({ type: 'AUTH_ERROR', error: result.error });
+          return;
+        }
+        const member = await authService.getCurrentMember();
+        if (member) {
+          dispatch({ type: 'AUTH_SUCCESS', user: member });
+        } else {
+          dispatch({ type: 'AUTH_ERROR', error: 'Registration failed' });
+        }
+      } catch (err) {
+        dispatch({ type: 'AUTH_ERROR', error: (err as Error).message });
       }
     },
     [authService],
@@ -291,39 +299,51 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     }
 
     // Fallback to Wix OAuth when Google client IDs are not configured
-    const result = await authService.loginWithOAuth();
-    if (!result.success) {
-      dispatch({ type: 'AUTH_ERROR', error: result.error });
-      return;
-    }
-    const member = await authService.getCurrentMember();
-    if (member) {
-      dispatch({ type: 'AUTH_SUCCESS', user: member });
-    } else {
-      dispatch({ type: 'AUTH_ERROR', error: 'Google login failed' });
+    try {
+      const result = await authService.loginWithOAuth();
+      if (!result.success) {
+        dispatch({ type: 'AUTH_ERROR', error: result.error });
+        return;
+      }
+      const member = await authService.getCurrentMember();
+      if (member) {
+        dispatch({ type: 'AUTH_SUCCESS', user: member });
+      } else {
+        dispatch({ type: 'AUTH_ERROR', error: 'Google login failed' });
+      }
+    } catch (err) {
+      dispatch({ type: 'AUTH_ERROR', error: (err as Error).message });
     }
   }, [googleConfigured, googlePromptAsync, authService]);
 
   const signInWithApple = useCallback(async () => {
     dispatch({ type: 'AUTH_START' });
-    const result = await authService.loginWithApple();
-    if (!result.success) {
-      dispatch({ type: 'AUTH_ERROR', error: result.error });
-      return;
-    }
-    const member = await authService.getCurrentMember();
-    if (member) {
-      dispatch({ type: 'AUTH_SUCCESS', user: member });
-    } else {
-      dispatch({ type: 'AUTH_ERROR', error: 'Apple login failed' });
+    try {
+      const result = await authService.loginWithApple();
+      if (!result.success) {
+        dispatch({ type: 'AUTH_ERROR', error: result.error });
+        return;
+      }
+      const member = await authService.getCurrentMember();
+      if (member) {
+        dispatch({ type: 'AUTH_SUCCESS', user: member });
+      } else {
+        dispatch({ type: 'AUTH_ERROR', error: 'Apple login failed' });
+      }
+    } catch (err) {
+      dispatch({ type: 'AUTH_ERROR', error: (err as Error).message });
     }
   }, [authService]);
 
   const resetPassword = useCallback(
     async (email: string) => {
       dispatch({ type: 'AUTH_START' });
-      await authService.sendPasswordReset(email);
-      dispatch({ type: 'CLEAR_ERROR' });
+      try {
+        await authService.sendPasswordReset(email);
+        dispatch({ type: 'CLEAR_ERROR' });
+      } catch (err) {
+        dispatch({ type: 'AUTH_ERROR', error: (err as Error).message });
+      }
     },
     [authService],
   );
@@ -332,24 +352,32 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     async (data: UpdateProfileData) => {
       if (!state.user) return;
       dispatch({ type: 'AUTH_START' });
-      const result = await authService.updateMember(state.user.id, data);
-      if (!result.success) {
-        dispatch({ type: 'AUTH_ERROR', error: result.error });
-        return;
-      }
-      const member = await authService.getCurrentMember();
-      if (member) {
-        dispatch({ type: 'UPDATE_USER', user: member });
-      } else {
-        dispatch({ type: 'CLEAR_ERROR' });
+      try {
+        const result = await authService.updateMember(state.user.id, data);
+        if (!result.success) {
+          dispatch({ type: 'AUTH_ERROR', error: result.error });
+          return;
+        }
+        const member = await authService.getCurrentMember();
+        if (member) {
+          dispatch({ type: 'UPDATE_USER', user: member });
+        } else {
+          dispatch({ type: 'CLEAR_ERROR' });
+        }
+      } catch (err) {
+        dispatch({ type: 'AUTH_ERROR', error: (err as Error).message });
       }
     },
     [authService, state.user],
   );
 
-  const signOut = useCallback(() => {
-    authService.logout();
-    clearGoogleSession();
+  const signOut = useCallback(async () => {
+    try {
+      await authService.logout();
+      await clearGoogleSession();
+    } catch {
+      // Best-effort cleanup — proceed with local sign-out regardless
+    }
     dispatch({ type: 'SIGN_OUT' });
   }, [authService]);
 

--- a/src/screens/__tests__/AccountScreen.test.tsx
+++ b/src/screens/__tests__/AccountScreen.test.tsx
@@ -190,7 +190,9 @@ describe('AccountScreen', () => {
         expect(getByTestId('sign-out-button')).toBeTruthy();
       });
       fireEvent.press(getByTestId('sign-out-button'));
-      expect(getByTestId('guest-title')).toBeTruthy();
+      await waitFor(() => {
+        expect(getByTestId('guest-title')).toBeTruthy();
+      });
     });
 
     it('shows menu items', async () => {


### PR DESCRIPTION
## Summary

- Wraps all async auth callbacks (`signIn`, `signUp`, `signInWithGoogle`, `signInWithApple`, `resetPassword`, `updateProfile`, `signOut`) with try/catch so unhandled rejections surface as user-visible error messages
- Makes `signOut` async — `await`s both `authService.logout()` and `clearGoogleSession()` before dispatching `SIGN_OUT`
- Updates AccountScreen test to handle async signOut

**Note:** The original PR also included notification gap fixes (cm-zq0), but those are already on main via a prior commit using direct AsyncStorage. Only the auth hardening is included in this rebased PR.

## Test plan

- [x] 28/28 useAuth tests pass
- [x] 29/29 AccountScreen tests pass
- [x] 70/70 useNotifications tests pass (unchanged, verified no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)