### PR TITLE
perf: memoize StoreCard, optimize FlatLists, swap RN Image for expo-image (hq-hi6bs)

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -24,6 +24,16 @@
         "buildType": "apk"
       }
     },
+    "simulator": {
+      "distribution": "internal",
+      "channel": "preview",
+      "env": {
+        "SENTRY_DISABLE_AUTO_UPLOAD": "true"
+      },
+      "ios": {
+        "simulator": true
+      }
+    },
     "production": {
       "channel": "production",
       "autoIncrement": true,

--- a/src/components/ReviewForm.tsx
+++ b/src/components/ReviewForm.tsx
@@ -8,7 +8,8 @@
  */
 
 import React, { useState, useCallback } from 'react';
-import { StyleSheet, View, Text, TextInput, TouchableOpacity, Image } from 'react-native';
+import { StyleSheet, View, Text, TextInput, TouchableOpacity } from 'react-native';
+import { Image } from 'expo-image';
 import * as ImagePicker from 'expo-image-picker';
 import { useTheme } from '@/theme';
 

--- a/src/components/StoreCard.tsx
+++ b/src/components/StoreCard.tsx
@@ -7,7 +7,7 @@
  * (e.g. "Mattress Gallery", "Free Delivery").
  */
 
-import React from 'react';
+import React, { memo, useCallback } from 'react';
 import { StyleSheet, Text, View, TouchableOpacity } from 'react-native';
 import { useTheme } from '@/theme';
 import { type Store, isStoreOpen, formatPhone } from '@/data/stores';
@@ -20,9 +20,10 @@ interface Props {
 }
 
 /** Tappable store location card with open/closed status, address, phone, and feature tags. */
-export function StoreCard({ store, distance, onPress, testID }: Props) {
+export const StoreCard = memo(function StoreCard({ store, distance, onPress, testID }: Props) {
   const { colors, spacing, borderRadius, shadows } = useTheme();
   const open = isStoreOpen(store);
+  const handlePress = useCallback(() => onPress?.(store), [onPress, store]);
 
   return (
     <TouchableOpacity
@@ -31,7 +32,7 @@ export function StoreCard({ store, distance, onPress, testID }: Props) {
         shadows.card,
         { backgroundColor: colors.white, borderRadius: borderRadius.card },
       ]}
-      onPress={() => onPress?.(store)}
+      onPress={handlePress}
       testID={testID ?? `store-card-${store.id}`}
       accessibilityLabel={`${store.name}, ${store.city}, ${open ? 'Open' : 'Closed'}`}
       accessibilityRole="button"
@@ -85,7 +86,7 @@ export function StoreCard({ store, distance, onPress, testID }: Props) {
       )}
     </TouchableOpacity>
   );
-}
+});
 
 const styles = StyleSheet.create({
   card: {

--- a/src/screens/CollectionDetailScreen.tsx
+++ b/src/screens/CollectionDetailScreen.tsx
@@ -256,6 +256,10 @@ export function CollectionDetailScreen() {
         showsVerticalScrollIndicator={false}
         onScroll={onScroll}
         scrollEventThrottle={16}
+        windowSize={5}
+        maxToRenderPerBatch={6}
+        removeClippedSubviews
+        initialNumToRender={4}
       />
     </View>
   );

--- a/src/screens/CompareScreen.tsx
+++ b/src/screens/CompareScreen.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { StyleSheet, View, Text, ScrollView, TouchableOpacity, Image } from 'react-native';
+import { StyleSheet, View, Text, ScrollView, TouchableOpacity } from 'react-native';
+import { Image } from 'expo-image';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '@/theme';
 import type { Product } from '@/data/products';
@@ -154,6 +155,9 @@ export function CompareScreen({
                   source={{ uri: product.images[0].uri }}
                   style={[styles.productImage, { borderRadius: borderRadius.md }]}
                   accessibilityLabel={product.images[0].alt}
+                  contentFit="cover"
+                  cachePolicy="memory-disk"
+                  transition={200}
                 />
               )}
               <TouchableOpacity

--- a/src/screens/OrderHistoryScreen.tsx
+++ b/src/screens/OrderHistoryScreen.tsx
@@ -198,6 +198,10 @@ export function OrderHistoryScreen({
           />
         }
         testID="order-list"
+        windowSize={5}
+        maxToRenderPerBatch={8}
+        removeClippedSubviews
+        initialNumToRender={6}
       />
     </View>
   );

--- a/src/screens/StoreLocatorScreen.tsx
+++ b/src/screens/StoreLocatorScreen.tsx
@@ -171,6 +171,10 @@ export function StoreLocatorScreen({ onStorePress, userLatitude, userLongitude, 
         contentContainerStyle={styles.listContent}
         showsVerticalScrollIndicator={false}
         testID="store-list"
+        windowSize={5}
+        maxToRenderPerBatch={6}
+        removeClippedSubviews
+        initialNumToRender={4}
       />
     </View>
   );


### PR DESCRIPTION
## Summary
- **StoreCard**: Wrapped in `React.memo` with `useCallback` for `onPress` — prevents re-renders in StoreLocator list
- **FlatList optimization**: Added `windowSize`, `maxToRenderPerBatch`, `removeClippedSubviews`, `initialNumToRender` to 3 screens (CollectionDetail, OrderHistory, StoreLocator) that were missing perf props
- **expo-image migration**: Replaced `react-native` `Image` with `expo-image` in CompareScreen and ReviewForm for memory-disk caching and faster load
- **iOS simulator build**: Added `simulator` profile to eas.json

## Test plan
- [x] All 80 affected tests pass (StoreCard, CompareScreen, StoreLocator, OrderHistory, CollectionDetail, ReviewForm)
- [x] No new warnings or errors
- [x] FlatList props are additive — no behavior change, only performance improvement

Closes hq-hi6bs

🤖 Generated with [Claude Code](https://claude.com/claude-code)