### PR TITLE
test: social auth coverage for Apple Sign-In and LoginScreen

### DIFF
--- a/src/screens/__tests__/LoginScreen.test.tsx
+++ b/src/screens/__tests__/LoginScreen.test.tsx
@@ -156,13 +156,80 @@ describe('LoginScreen', () => {
   });
 
   describe('Social sign-in', () => {
+    it('renders Google sign-in button with correct accessibility', async () => {
+      const { getByTestId } = renderLogin();
+      await waitFor(() => expect(getByTestId('google-sign-in-button')).toBeTruthy());
+      const btn = getByTestId('google-sign-in-button');
+      expect(btn.props.accessibilityLabel).toBe('Sign in with Google');
+      expect(btn.props.accessibilityRole).toBe('button');
+    });
+
     it('pressing Google button does not crash', async () => {
       mockAuthService.loginWithOAuth.mockResolvedValue({ success: false, error: 'cancelled' });
       const { getByTestId } = renderLogin();
       await waitFor(() => expect(getByTestId('google-sign-in-button')).toBeTruthy());
       fireEvent.press(getByTestId('google-sign-in-button'));
-      // Should not throw — just verifying the button press triggers without error
       await waitFor(() => expect(getByTestId('google-sign-in-button')).toBeTruthy());
+    });
+
+    it('Google button has dark surface styling', async () => {
+      const { getByTestId } = renderLogin();
+      await waitFor(() => expect(getByTestId('google-sign-in-button')).toBeTruthy());
+      const btn = getByTestId('google-sign-in-button');
+      const styles = Array.isArray(btn.props.style)
+        ? Object.assign({}, ...btn.props.style)
+        : btn.props.style;
+      expect(styles.backgroundColor).toBe(darkPalette.surfaceElevated);
+    });
+
+    it('shows auth error when Google sign-in fails', async () => {
+      mockAuthService.loginWithOAuth.mockResolvedValue({
+        success: false,
+        error: 'Google login failed',
+      });
+      const { getByTestId } = renderLogin();
+      await waitFor(() => expect(getByTestId('google-sign-in-button')).toBeTruthy());
+      fireEvent.press(getByTestId('google-sign-in-button'));
+      await waitFor(() => {
+        expect(getByTestId('login-error')).toBeTruthy();
+      });
+    });
+
+    it('shows auth error when Apple sign-in fails', async () => {
+      mockAuthService.loginWithApple.mockResolvedValue({
+        success: false,
+        error: 'Apple sign-in cancelled',
+      });
+      // Apple button only renders on iOS — mock Platform
+      const origOS = require('react-native').Platform.OS;
+      require('react-native').Platform.OS = 'ios';
+      const { getByTestId } = renderLogin();
+      await waitFor(() => expect(getByTestId('apple-sign-in-button')).toBeTruthy());
+      fireEvent.press(getByTestId('apple-sign-in-button'));
+      await waitFor(() => {
+        expect(getByTestId('login-error')).toBeTruthy();
+      });
+      require('react-native').Platform.OS = origOS;
+    });
+
+    it('Apple button only renders on iOS', async () => {
+      const origOS = require('react-native').Platform.OS;
+      require('react-native').Platform.OS = 'android';
+      const { queryByTestId } = renderLogin();
+      await waitFor(() => expect(queryByTestId('google-sign-in-button')).toBeTruthy());
+      expect(queryByTestId('apple-sign-in-button')).toBeNull();
+      require('react-native').Platform.OS = origOS;
+    });
+
+    it('Apple button renders on iOS with correct accessibility', async () => {
+      const origOS = require('react-native').Platform.OS;
+      require('react-native').Platform.OS = 'ios';
+      const { getByTestId } = renderLogin();
+      await waitFor(() => expect(getByTestId('apple-sign-in-button')).toBeTruthy());
+      const btn = getByTestId('apple-sign-in-button');
+      expect(btn.props.accessibilityLabel).toBe('Sign in with Apple');
+      expect(btn.props.accessibilityRole).toBe('button');
+      require('react-native').Platform.OS = origOS;
     });
   });
 

--- a/src/services/__tests__/appleAuth.test.ts
+++ b/src/services/__tests__/appleAuth.test.ts
@@ -1,0 +1,145 @@
+import { Platform } from 'react-native';
+import * as AppleAuthentication from 'expo-apple-authentication';
+
+import { isAppleAuthAvailable, signInWithApple } from '../appleAuth';
+
+jest.mock('expo-apple-authentication', () => ({
+  isAvailableAsync: jest.fn(),
+  signInAsync: jest.fn(),
+  AppleAuthenticationScope: {
+    FULL_NAME: 0,
+    EMAIL: 1,
+  },
+}));
+
+describe('appleAuth', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('isAppleAuthAvailable', () => {
+    it('returns false on Android', async () => {
+      const origOS = Platform.OS;
+      (Platform as any).OS = 'android';
+      const result = await isAppleAuthAvailable();
+      expect(result).toBe(false);
+      expect(AppleAuthentication.isAvailableAsync).not.toHaveBeenCalled();
+      (Platform as any).OS = origOS;
+    });
+
+    it('returns true on iOS when available', async () => {
+      const origOS = Platform.OS;
+      (Platform as any).OS = 'ios';
+      (AppleAuthentication.isAvailableAsync as jest.Mock).mockResolvedValue(true);
+      const result = await isAppleAuthAvailable();
+      expect(result).toBe(true);
+      (Platform as any).OS = origOS;
+    });
+
+    it('returns false on iOS when not available (old device)', async () => {
+      const origOS = Platform.OS;
+      (Platform as any).OS = 'ios';
+      (AppleAuthentication.isAvailableAsync as jest.Mock).mockResolvedValue(false);
+      const result = await isAppleAuthAvailable();
+      expect(result).toBe(false);
+      (Platform as any).OS = origOS;
+    });
+  });
+
+  describe('signInWithApple', () => {
+    it('returns credential on successful sign-in', async () => {
+      (AppleAuthentication.signInAsync as jest.Mock).mockResolvedValue({
+        identityToken: 'apple-id-token-123',
+        authorizationCode: 'auth-code-456',
+        email: 'user@icloud.com',
+        fullName: { givenName: 'Jane', familyName: 'Doe' },
+      });
+
+      const result = await signInWithApple();
+
+      expect(result).toEqual({
+        identityToken: 'apple-id-token-123',
+        authorizationCode: 'auth-code-456',
+        email: 'user@icloud.com',
+        fullName: 'Jane Doe',
+      });
+      expect(AppleAuthentication.signInAsync).toHaveBeenCalledWith({
+        requestedScopes: [
+          AppleAuthentication.AppleAuthenticationScope.FULL_NAME,
+          AppleAuthentication.AppleAuthenticationScope.EMAIL,
+        ],
+      });
+    });
+
+    it('returns null email/fullName on subsequent sign-ins (Apple only provides on first)', async () => {
+      (AppleAuthentication.signInAsync as jest.Mock).mockResolvedValue({
+        identityToken: 'apple-id-token-789',
+        authorizationCode: 'auth-code-abc',
+        email: null,
+        fullName: { givenName: null, familyName: null },
+      });
+
+      const result = await signInWithApple();
+
+      expect(result.email).toBeNull();
+      expect(result.fullName).toBeNull();
+    });
+
+    it('returns empty string for authorizationCode when not provided', async () => {
+      (AppleAuthentication.signInAsync as jest.Mock).mockResolvedValue({
+        identityToken: 'token',
+        authorizationCode: null,
+        email: null,
+        fullName: null,
+      });
+
+      const result = await signInWithApple();
+      expect(result.authorizationCode).toBe('');
+    });
+
+    it('throws when no identity token received', async () => {
+      (AppleAuthentication.signInAsync as jest.Mock).mockResolvedValue({
+        identityToken: null,
+        authorizationCode: null,
+        email: null,
+        fullName: null,
+      });
+
+      await expect(signInWithApple()).rejects.toThrow(
+        'Apple Sign-In failed: no identity token received',
+      );
+    });
+
+    it('throws when user cancels the sign-in sheet', async () => {
+      (AppleAuthentication.signInAsync as jest.Mock).mockRejectedValue(
+        new Error('The user canceled the authorization attempt'),
+      );
+
+      await expect(signInWithApple()).rejects.toThrow('canceled');
+    });
+
+    it('handles partial name (only given name)', async () => {
+      (AppleAuthentication.signInAsync as jest.Mock).mockResolvedValue({
+        identityToken: 'token',
+        authorizationCode: 'code',
+        email: 'test@icloud.com',
+        fullName: { givenName: 'Jane', familyName: null },
+      });
+
+      const result = await signInWithApple();
+      expect(result.fullName).toBe('Jane');
+    });
+
+    it('handles partial name (only family name)', async () => {
+      (AppleAuthentication.signInAsync as jest.Mock).mockResolvedValue({
+        identityToken: 'token',
+        authorizationCode: 'code',
+        email: null,
+        fullName: { givenName: null, familyName: 'Doe' },
+      });
+
+      const result = await signInWithApple();
+      expect(result.fullName).toBe('Doe');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `appleAuth.test.ts` (10 tests) covering the native Apple Sign-In service: availability checks per platform, credential parsing, error/cancellation handling, and edge cases (partial names, null fields on subsequent sign-ins)
- Expand `LoginScreen.test.tsx` social auth section (6 new tests): accessibility attributes, platform-gated Apple button rendering, Google button styling, and error state display for both social providers

Addresses bead `hq-1kp1k` (Social Auth wiring).

## Test plan
- [x] `appleAuth.test.ts` — 10/10 passing
- [x] `LoginScreen.test.tsx` — 35/35 passing (6 new social auth tests)
- [x] `useAuth.test.tsx` — 30/30 passing (no regressions)
- [x] `googleAuth.test.ts` — 10/10 passing (no regressions)
- [x] QA sandbox — all 6 checks green (Jest, TypeScript, ESLint, Expo Web, EAS Android, EAS iOS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)