### PR TITLE
perf: skeleton loading states, bundle size audit (cm-q56en)

### DIFF
--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -20,6 +20,7 @@ import { useTheme } from '@/theme';
 import { darkPalette } from '@/theme/tokens';
 import { GlassCard } from '@/components/GlassCard';
 import { CollectionCard } from '@/components/CollectionCard';
+import { SkeletonCarouselRow } from '@/components/SkeletonCarouselItem';
 import { MountainSkyline } from '@/components/MountainSkyline';
 import { PromoBannerCarousel } from '@/components/PromoBannerCarousel';
 import { useCollections } from '@/hooks/useCollections';
@@ -52,7 +53,7 @@ export function HomeScreen({ onOpenAR, onOpenShop, onCollectionPress }: Props) {
   const { colors, spacing, typography, borderRadius } = useTheme();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const insets = useSafeAreaInsets();
-  const { featured } = useCollections();
+  const { featured, isLoading: collectionsLoading } = useCollections();
   const { recentProducts } = useRecentlyViewed();
 
   const handleOpenAR = useCallback(() => {
@@ -261,7 +262,7 @@ export function HomeScreen({ onOpenAR, onOpenShop, onCollectionPress }: Props) {
       </GlassCard>
 
       {/* Collection Carousel */}
-      {featured.length > 0 && (
+      {(collectionsLoading || featured.length > 0) && (
         <View style={styles.carouselSection}>
           <Text
             style={[
@@ -277,27 +278,31 @@ export function HomeScreen({ onOpenAR, onOpenShop, onCollectionPress }: Props) {
           >
             Shop the Look
           </Text>
-          <ScrollView
-            horizontal
-            showsHorizontalScrollIndicator={false}
-            contentContainerStyle={[
-              styles.carouselContent,
-              { paddingHorizontal: spacing.lg, gap: spacing.md },
-            ]}
-            testID="collection-carousel"
-            accessibilityRole="adjustable"
-            accessibilityLabel="Shop the Look collections"
-            accessibilityHint="Swipe left or right to browse collections"
-          >
-            {featured.map((collection) => (
-              <CollectionCard
-                key={collection.id}
-                collection={collection}
-                onPress={handleCollectionPress}
-                variant="compact"
-              />
-            ))}
-          </ScrollView>
+          {collectionsLoading && featured.length === 0 ? (
+            <SkeletonCarouselRow count={3} />
+          ) : (
+            <ScrollView
+              horizontal
+              showsHorizontalScrollIndicator={false}
+              contentContainerStyle={[
+                styles.carouselContent,
+                { paddingHorizontal: spacing.lg, gap: spacing.md },
+              ]}
+              testID="collection-carousel"
+              accessibilityRole="adjustable"
+              accessibilityLabel="Shop the Look collections"
+              accessibilityHint="Swipe left or right to browse collections"
+            >
+              {featured.map((collection) => (
+                <CollectionCard
+                  key={collection.id}
+                  collection={collection}
+                  onPress={handleCollectionPress}
+                  variant="compact"
+                />
+              ))}
+            </ScrollView>
+          )}
         </View>
       )}
 

--- a/src/screens/ShopScreen.tsx
+++ b/src/screens/ShopScreen.tsx
@@ -10,6 +10,7 @@
 import React, { useCallback, useState } from 'react';
 import { StyleSheet, View, Text, FlatList } from 'react-native';
 import { BrandedSpinner } from '@/components/BrandedSpinner';
+import { SkeletonProductGrid } from '@/components/SkeletonProductCard';
 import Animated, { FadeInDown } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useNavigation } from '@react-navigation/native';
@@ -68,6 +69,7 @@ export function ShopScreen({ onProductPress, testID }: Props) {
     selectedCategory,
     sortBy,
     isLoading,
+    isInitialLoading,
     suggestions,
     setSearchQuery,
     setSelectedCategory,
@@ -204,7 +206,9 @@ export function ShopScreen({ onProductPress, testID }: Props) {
 
   const renderEmpty = useCallback(
     () =>
-      searchQuery ? (
+      isInitialLoading ? (
+        <SkeletonProductGrid count={6} />
+      ) : searchQuery ? (
         <SearchEmptyState
           query={searchQuery}
           categories={categories.map((c) => ({ id: c.id, label: c.label }))}
@@ -238,7 +242,14 @@ export function ShopScreen({ onProductPress, testID }: Props) {
           </Text>
         </View>
       ),
-    [searchQuery, colors, categories, handleEmptyCategoryPress, handleTrendingPress],
+    [
+      isInitialLoading,
+      searchQuery,
+      colors,
+      categories,
+      handleEmptyCategoryPress,
+      handleTrendingPress,
+    ],
   );
 
   const renderFooter = useCallback(


### PR DESCRIPTION
## Summary
- **ShopScreen skeleton**: Shows `SkeletonProductGrid` (6 shimmer cards) during initial data load instead of flashing the "No products found" empty state before products arrive
- **HomeScreen skeleton**: Shows `SkeletonCarouselRow` while collections load via `useDataCache`, preventing layout shift in the "Shop the Look" section
- **Bundle size audit**: Main JS 1.0M gzipped (healthy). Font assets bloated: 28 fonts bundled (6.9M) but only 5 used — `@expo-google-fonts` packages ship all weights. Tracked for follow-up.

## Before/After
| Screen | Before | After |
|--------|--------|-------|
| ShopScreen | Flash of "No products found" → products | Shimmer skeleton → products |
| HomeScreen collections | Empty → cards pop in | Shimmer skeleton → cards |

## Test plan
- [x] ShopScreen tests pass (20/20)
- [x] App integration tests pass (3/3)
- [x] SkeletonCarouselItem tests pass (5/5)
- [x] TypeScript clean (`tsc --noEmit`)
- [x] ESLint clean on changed files (pre-existing warnings only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)