### PR TITLE
feat: financing calculator with monthly payment breakdown (cm-731a)

### DIFF
--- a/src/components/FinancingBadge.tsx
+++ b/src/components/FinancingBadge.tsx
@@ -1,0 +1,112 @@
+/**
+ * Financing badge showing "As low as $X/mo" for eligible products.
+ *
+ * Compact variant for ProductCard, detail variant for ProductDetailScreen
+ * with full term breakdown and disclaimer.
+ */
+import React from 'react';
+import { StyleSheet, View, Text } from 'react-native';
+import { useTheme } from '@/theme';
+import { isFinancingEligible, getFinancingTerms } from '@/utils/financing';
+import { formatPrice } from '@/utils';
+
+interface Props {
+  price: number;
+  variant?: 'compact' | 'detail';
+  testID?: string;
+}
+
+export function FinancingBadge({ price, variant = 'compact', testID }: Props) {
+  const { colors, spacing, borderRadius } = useTheme();
+
+  if (!isFinancingEligible(price)) return null;
+
+  const terms = getFinancingTerms(price);
+  if (terms.length === 0) return null;
+
+  // Use the longest term (lowest monthly payment) for the badge
+  const lowestTerm = terms[terms.length - 1];
+
+  if (variant === 'compact') {
+    return (
+      <View
+        style={[
+          styles.compactBadge,
+          { backgroundColor: colors.mountainBlue, borderRadius: borderRadius.sm },
+        ]}
+        testID={testID ?? 'financing-badge'}
+      >
+        <Text style={styles.compactText}>
+          As low as {formatPrice(lowestTerm.monthlyPayment)}/mo
+        </Text>
+      </View>
+    );
+  }
+
+  return (
+    <View
+      style={[styles.detailContainer, { borderColor: colors.mountainBlue }]}
+      testID={testID ?? 'financing-badge'}
+    >
+      <Text style={[styles.detailTitle, { color: colors.mountainBlue }]}>
+        As low as {formatPrice(lowestTerm.monthlyPayment)}/mo
+      </Text>
+      <View style={styles.termsRow}>
+        {terms.map((term) => (
+          <View key={term.months} style={[styles.termPill, { backgroundColor: `${colors.mountainBlue}15` }]}>
+            <Text style={[styles.termText, { color: colors.mountainBlue }]}>
+              {term.months}mo: {formatPrice(term.monthlyPayment)}
+            </Text>
+          </View>
+        ))}
+      </View>
+      <Text style={[styles.disclaimer, { color: colors.espressoLight }]}>
+        Subject to credit approval. {FINANCING_APR_DISPLAY} APR.
+      </Text>
+    </View>
+  );
+}
+
+const FINANCING_APR_DISPLAY = '9.99%';
+
+const styles = StyleSheet.create({
+  compactBadge: {
+    paddingHorizontal: 6,
+    paddingVertical: 2,
+    alignSelf: 'flex-start',
+  },
+  compactText: {
+    color: '#FFFFFF',
+    fontSize: 10,
+    fontWeight: '600',
+    letterSpacing: 0.2,
+  },
+  detailContainer: {
+    borderWidth: 1,
+    borderRadius: 8,
+    padding: 12,
+    gap: 8,
+  },
+  detailTitle: {
+    fontSize: 16,
+    fontWeight: '700',
+  },
+  termsRow: {
+    flexDirection: 'row',
+    gap: 8,
+    flexWrap: 'wrap',
+  },
+  termPill: {
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    borderRadius: 12,
+  },
+  termText: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  disclaimer: {
+    fontSize: 11,
+    lineHeight: 14,
+  },
+});

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -21,6 +21,7 @@ import {
 import { formatPrice } from '@/utils';
 import { sharedTransitionTag } from '@/utils/sharedTransitionTag';
 import { WishlistButton } from './WishlistButton';
+import { FinancingBadge } from './FinancingBadge';
 
 interface Props {
   product: Product;
@@ -130,6 +131,8 @@ export const ProductCard = memo(function ProductCard({
             </Text>
           )}
         </View>
+
+        <FinancingBadge price={product.price} variant="compact" />
 
         {stockBadge && (
           <View

--- a/src/components/__tests__/FinancingBadge.test.tsx
+++ b/src/components/__tests__/FinancingBadge.test.tsx
@@ -1,0 +1,57 @@
+/**
+ * Tests for the FinancingBadge component shown on ProductCard and ProductDetail.
+ */
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { FinancingBadge } from '../FinancingBadge';
+
+jest.mock('@/theme', () => ({
+  useTheme: () => ({
+    colors: {
+      mountainBlue: '#5B8FA8',
+      white: '#FFFFFF',
+      espressoLight: '#6B5B4F',
+    },
+    spacing: { xs: 4, sm: 8 },
+    borderRadius: { sm: 4 },
+  }),
+}));
+
+describe('FinancingBadge', () => {
+  it('renders "As low as" text with monthly payment for eligible price', () => {
+    const { getByText } = render(<FinancingBadge price={500} />);
+    expect(getByText(/As low as/)).toBeTruthy();
+    expect(getByText(/\/mo/)).toBeTruthy();
+  });
+
+  it('renders nothing for ineligible price', () => {
+    const { toJSON } = render(<FinancingBadge price={100} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('renders nothing for price at threshold', () => {
+    const { toJSON } = render(<FinancingBadge price={299} />);
+    expect(toJSON()).toBeNull();
+  });
+
+  it('uses lowest monthly payment (12-month term)', () => {
+    const { getByTestId } = render(<FinancingBadge price={1200} />);
+    const badge = getByTestId('financing-badge');
+    expect(badge).toBeTruthy();
+  });
+
+  it('accepts custom testID', () => {
+    const { getByTestId } = render(<FinancingBadge price={500} testID="custom-badge" />);
+    expect(getByTestId('custom-badge')).toBeTruthy();
+  });
+
+  it('shows disclaimer text when variant is "detail"', () => {
+    const { getByText } = render(<FinancingBadge price={500} variant="detail" />);
+    expect(getByText(/Subject to credit approval/)).toBeTruthy();
+  });
+
+  it('does not show disclaimer when variant is "compact"', () => {
+    const { queryByText } = render(<FinancingBadge price={500} variant="compact" />);
+    expect(queryByText(/Subject to credit approval/)).toBeNull();
+  });
+});

--- a/src/screens/ProductDetailScreen.tsx
+++ b/src/screens/ProductDetailScreen.tsx
@@ -58,6 +58,7 @@ import { AnimatedPressable } from '@/components/AnimatedPressable';
 import { ImageGalleryModal } from '@/components/ImageGalleryModal';
 import { useRecentlyViewed } from '@/hooks/useRecentlyViewed';
 import { usePremium } from '@/hooks/usePremium';
+import { FinancingBadge } from '@/components/FinancingBadge';
 import { useBackInStockSubscription } from '@/hooks/useBackInStockSubscription';
 import { getStockStatus } from '@/hooks/useProducts';
 import { SkeletonProductDetail } from '@/components/SkeletonProductDetail';
@@ -499,6 +500,7 @@ export function ProductDetailScreen({
               </Text>
             )}
           </View>
+          <FinancingBadge price={totalPrice} variant="detail" testID="financing-detail" />
         </View>
 
         {/* Fabric Selector */}

--- a/src/utils/__tests__/financing.test.ts
+++ b/src/utils/__tests__/financing.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for financing calculator utility.
+ */
+import {
+  calculateMonthlyPayment,
+  isFinancingEligible,
+  getFinancingTerms,
+  FINANCING_THRESHOLD,
+  FINANCING_APR,
+} from '../financing';
+
+describe('Financing calculator', () => {
+  describe('isFinancingEligible', () => {
+    it('returns true for prices above threshold', () => {
+      expect(isFinancingEligible(300)).toBe(true);
+      expect(isFinancingEligible(1000)).toBe(true);
+    });
+
+    it('returns false for prices at or below threshold', () => {
+      expect(isFinancingEligible(299)).toBe(false);
+      expect(isFinancingEligible(100)).toBe(false);
+      expect(isFinancingEligible(0)).toBe(false);
+    });
+
+    it('returns false for negative prices', () => {
+      expect(isFinancingEligible(-100)).toBe(false);
+    });
+
+    it('threshold is 299 dollars', () => {
+      expect(FINANCING_THRESHOLD).toBe(299);
+    });
+  });
+
+  describe('calculateMonthlyPayment', () => {
+    it('calculates monthly payment with APR for 3 months', () => {
+      const payment = calculateMonthlyPayment(300, 3);
+      // With 9.99% APR, monthly rate = 0.0999/12 ≈ 0.008325
+      // Payment should be slightly more than price/months
+      expect(payment).toBeGreaterThan(100);
+      expect(payment).toBeLessThan(110); // reasonable markup
+    });
+
+    it('calculates monthly payment for 6 months', () => {
+      const payment = calculateMonthlyPayment(600, 6);
+      expect(payment).toBeGreaterThan(100);
+      expect(payment).toBeLessThan(115);
+    });
+
+    it('calculates monthly payment for 12 months', () => {
+      const payment = calculateMonthlyPayment(1200, 12);
+      expect(payment).toBeGreaterThan(100);
+      expect(payment).toBeLessThan(115);
+    });
+
+    it('returns a number rounded to 2 decimal places', () => {
+      const payment = calculateMonthlyPayment(349, 6);
+      const decimals = payment.toString().split('.')[1];
+      expect(!decimals || decimals.length <= 2).toBe(true);
+    });
+
+    it('handles exact division cleanly', () => {
+      const payment = calculateMonthlyPayment(300, 3);
+      expect(typeof payment).toBe('number');
+      expect(payment).toBeGreaterThan(0);
+    });
+  });
+
+  describe('getFinancingTerms', () => {
+    it('returns all 3 term options for eligible price', () => {
+      const terms = getFinancingTerms(500);
+      expect(terms).toHaveLength(3);
+      expect(terms.map((t) => t.months)).toEqual([3, 6, 12]);
+    });
+
+    it('each term has months and monthlyPayment', () => {
+      const terms = getFinancingTerms(500);
+      for (const term of terms) {
+        expect(term.months).toBeDefined();
+        expect(term.monthlyPayment).toBeDefined();
+        expect(term.monthlyPayment).toBeGreaterThan(0);
+      }
+    });
+
+    it('shorter terms have higher monthly payments', () => {
+      const terms = getFinancingTerms(500);
+      expect(terms[0].monthlyPayment).toBeGreaterThan(terms[1].monthlyPayment);
+      expect(terms[1].monthlyPayment).toBeGreaterThan(terms[2].monthlyPayment);
+    });
+
+    it('returns empty array for ineligible price', () => {
+      expect(getFinancingTerms(100)).toEqual([]);
+      expect(getFinancingTerms(299)).toEqual([]);
+    });
+  });
+
+  describe('APR configuration', () => {
+    it('APR is 9.99%', () => {
+      expect(FINANCING_APR).toBe(0.0999);
+    });
+  });
+});

--- a/src/utils/financing.ts
+++ b/src/utils/financing.ts
@@ -1,0 +1,55 @@
+/**
+ * Financing calculator for monthly payment breakdowns.
+ *
+ * Static calculation (no Affirm/Afterpay SDK). Uses standard amortization
+ * formula with a fixed APR. Products over $299 qualify for financing.
+ */
+
+/** Minimum price to qualify for financing */
+export const FINANCING_THRESHOLD = 299;
+
+/** Annual percentage rate for financing calculations */
+export const FINANCING_APR = 0.0999;
+
+/** Available financing term lengths in months */
+export const FINANCING_TERMS = [3, 6, 12] as const;
+
+export type FinancingTerm = (typeof FINANCING_TERMS)[number];
+
+export interface FinancingOption {
+  months: FinancingTerm;
+  monthlyPayment: number;
+}
+
+/**
+ * Returns true if the price qualifies for financing.
+ */
+export function isFinancingEligible(price: number): boolean {
+  return price > FINANCING_THRESHOLD;
+}
+
+/**
+ * Calculates the monthly payment using standard amortization formula.
+ *
+ * Formula: M = P * [r(1+r)^n] / [(1+r)^n - 1]
+ * where P = principal, r = monthly rate, n = number of months
+ */
+export function calculateMonthlyPayment(price: number, months: number): number {
+  const monthlyRate = FINANCING_APR / 12;
+  const factor = Math.pow(1 + monthlyRate, months);
+  const payment = price * (monthlyRate * factor) / (factor - 1);
+  return Math.round(payment * 100) / 100;
+}
+
+/**
+ * Returns all financing term options for a given price.
+ * Returns empty array if price is not eligible.
+ */
+export function getFinancingTerms(price: number): FinancingOption[] {
+  if (!isFinancingEligible(price)) return [];
+
+  return FINANCING_TERMS.map((months) => ({
+    months,
+    monthlyPayment: calculateMonthlyPayment(price, months),
+  }));
+}

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -12,6 +12,13 @@ export type { FuzzyResult } from './fuzzySearch';
 export { isStoreOpen, calculateDistance, formatPhone } from './storeUtils';
 export { inchesToFeetDisplay } from './dimensions';
 export {
+  calculateMonthlyPayment,
+  isFinancingEligible,
+  getFinancingTerms,
+  FINANCING_THRESHOLD,
+  FINANCING_APR,
+} from './financing';
+export {
   type ProductId,
   type FutonModelId,
   productId,


### PR DESCRIPTION
## Summary
- `financing.ts` utility: standard amortization formula with 9.99% APR, 3/6/12 month terms
- Products over $299 qualify for financing display
- `FinancingBadge` component with two variants:
  - **compact** (ProductCard): "As low as $X/mo" badge
  - **detail** (ProductDetailScreen): full term breakdown with disclaimer
- Wired into ProductCard (after price) and ProductDetailScreen (after price section)
- Exported from utils barrel for reuse

## Test plan
- [x] `financing.test.ts` — 14 tests: eligibility, amortization math, term generation, APR config
- [x] `FinancingBadge.test.tsx` — 7 tests: rendering, eligibility gating, variants, disclaimer
- [x] Existing `ProductCard.test.tsx` — 26 tests pass
- [x] Existing `ProductDetailScreen.test.tsx` — 109 tests pass