### PR TITLE
fix: resolve jest.mock out-of-scope React variable (cm-hzje)

### DIFF
--- a/src/components/__tests__/PromoBannerCarousel.test.tsx
+++ b/src/components/__tests__/PromoBannerCarousel.test.tsx
@@ -36,10 +36,13 @@ jest.mock('@/theme/tokens', () => ({
   colors: {},
 }));
 
-jest.mock('@/components/GlassCard', () => ({
-  GlassCard: ({ children, style, testID }: any) =>
-    React.createElement('View', { style, testID }, children),
-}));
+jest.mock('@/components/GlassCard', () => {
+  const { createElement } = require('react');
+  return {
+    GlassCard: ({ children, style, testID }: any) =>
+      createElement('View', { style, testID }, children),
+  };
+});
 
 const TEST_ITEMS: PromoBannerItem[] = [
   {


### PR DESCRIPTION
## Summary
- Fixed `PromoBannerCarousel.test.tsx` — `jest.mock()` factory was referencing `React` from outer scope, which Jest disallows
- Changed to `require('react')` inside the factory function
- All 201 test suites pass (3140 tests), 0 failures

## Test plan
- [x] `PromoBannerCarousel.test.tsx` — all 8 tests pass
- [x] Full test suite — 201 suites pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)