### PR TITLE
fix: remove duplicate property in useCart.test.tsx (cm-o81s)

### DIFF
--- a/src/hooks/__tests__/useCart.test.tsx
+++ b/src/hooks/__tests__/useCart.test.tsx
@@ -95,7 +95,6 @@ const mockAuthValue = {
   updateProfile: jest.fn(),
   signOut: jest.fn(),
   clearError: jest.fn(),
-  updateProfile: jest.fn(),
 };
 
 beforeEach(() => {


### PR DESCRIPTION
## Summary
- Removes duplicate `updateProfile: jest.fn()` property in useCart.test.tsx mock object (was at lines 95 and 98)
- Fixes TS1117 (duplicate property name in object literal) that was pre-existing on main

## Test plan
- [x] `npx tsc --noEmit` — 0 errors
- [x] `useCart.test.tsx` — 26 tests pass