### PR TITLE
feat: pull-to-refresh on category and wishlist screens (cm-8eo)

### DIFF
--- a/src/screens/CategoryScreen.tsx
+++ b/src/screens/CategoryScreen.tsx
@@ -7,12 +7,13 @@
  * products yet.
  */
 
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { StyleSheet, View, Text, FlatList, TouchableOpacity } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '@/theme';
 import { useProducts, type Product, type ProductCategory } from '@/hooks/useProducts';
 import { useScrollPerformance } from '@/hooks/useScrollPerformance';
+import { MountainRefreshControl } from '@/components/MountainRefreshControl';
 import { ProductCard } from '@/components/ProductCard';
 import { SortPicker } from '@/components/SortPicker';
 import { EmptyState } from '@/components/EmptyState';
@@ -57,10 +58,17 @@ export function CategoryScreen({
   const { colors, spacing } = useTheme();
   const insets = useSafeAreaInsets();
 
-  const { products, sortBy, setSortBy, setSelectedCategory } = useProducts({
+  const { products, sortBy, setSortBy, setSelectedCategory, refresh } = useProducts({
     initialCategory: resolvedCategory,
   });
   const scrollPerf = useScrollPerformance('CategoryScreen');
+  const [refreshing, setRefreshing] = useState(false);
+
+  const handleRefresh = useCallback(() => {
+    setRefreshing(true);
+    refresh();
+    setTimeout(() => setRefreshing(false), 600);
+  }, [refresh]);
 
   // Sync hook state when category changes
   useEffect(() => {
@@ -138,6 +146,13 @@ export function CategoryScreen({
         onScrollBeginDrag={scrollPerf.onScrollBeginDrag}
         onScrollEndDrag={scrollPerf.onScrollEndDrag}
         onMomentumScrollEnd={scrollPerf.onMomentumScrollEnd}
+        refreshControl={
+          <MountainRefreshControl
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            testID="category-refresh-control"
+          />
+        }
         contentContainerStyle={[styles.listContent, { paddingBottom: insets.bottom + 16 }]}
         showsVerticalScrollIndicator={false}
         removeClippedSubviews

--- a/src/screens/WishlistScreen.tsx
+++ b/src/screens/WishlistScreen.tsx
@@ -6,7 +6,7 @@
  * spot deals. Long-press triggers a removal confirmation dialog.
  * Share exports a plain-text list via the native share sheet.
  */
-import React, { useCallback } from 'react';
+import React, { useCallback, useState } from 'react';
 import {
   StyleSheet,
   View,
@@ -20,6 +20,7 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import * as Haptics from 'expo-haptics';
 import { useTheme } from '@/theme';
+import { MountainRefreshControl } from '@/components/MountainRefreshControl';
 import { useWishlist } from '@/hooks/useWishlist';
 import { type Product } from '@/hooks/useProducts';
 import { ProductCard } from '@/components/ProductCard';
@@ -41,6 +42,13 @@ export function WishlistScreen({ onProductPress, onBrowse, testID }: Props) {
   const { count, getProducts, getShareText, remove, clear } = useWishlist();
 
   const products = getProducts();
+  const [refreshing, setRefreshing] = useState(false);
+
+  const handleRefresh = useCallback(() => {
+    setRefreshing(true);
+    // Wishlist is local state; refresh triggers a re-render for price updates
+    setTimeout(() => setRefreshing(false), 600);
+  }, []);
 
   const handleRemove = useCallback(
     (productId: string) => {
@@ -186,6 +194,13 @@ export function WishlistScreen({ onProductPress, onBrowse, testID }: Props) {
         columnWrapperStyle={products.length > 0 ? styles.row : undefined}
         ListHeaderComponent={renderHeader}
         ListEmptyComponent={renderEmpty}
+        refreshControl={
+          <MountainRefreshControl
+            refreshing={refreshing}
+            onRefresh={handleRefresh}
+            testID="wishlist-refresh-control"
+          />
+        }
         contentContainerStyle={[styles.listContent, { paddingBottom: insets.bottom + 16 }]}
         showsVerticalScrollIndicator={false}
         testID="wishlist-list"

--- a/src/screens/__tests__/CategoryScreen.test.tsx
+++ b/src/screens/__tests__/CategoryScreen.test.tsx
@@ -160,4 +160,12 @@ describe('CategoryScreen', () => {
       expect(onProductPress).toHaveBeenCalledWith(expect.objectContaining({ id: firstFuton.id }));
     });
   });
+
+  describe('pull-to-refresh', () => {
+    it('FlatList has refreshControl configured', async () => {
+      const { getByTestId } = await renderCategory({ categoryId: 'futons' });
+      const flatList = getByTestId('category-product-list');
+      expect(flatList.props.refreshControl).toBeTruthy();
+    });
+  });
 });

--- a/src/screens/__tests__/WishlistScreen.test.tsx
+++ b/src/screens/__tests__/WishlistScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent } from '@testing-library/react-native';
+import { render, fireEvent, act } from '@testing-library/react-native';
 import { Alert, Share } from 'react-native';
 import { WishlistScreen } from '../WishlistScreen';
 import { ThemeProvider } from '@/theme/ThemeProvider';
@@ -204,6 +204,20 @@ describe('WishlistScreen', () => {
       expect(getByTestId('wishlist-clear').props.accessibilityLabel).toBe(
         'Clear all items from wishlist',
       );
+    });
+  });
+
+  describe('pull-to-refresh', () => {
+    it('FlatList has refreshControl configured', () => {
+      const { getByTestId } = renderScreen({ items: makeItems(product1) });
+      const flatList = getByTestId('wishlist-list');
+      expect(flatList.props.refreshControl).toBeTruthy();
+    });
+
+    it('FlatList has refreshControl on empty wishlist', () => {
+      const { getByTestId } = renderScreen();
+      const flatList = getByTestId('wishlist-list');
+      expect(flatList.props.refreshControl).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Add `MountainRefreshControl` pull-to-refresh to **CategoryScreen** (triggers product re-fetch via `useProducts.refresh()`)
- Add `MountainRefreshControl` pull-to-refresh to **WishlistScreen** (triggers re-render for price drop updates)
- ShopScreen already had pull-to-refresh — no changes needed
- Tests added verifying `refreshControl` prop is configured on both FlatLists

## Test plan
- [x] CategoryScreen test: FlatList has refreshControl configured
- [x] WishlistScreen test: FlatList has refreshControl on populated and empty lists
- [x] All 39 existing + new tests pass
- [ ] Manual: Pull down on Category screen — spinner appears, products refresh
- [ ] Manual: Pull down on Wishlist screen — spinner appears, list re-renders

🤖 Generated with [Claude Code](https://claude.com/claude-code)