### PR TITLE
ci: add workflow_dispatch to CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
## Summary
- Add `workflow_dispatch` trigger to CI workflow, allowing manual runs from the Actions tab
- Nightly and Build & Deploy workflows already have this — CI was the only one missing
- Helps debug the PR-triggered CI issue (PR #74 never triggered CI despite correct config)

## CI investigation findings
- `pull_request` trigger is correctly configured in ci.yml
- PR #74 targeted main, authored by repo owner — no first-time contributor block
- Last PR-triggered CI run was 2026-03-08; push and schedule events work fine
- Root cause unclear — likely GitHub-side issue. `workflow_dispatch` provides a manual workaround

## Test plan
- [ ] Manually trigger CI from Actions tab after merge
- [ ] Verify next PR triggers CI automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)