### PR TITLE
feat: SearchScreen with full-text search, results grid, recent searches

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -121,6 +121,11 @@ const OrderConfirmationScreen = lazy(() =>
     default: m.OrderConfirmationScreen,
   })),
 );
+const SearchScreen = lazy(() =>
+  import('@/screens/SearchScreen').then((m) => ({
+    default: withScreenErrorBoundary(m.SearchScreen, 'Search'),
+  })),
+);
 const CompareScreen = lazy(() =>
   import('@/screens/CompareScreen').then((m) => ({
     default: withScreenErrorBoundary(m.CompareScreen, 'Compare'),
@@ -164,6 +169,7 @@ export type RootStackParamList = {
   CollectionDetail: { slug: string };
   Premium: undefined;
   StyleQuiz: undefined;
+  Search: undefined;
   Compare: { productSlugs: string[] };
   PrivacyPolicy: undefined;
 };
@@ -318,6 +324,7 @@ export function AppNavigator() {
             <StyleQuizScreen onComplete={() => nav.goBack()} onBack={() => nav.goBack()} />
           )}
         </Stack.Screen>
+        <Stack.Screen name="Search" component={SearchScreen} options={fadeTransition} />
         <Stack.Screen name="Compare" options={fadeTransition}>
           {({ navigation: nav, route }) => {
             const { PRODUCTS } = require('@/data/products');

--- a/src/screens/SearchScreen.tsx
+++ b/src/screens/SearchScreen.tsx
@@ -1,0 +1,369 @@
+/**
+ * @module SearchScreen
+ *
+ * Dedicated full-screen search experience. Reached by tapping the search bar
+ * on the ShopScreen. Auto-focuses the input, shows recent searches and
+ * trending terms, and displays a two-column product results grid with
+ * autocomplete suggestions as the user types.
+ */
+
+import React, { useCallback, useState } from 'react';
+import { StyleSheet, View, Text, FlatList, TouchableOpacity } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { useNavigation } from '@react-navigation/native';
+import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import Animated, { FadeInDown } from 'react-native-reanimated';
+import { useTheme } from '@/theme';
+import {
+  useProducts,
+  type Product,
+  type ProductCategory,
+  type SortOption,
+} from '@/hooks/useProducts';
+import { useRecentSearches } from '@/hooks/useRecentSearches';
+import { SearchBar } from '@/components/SearchBar';
+import { ProductCard } from '@/components/ProductCard';
+import { SearchEmptyState } from '@/components/SearchEmptyState';
+import { SortPicker } from '@/components/SortPicker';
+import { AnimatedPressable } from '@/components/AnimatedPressable';
+import { events } from '@/services/analytics';
+import { useScrollPerformance } from '@/hooks/useScrollPerformance';
+import type { RootStackParamList } from '@/navigation/AppNavigator';
+
+const ESTIMATED_PRODUCT_ROW_HEIGHT = 262;
+
+const TRENDING_SEARCHES = ['futon mattress', 'queen size', 'wall bed', 'slipcover', 'memory foam'];
+
+const POPULAR_CATEGORIES: { id: ProductCategory; label: string }[] = [
+  { id: 'futons', label: 'Futons' },
+  { id: 'murphy-beds', label: 'Murphy Beds' },
+  { id: 'covers', label: 'Covers' },
+  { id: 'mattresses', label: 'Mattresses' },
+  { id: 'frames', label: 'Frames' },
+  { id: 'pillows', label: 'Pillows' },
+  { id: 'accessories', label: 'Accessories' },
+];
+
+interface Props {
+  testID?: string;
+}
+
+export function SearchScreen({ testID }: Props) {
+  const { colors, spacing, typography, borderRadius } = useTheme();
+  const insets = useSafeAreaInsets();
+  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
+  const scrollPerf = useScrollPerformance('SearchScreen');
+
+  const {
+    products,
+    categories,
+    searchQuery,
+    sortBy,
+    suggestions,
+    isLoading,
+    setSearchQuery,
+    setSortBy,
+    loadMore,
+  } = useProducts();
+  const { recentSearches, addSearch, removeSearch, clearAll } = useRecentSearches();
+  const [hasSearched, setHasSearched] = useState(false);
+
+  const handleBack = useCallback(() => {
+    navigation.goBack();
+  }, [navigation]);
+
+  const handleProductPress = useCallback(
+    (product: Product) => {
+      navigation.navigate('ProductDetail', { slug: product.slug });
+    },
+    [navigation],
+  );
+
+  const handleSubmitSearch = useCallback(
+    (query: string) => {
+      setSearchQuery(query);
+      addSearch(query);
+      setHasSearched(true);
+      events.search(query, products.length);
+    },
+    [setSearchQuery, addSearch, products.length],
+  );
+
+  const handleCategoryPress = useCallback(
+    (categoryId: ProductCategory) => {
+      navigation.navigate('Category', { slug: categoryId });
+    },
+    [navigation],
+  );
+
+  const handleTrendingPress = useCallback(
+    (term: string) => {
+      setSearchQuery(term);
+      addSearch(term);
+      setHasSearched(true);
+      events.search(term, 0);
+    },
+    [setSearchQuery, addSearch],
+  );
+
+  const handleChangeText = useCallback(
+    (text: string) => {
+      setSearchQuery(text);
+      if (text.length === 0) {
+        setHasSearched(false);
+      }
+    },
+    [setSearchQuery],
+  );
+
+  const renderProduct = useCallback(
+    ({ item, index }: { item: Product; index: number }) => (
+      <Animated.View
+        testID={`product-card-animated-${item.id}`}
+        entering={FadeInDown.delay(index * 60).duration(350)}
+      >
+        <ProductCard product={item} onPress={handleProductPress} />
+      </Animated.View>
+    ),
+    [handleProductPress],
+  );
+
+  const keyExtractor = useCallback((item: Product) => item.id, []);
+
+  const showResults = searchQuery.length > 0;
+  const showInitialState = !showResults;
+
+  const renderResultsHeader = useCallback(
+    () => (
+      <View style={[styles.resultsHeader, { paddingHorizontal: spacing.md }]}>
+        <Text
+          style={[styles.resultCount, { color: colors.espressoLight }]}
+          testID="search-result-count"
+        >
+          {products.length} {products.length === 1 ? 'result' : 'results'}
+        </Text>
+        <SortPicker value={sortBy} onChange={setSortBy} resultCount={products.length} />
+      </View>
+    ),
+    [products.length, sortBy, setSortBy, colors, spacing],
+  );
+
+  const renderEmpty = useCallback(
+    () =>
+      searchQuery ? (
+        <SearchEmptyState
+          query={searchQuery}
+          categories={categories.map((c) => ({ id: c.id, label: c.label }))}
+          onCategoryPress={handleCategoryPress}
+          onTrendingPress={handleTrendingPress}
+        />
+      ) : null,
+    [searchQuery, categories, handleCategoryPress, handleTrendingPress],
+  );
+
+  return (
+    <View
+      style={[styles.container, { backgroundColor: colors.sandBase, paddingTop: insets.top }]}
+      testID={testID ?? 'search-screen'}
+    >
+      {/* Header with back + search */}
+      <View style={[styles.header, { paddingHorizontal: spacing.md }]}>
+        <TouchableOpacity
+          onPress={handleBack}
+          style={styles.backButton}
+          testID="search-back"
+          accessibilityLabel="Go back"
+          accessibilityRole="button"
+        >
+          <Text style={[styles.backText, { color: colors.espresso }]}>{'‹'}</Text>
+        </TouchableOpacity>
+        <View style={styles.searchBarWrap}>
+          <SearchBar
+            value={searchQuery}
+            onChangeText={handleChangeText}
+            suggestions={suggestions}
+            recentSearches={recentSearches}
+            onSubmitSearch={handleSubmitSearch}
+            onRemoveRecent={removeSearch}
+            onClearRecent={clearAll}
+            placeholder="Search products..."
+          />
+        </View>
+      </View>
+
+      {/* Initial state — no query yet */}
+      {showInitialState && (
+        <View style={styles.initialState} testID="search-initial-state">
+          {/* Popular categories */}
+          <View style={[styles.section, { paddingHorizontal: spacing.md }]}>
+            <Text
+              style={[styles.sectionTitle, { color: colors.espressoLight }]}
+              accessibilityRole="header"
+            >
+              Popular Categories
+            </Text>
+            <View style={[styles.chipsContainer, { gap: spacing.sm }]}>
+              {POPULAR_CATEGORIES.map((cat) => (
+                <AnimatedPressable
+                  key={cat.id}
+                  style={[
+                    styles.chip,
+                    {
+                      backgroundColor: colors.sandLight,
+                      borderRadius: borderRadius.pill,
+                      borderColor: colors.sandDark,
+                    },
+                  ]}
+                  onPress={() => handleCategoryPress(cat.id)}
+                  testID={`initial-category-${cat.id}`}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Browse ${cat.label}`}
+                  haptic="light"
+                >
+                  <Text style={[styles.chipText, { color: colors.espresso }]}>{cat.label}</Text>
+                </AnimatedPressable>
+              ))}
+            </View>
+          </View>
+
+          {/* Trending searches */}
+          <View style={[styles.section, { paddingHorizontal: spacing.md }]}>
+            <Text
+              style={[styles.sectionTitle, { color: colors.espressoLight }]}
+              accessibilityRole="header"
+            >
+              Trending Searches
+            </Text>
+            <View style={[styles.chipsContainer, { gap: spacing.sm }]}>
+              {TRENDING_SEARCHES.map((term, index) => (
+                <AnimatedPressable
+                  key={term}
+                  style={[
+                    styles.trendingChip,
+                    {
+                      backgroundColor: colors.mountainBlue,
+                      borderRadius: borderRadius.pill,
+                    },
+                  ]}
+                  onPress={() => handleTrendingPress(term)}
+                  testID={`initial-trending-${index}`}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Search for ${term}`}
+                  haptic="light"
+                >
+                  <Text style={[styles.trendingChipText, { color: colors.offWhite }]}>{term}</Text>
+                </AnimatedPressable>
+              ))}
+            </View>
+          </View>
+        </View>
+      )}
+
+      {/* Search results grid */}
+      {showResults && (
+        <FlatList
+          data={products}
+          renderItem={renderProduct}
+          keyExtractor={keyExtractor}
+          numColumns={2}
+          columnWrapperStyle={products.length > 0 ? styles.row : undefined}
+          ListHeaderComponent={products.length > 0 ? renderResultsHeader : undefined}
+          ListEmptyComponent={renderEmpty}
+          getItemLayout={(_data, index) => ({
+            length: ESTIMATED_PRODUCT_ROW_HEIGHT,
+            offset: ESTIMATED_PRODUCT_ROW_HEIGHT * index,
+            index,
+          })}
+          onEndReached={loadMore}
+          onEndReachedThreshold={0.5}
+          contentContainerStyle={[styles.listContent, { paddingBottom: insets.bottom + 16 }]}
+          onScrollBeginDrag={scrollPerf.onScrollBeginDrag}
+          onScrollEndDrag={scrollPerf.onScrollEndDrag}
+          onMomentumScrollEnd={scrollPerf.onMomentumScrollEnd}
+          showsVerticalScrollIndicator={false}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="on-drag"
+          windowSize={5}
+          maxToRenderPerBatch={6}
+          initialNumToRender={4}
+          removeClippedSubviews
+          testID="search-results-grid"
+        />
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingVertical: 8,
+    gap: 4,
+  },
+  backButton: {
+    paddingRight: 4,
+  },
+  backText: {
+    fontSize: 28,
+    fontWeight: '300',
+    marginTop: -2,
+  },
+  searchBarWrap: {
+    flex: 1,
+  },
+  initialState: {
+    flex: 1,
+    paddingTop: 24,
+  },
+  section: {
+    marginBottom: 28,
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: '700',
+    marginBottom: 12,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  chipsContainer: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+  },
+  chip: {
+    paddingVertical: 8,
+    paddingHorizontal: 16,
+    borderWidth: 1,
+  },
+  chipText: {
+    fontSize: 13,
+    fontWeight: '600',
+  },
+  trendingChip: {
+    paddingVertical: 6,
+    paddingHorizontal: 14,
+  },
+  trendingChipText: {
+    color: '#FFFFFF',
+    fontSize: 12,
+    fontWeight: '600',
+  },
+  resultsHeader: {
+    paddingTop: 8,
+    paddingBottom: 4,
+  },
+  resultCount: {
+    fontSize: 14,
+    fontWeight: '600',
+    marginBottom: 4,
+  },
+  listContent: {
+    flexGrow: 1,
+  },
+  row: {
+    paddingHorizontal: 10,
+  },
+});

--- a/src/screens/__tests__/SearchScreen.test.tsx
+++ b/src/screens/__tests__/SearchScreen.test.tsx
@@ -1,0 +1,348 @@
+import React from 'react';
+import { render, fireEvent, act, waitFor } from '@testing-library/react-native';
+import { SearchScreen } from '../SearchScreen';
+import { ThemeProvider } from '@/theme/ThemeProvider';
+import { WishlistProvider } from '@/hooks/useWishlist';
+import { PRODUCTS } from '@/data/products';
+
+const mockNavigate = jest.fn();
+const mockGoBack = jest.fn();
+
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({
+    navigate: mockNavigate,
+    goBack: mockGoBack,
+  }),
+}));
+
+jest.mock('@/services/wix', () => ({
+  useOptionalWixClient: () => null,
+}));
+
+jest.mock('@react-native-async-storage/async-storage', () => ({
+  getItem: jest.fn().mockResolvedValue(null),
+  setItem: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock('@/services/analytics', () => ({
+  events: {
+    search: jest.fn(),
+    screenView: jest.fn(),
+    filterCategory: jest.fn(),
+    sortProducts: jest.fn(),
+  },
+}));
+
+jest.useFakeTimers();
+
+function renderSearchScreen() {
+  return render(
+    <ThemeProvider>
+      <WishlistProvider>
+        <SearchScreen />
+      </WishlistProvider>
+    </ThemeProvider>,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('SearchScreen', () => {
+  describe('rendering', () => {
+    it('renders with testID', async () => {
+      const { getByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
+      expect(getByTestId('search-screen')).toBeTruthy();
+    });
+
+    it('renders search input', async () => {
+      const { getByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
+      expect(getByTestId('search-input')).toBeTruthy();
+    });
+
+    it('renders back button', async () => {
+      const { getByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
+      expect(getByTestId('search-back')).toBeTruthy();
+    });
+
+    it('accepts custom testID', async () => {
+      const { getByTestId } = render(
+        <ThemeProvider>
+          <WishlistProvider>
+            <SearchScreen testID="custom-search" />
+          </WishlistProvider>
+        </ThemeProvider>,
+      );
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
+      expect(getByTestId('custom-search')).toBeTruthy();
+    });
+  });
+
+  describe('navigation', () => {
+    it('calls goBack when back button pressed', async () => {
+      const { getByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
+      fireEvent.press(getByTestId('search-back'));
+      expect(mockGoBack).toHaveBeenCalledTimes(1);
+    });
+
+    it('navigates to ProductDetail when product tapped', async () => {
+      const { getByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(700);
+      });
+      // Search for something that will return results
+      fireEvent.changeText(getByTestId('search-input'), 'futon');
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+      // Find a product card and tap it
+      const firstFuton = PRODUCTS.find((p) => p.name.toLowerCase().includes('futon'));
+      if (firstFuton) {
+        const card = getByTestId(`product-card-${firstFuton.id}`);
+        fireEvent.press(card);
+        expect(mockNavigate).toHaveBeenCalledWith('ProductDetail', { slug: firstFuton.slug });
+      }
+    });
+
+    it('navigates to Category when category chip pressed in empty state', async () => {
+      const { getByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(700);
+      });
+      // Search for something that returns no results
+      fireEvent.changeText(getByTestId('search-input'), 'xyznonexistent999');
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+      const chip = getByTestId('category-chip-futons');
+      fireEvent.press(chip);
+      expect(mockNavigate).toHaveBeenCalledWith('Category', { slug: 'futons' });
+    });
+  });
+
+  describe('search behavior', () => {
+    it('shows results when typing a query', async () => {
+      const { getByTestId, queryByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(700);
+      });
+      fireEvent.changeText(getByTestId('search-input'), 'futon');
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+      expect(queryByTestId('search-results-grid')).toBeTruthy();
+    });
+
+    it('shows empty state when query returns no results', async () => {
+      const { getByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(700);
+      });
+      fireEvent.changeText(getByTestId('search-input'), 'xyznonexistent999');
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+      expect(getByTestId('search-empty-state')).toBeTruthy();
+    });
+
+    it('shows trending searches in empty state', async () => {
+      const { getByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(700);
+      });
+      fireEvent.changeText(getByTestId('search-input'), 'xyznonexistent999');
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+      expect(getByTestId('trending-section')).toBeTruthy();
+    });
+
+    it('applies trending search when trending chip pressed', async () => {
+      const { getByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(700);
+      });
+      fireEvent.changeText(getByTestId('search-input'), 'xyznonexistent999');
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+      fireEvent.press(getByTestId('trending-chip-0'));
+      // Should update search query to trending term
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+    });
+
+    it('clears search when clear button pressed', async () => {
+      const { getByTestId, queryByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(700);
+      });
+      fireEvent.changeText(getByTestId('search-input'), 'futon');
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+      fireEvent.press(getByTestId('search-clear'));
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+      // Should show initial state, not results
+      expect(queryByTestId('search-results-grid')).toBeNull();
+    });
+  });
+
+  describe('initial state', () => {
+    it('shows recent searches prompt when no query', async () => {
+      const { getByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(700);
+      });
+      expect(getByTestId('search-initial-state')).toBeTruthy();
+    });
+
+    it('shows trending searches section in initial state', async () => {
+      const { getByText } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(700);
+      });
+      expect(getByText('Trending Searches')).toBeTruthy();
+    });
+
+    it('shows popular categories in initial state', async () => {
+      const { getByText } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(700);
+      });
+      expect(getByText('Popular Categories')).toBeTruthy();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('back button has accessibility label', async () => {
+      const { getByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
+      expect(getByTestId('search-back').props.accessibilityLabel).toBe('Go back');
+    });
+
+    it('search input has accessibility label', async () => {
+      const { getByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(100);
+      });
+      expect(getByTestId('search-input').props.accessibilityLabel).toBe('Search products');
+    });
+  });
+
+  describe('results count', () => {
+    it('shows result count when search has results', async () => {
+      const { getByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(700);
+      });
+      fireEvent.changeText(getByTestId('search-input'), 'futon');
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+      expect(getByTestId('search-result-count')).toBeTruthy();
+    });
+  });
+
+  describe('edge cases', () => {
+    it('handles empty string search gracefully', async () => {
+      const { getByTestId, queryByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(700);
+      });
+      fireEvent.changeText(getByTestId('search-input'), '');
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+      // Should show initial state, not results or empty state
+      expect(getByTestId('search-initial-state')).toBeTruthy();
+      expect(queryByTestId('search-results-grid')).toBeNull();
+    });
+
+    it('handles whitespace-only search', async () => {
+      const { getByTestId, queryByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(700);
+      });
+      fireEvent.changeText(getByTestId('search-input'), '   ');
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+      // Whitespace triggers results mode but likely no matches
+      expect(queryByTestId('search-initial-state')).toBeNull();
+    });
+
+    it('navigates to Category from initial state category chip', async () => {
+      const { getByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(700);
+      });
+      fireEvent.press(getByTestId('initial-category-futons'));
+      expect(mockNavigate).toHaveBeenCalledWith('Category', { slug: 'futons' });
+    });
+
+    it('applies trending search from initial state', async () => {
+      const { getByTestId, queryByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(700);
+      });
+      fireEvent.press(getByTestId('initial-trending-0'));
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+      // Should now show results mode (search-initial-state should be gone)
+      expect(queryByTestId('search-initial-state')).toBeNull();
+    });
+
+    it('transitions from results back to initial state on clear', async () => {
+      const { getByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(700);
+      });
+      // Search for something
+      fireEvent.changeText(getByTestId('search-input'), 'futon');
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+      // Clear
+      fireEvent.press(getByTestId('search-clear'));
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+      // Should be back to initial state
+      expect(getByTestId('search-initial-state')).toBeTruthy();
+    });
+
+    it('shows sort picker in results mode', async () => {
+      const { getByTestId } = renderSearchScreen();
+      await act(async () => {
+        jest.advanceTimersByTime(700);
+      });
+      fireEvent.changeText(getByTestId('search-input'), 'futon');
+      await act(async () => {
+        jest.advanceTimersByTime(500);
+      });
+      expect(getByTestId('sort-picker')).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- New `SearchScreen` component composing existing `SearchBar`, `useRecentSearches`, `useProducts`, and `SearchEmptyState`
- Full-text product search with 2-column results grid, sort controls, autocomplete suggestions
- Initial state with popular categories and trending searches; empty state with category chips and trending terms
- Navigation wiring: `Search` route added to `AppNavigator` with fade transition

## Implementation
- Uses existing `useProducts` hook for Wix API query integration (server-side `$contains` search when configured, client-side fuzzy fallback)
- Uses existing `useRecentSearches` hook for persistent search history (AsyncStorage)
- 24 tests covering rendering, navigation, search behavior, initial/empty states, accessibility, edge cases

## Test plan
- [x] 24 unit tests pass (SearchScreen.test.tsx)
- [x] Full test suite: 226/228 suites pass (2 pre-existing timeouts: ShopScreen, ListVirtualization)
- [ ] Manual: navigate to Search from ShopScreen
- [ ] Manual: type query → see autocomplete → see results grid
- [ ] Manual: tap product → navigates to ProductDetail
- [ ] Manual: search nonsense → see empty state with category chips + trending
- [ ] Manual: tap category chip → navigates to Category

🤖 Generated with [Claude Code](https://claude.com/claude-code)