### PR TITLE
feat: wire review submission to Wix CMS API (hq-s6q12)

### DIFF
--- a/src/hooks/__tests__/useReviews.test.ts
+++ b/src/hooks/__tests__/useReviews.test.ts
@@ -2,10 +2,21 @@ import { renderHook, act } from '@testing-library/react-native';
 import { useReviews } from '../useReviews';
 import { getEventBuffer, clearEventBuffer } from '@/services/analytics';
 
+// ── Wix client mock ────────────────────────────────────────────
+const mockCreateReview = jest.fn();
+const mockQueryReviews = jest.fn();
+let mockWixClient: any = null;
+
+jest.mock('@/services/wix/wixProvider', () => ({
+  useOptionalWixClient: () => mockWixClient,
+}));
+
 jest.useFakeTimers();
 
 beforeEach(() => {
   clearEventBuffer();
+  jest.clearAllMocks();
+  mockWixClient = null; // Default: no Wix client (mock-data mode)
 });
 
 afterAll(() => {
@@ -42,6 +53,16 @@ describe('useReviews', () => {
     it('form is hidden initially', () => {
       const { result } = renderHook(() => useReviews(productId));
       expect(result.current.showForm).toBe(false);
+    });
+
+    it('has no submit error initially', () => {
+      const { result } = renderHook(() => useReviews(productId));
+      expect(result.current.submitError).toBeNull();
+    });
+
+    it('submitSuccess is false initially', () => {
+      const { result } = renderHook(() => useReviews(productId));
+      expect(result.current.submitSuccess).toBe(false);
     });
   });
 
@@ -83,7 +104,7 @@ describe('useReviews', () => {
     });
   });
 
-  describe('submit review', () => {
+  describe('submit review (mock-data fallback, no Wix client)', () => {
     it('adds review to the list after submission', async () => {
       const { result } = renderHook(() => useReviews(productId));
       const initialCount = result.current.reviews.length;
@@ -181,6 +202,252 @@ describe('useReviews', () => {
       });
 
       expect(result.current.summary.totalReviews).toBe(initialTotal + 1);
+    });
+
+    it('sets submitSuccess=true after successful submission', async () => {
+      const { result } = renderHook(() => useReviews(productId));
+
+      await act(async () => {
+        const promise = result.current.submitReview({
+          rating: 5,
+          title: 'Great',
+          body: 'Loved it.',
+          photos: [],
+        });
+        jest.advanceTimersByTime(600);
+        await promise;
+      });
+
+      expect(result.current.submitSuccess).toBe(true);
+    });
+  });
+
+  describe('submit review (Wix client connected)', () => {
+    beforeEach(() => {
+      mockWixClient = {
+        createReview: mockCreateReview,
+        queryReviews: mockQueryReviews,
+      };
+    });
+
+    it('calls wixClient.createReview with correct payload', async () => {
+      mockCreateReview.mockResolvedValue({
+        id: 'wix-rev-1',
+        productId,
+        authorName: 'Test User',
+        rating: 5,
+        title: 'Wix review',
+        body: 'Submitted via API.',
+        createdAt: new Date().toISOString(),
+        helpful: 0,
+        verified: false,
+        photos: [],
+      });
+
+      const { result } = renderHook(() => useReviews(productId));
+
+      await act(async () => {
+        await result.current.submitReview({
+          rating: 5,
+          title: 'Wix review',
+          body: 'Submitted via API.',
+          photos: ['file:///photo1.jpg'],
+        });
+      });
+
+      expect(mockCreateReview).toHaveBeenCalledWith({
+        productId,
+        authorName: expect.any(String),
+        rating: 5,
+        title: 'Wix review',
+        body: 'Submitted via API.',
+        photos: ['file:///photo1.jpg'],
+      });
+    });
+
+    it('adds optimistic review immediately before API resolves', async () => {
+      let resolveApi: (val: any) => void;
+      const apiPromise = new Promise((resolve) => {
+        resolveApi = resolve;
+      });
+      mockCreateReview.mockReturnValue(apiPromise);
+
+      const { result } = renderHook(() => useReviews(productId));
+      const initialCount = result.current.reviews.length;
+
+      // Start submit — should add optimistic review
+      let submitPromise: Promise<boolean>;
+      act(() => {
+        submitPromise = result.current.submitReview({
+          rating: 5,
+          title: 'Optimistic review',
+          body: 'Should appear immediately.',
+          photos: [],
+        });
+      });
+
+      // Review should appear optimistically
+      expect(result.current.reviews.length).toBe(initialCount + 1);
+      const optimistic = result.current.reviews.find((r) => r.title === 'Optimistic review');
+      expect(optimistic).toBeDefined();
+
+      // Resolve API
+      await act(async () => {
+        resolveApi!({
+          id: 'wix-rev-99',
+          productId,
+          authorName: 'You',
+          rating: 5,
+          title: 'Optimistic review',
+          body: 'Should appear immediately.',
+          createdAt: new Date().toISOString(),
+          helpful: 0,
+          verified: false,
+        });
+        await submitPromise!;
+      });
+
+      // Review should still be there with server ID
+      expect(result.current.reviews.length).toBe(initialCount + 1);
+    });
+
+    it('rolls back optimistic review on API failure', async () => {
+      mockCreateReview.mockRejectedValue(new Error('Network error'));
+
+      const { result } = renderHook(() => useReviews(productId));
+      const initialCount = result.current.reviews.length;
+
+      await act(async () => {
+        await result.current.submitReview({
+          rating: 5,
+          title: 'Doomed review',
+          body: 'This will fail.',
+          photos: [],
+        });
+      });
+
+      // Review should be rolled back
+      expect(result.current.reviews.length).toBe(initialCount);
+      expect(result.current.reviews.find((r) => r.title === 'Doomed review')).toBeUndefined();
+    });
+
+    it('sets submitError on API failure', async () => {
+      mockCreateReview.mockRejectedValue(new Error('Server error'));
+
+      const { result } = renderHook(() => useReviews(productId));
+
+      await act(async () => {
+        await result.current.submitReview({
+          rating: 4,
+          title: 'Will fail',
+          body: 'Error test.',
+          photos: [],
+        });
+      });
+
+      expect(result.current.submitError).toBe('Failed to submit review. Please try again.');
+    });
+
+    it('returns false on API failure', async () => {
+      mockCreateReview.mockRejectedValue(new Error('Server error'));
+
+      const { result } = renderHook(() => useReviews(productId));
+
+      let success: boolean | undefined;
+      await act(async () => {
+        success = await result.current.submitReview({
+          rating: 4,
+          title: 'Will fail',
+          body: 'Error test.',
+          photos: [],
+        });
+      });
+
+      expect(success).toBe(false);
+    });
+
+    it('clears submitError on next successful submission', async () => {
+      // First: fail
+      mockCreateReview.mockRejectedValueOnce(new Error('Server error'));
+
+      const { result } = renderHook(() => useReviews(productId));
+
+      await act(async () => {
+        await result.current.submitReview({
+          rating: 4,
+          title: 'Will fail',
+          body: 'Error test.',
+          photos: [],
+        });
+      });
+      expect(result.current.submitError).not.toBeNull();
+
+      // Second: succeed
+      mockCreateReview.mockResolvedValueOnce({
+        id: 'wix-rev-2',
+        productId,
+        authorName: 'You',
+        rating: 5,
+        title: 'Will succeed',
+        body: 'Success test.',
+        createdAt: new Date().toISOString(),
+        helpful: 0,
+        verified: false,
+      });
+
+      await act(async () => {
+        await result.current.submitReview({
+          rating: 5,
+          title: 'Will succeed',
+          body: 'Success test.',
+          photos: [],
+        });
+      });
+
+      expect(result.current.submitError).toBeNull();
+      expect(result.current.submitSuccess).toBe(true);
+    });
+
+    it('keeps form open on API failure', async () => {
+      mockCreateReview.mockRejectedValue(new Error('Network error'));
+
+      const { result } = renderHook(() => useReviews(productId));
+      act(() => result.current.setShowForm(true));
+
+      await act(async () => {
+        await result.current.submitReview({
+          rating: 4,
+          title: 'Will fail',
+          body: 'Keeps form open.',
+          photos: [],
+        });
+      });
+
+      expect(result.current.showForm).toBe(true);
+    });
+  });
+
+  describe('clearSubmitStatus', () => {
+    it('clears both submitError and submitSuccess', async () => {
+      const { result } = renderHook(() => useReviews(productId));
+
+      await act(async () => {
+        const promise = result.current.submitReview({
+          rating: 5,
+          title: 'Test',
+          body: 'Test body',
+          photos: [],
+        });
+        jest.advanceTimersByTime(600);
+        await promise;
+      });
+
+      expect(result.current.submitSuccess).toBe(true);
+
+      act(() => result.current.clearSubmitStatus());
+
+      expect(result.current.submitSuccess).toBe(false);
+      expect(result.current.submitError).toBeNull();
     });
   });
 

--- a/src/hooks/useReviews.ts
+++ b/src/hooks/useReviews.ts
@@ -1,11 +1,12 @@
 /**
  * @module useReviews
  *
- * Product review management: listing, sorting, local submission with optimistic
- * UI, and "helpful" voting. Reviews are mock-backed today but the interface
- * is designed for direct API replacement.
+ * Product review management: listing, sorting, submission with optimistic UI,
+ * and "helpful" voting. When a WixClient is available via context, submissions
+ * go through the Wix Data CMS API with optimistic insert + rollback on failure.
+ * Falls back to local-only mock submission when no client is configured.
  */
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useRef } from 'react';
 import {
   type Review,
   type ReviewSummary,
@@ -14,6 +15,7 @@ import {
   sortReviews,
   MOCK_REVIEWS,
 } from '@/data/reviews';
+import { useOptionalWixClient } from '@/services/wix/wixProvider';
 import { events } from '@/services/analytics';
 
 type ReviewSort = 'recent' | 'helpful' | 'highest' | 'lowest';
@@ -36,11 +38,14 @@ interface UseReviewsReturn {
   showForm: boolean;
   setShowForm: (show: boolean) => void;
   hasReviews: boolean;
+  submitError: string | null;
+  submitSuccess: boolean;
+  clearSubmitStatus: () => void;
 }
 
 /**
  * Hook for managing product reviews: listing, sorting, submission, and helpful votes.
- * Uses mock data with simulated submission; designed for API integration later.
+ * Wires to the Wix CMS API when a client is available; falls back to mock data otherwise.
  */
 export function useReviews(productId: string): UseReviewsReturn {
   const [sort, setSort] = useState<ReviewSort>('helpful');
@@ -48,6 +53,12 @@ export function useReviews(productId: string): UseReviewsReturn {
   const [showForm, setShowForm] = useState(false);
   const [localReviews, setLocalReviews] = useState<Review[]>([]);
   const [helpfulVotes, setHelpfulVotes] = useState<Set<string>>(new Set());
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [submitSuccess, setSubmitSuccess] = useState(false);
+
+  const wixClient = useOptionalWixClient();
+  const localReviewsRef = useRef(localReviews);
+  localReviewsRef.current = localReviews;
 
   const allReviews = useMemo(() => {
     const existing = getReviewsForProduct(productId);
@@ -58,7 +69,6 @@ export function useReviews(productId: string): UseReviewsReturn {
 
   const summary = useMemo((): ReviewSummary => {
     const base = getReviewSummary(productId);
-    // Add local reviews to summary
     for (const review of localReviews) {
       base.distribution[review.rating - 1] += 1;
       base.totalReviews += 1;
@@ -73,41 +83,87 @@ export function useReviews(productId: string): UseReviewsReturn {
   const submitReview = useCallback(
     async (data: SubmitReviewData): Promise<boolean> => {
       setIsSubmitting(true);
-      try {
-        // Simulate API call
-        await new Promise((resolve) => setTimeout(resolve, 500));
+      setSubmitError(null);
+      setSubmitSuccess(false);
 
-        const newReview: Review = {
-          id: `rev-local-${Date.now()}`,
-          productId,
-          authorName: 'You',
-          rating: data.rating,
-          title: data.title,
-          body: data.body,
-          createdAt: new Date().toISOString(),
-          helpful: 0,
-          verified: true,
-          photos: data.photos.length > 0 ? data.photos : undefined,
-        };
+      const optimisticId = `rev-local-${Date.now()}`;
+      const optimisticReview: Review = {
+        id: optimisticId,
+        productId,
+        authorName: 'You',
+        rating: data.rating,
+        title: data.title,
+        body: data.body,
+        createdAt: new Date().toISOString(),
+        helpful: 0,
+        verified: true,
+        photos: data.photos.length > 0 ? data.photos : undefined,
+      };
 
-        setLocalReviews((prev) => [newReview, ...prev]);
-        setShowForm(false);
-        events.submitReview(productId, data.rating);
-        return true;
-      } catch {
-        return false;
-      } finally {
-        setIsSubmitting(false);
+      // Add optimistic review immediately
+      setLocalReviews((prev) => [optimisticReview, ...prev]);
+
+      if (wixClient) {
+        // ── Wix API path ──
+        try {
+          const serverReview = await wixClient.createReview({
+            productId,
+            authorName: 'You',
+            rating: data.rating,
+            title: data.title,
+            body: data.body,
+            photos: data.photos,
+          });
+
+          // Replace optimistic entry with server response
+          setLocalReviews((prev) =>
+            prev.map((r) =>
+              r.id === optimisticId
+                ? {
+                    ...serverReview,
+                    // Normalize to our Review shape
+                    verified: serverReview.verified ?? true,
+                  }
+                : r,
+            ),
+          );
+
+          setShowForm(false);
+          setSubmitSuccess(true);
+          events.submitReview(productId, data.rating);
+          return true;
+        } catch {
+          // Roll back optimistic review
+          setLocalReviews((prev) => prev.filter((r) => r.id !== optimisticId));
+          setSubmitError('Failed to submit review. Please try again.');
+          return false;
+        } finally {
+          setIsSubmitting(false);
+        }
+      } else {
+        // ── Mock fallback path ──
+        try {
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          setShowForm(false);
+          setSubmitSuccess(true);
+          events.submitReview(productId, data.rating);
+          return true;
+        } catch {
+          setLocalReviews((prev) => prev.filter((r) => r.id !== optimisticId));
+          setSubmitError('Failed to submit review. Please try again.');
+          return false;
+        } finally {
+          setIsSubmitting(false);
+        }
       }
     },
-    [productId],
+    [productId, wixClient],
   );
 
   const markHelpful = useCallback(
     (reviewId: string) => {
-      if (helpfulVotes.has(reviewId)) return; // Already voted
+      if (helpfulVotes.has(reviewId)) return;
       setHelpfulVotes((prev) => new Set(prev).add(reviewId));
-      // Update the helpful count in mock data (in-memory only)
       const review = MOCK_REVIEWS.find((r) => r.id === reviewId);
       if (review) review.helpful += 1;
       const localReview = localReviews.find((r) => r.id === reviewId);
@@ -116,6 +172,11 @@ export function useReviews(productId: string): UseReviewsReturn {
     },
     [productId, helpfulVotes, localReviews],
   );
+
+  const clearSubmitStatus = useCallback(() => {
+    setSubmitError(null);
+    setSubmitSuccess(false);
+  }, []);
 
   return {
     reviews,
@@ -128,5 +189,8 @@ export function useReviews(productId: string): UseReviewsReturn {
     showForm,
     setShowForm,
     hasReviews: reviews.length > 0,
+    submitError,
+    submitSuccess,
+    clearSubmitStatus,
   };
 }

--- a/src/screens/ProductDetailScreen.tsx
+++ b/src/screens/ProductDetailScreen.tsx
@@ -136,6 +136,9 @@ export function ProductDetailScreen({
     showForm: showReviewForm,
     setShowForm: setShowReviewForm,
     hasReviews,
+    submitError: reviewSubmitError,
+    submitSuccess: reviewSubmitSuccess,
+    clearSubmitStatus: clearReviewSubmitStatus,
   } = useReviews(model.id);
   const previewReviews = reviews.slice(0, 3);
 
@@ -758,6 +761,29 @@ export function ProductDetailScreen({
           {/* Write a Review — authenticated users only */}
           {isAuthenticated && (
             <>
+              {/* Success banner */}
+              {reviewSubmitSuccess && !showReviewForm && (
+                <View
+                  style={[
+                    styles.reviewFeedback,
+                    { backgroundColor: colors.success + '1A', borderColor: colors.success },
+                  ]}
+                  testID="review-submit-success"
+                  accessibilityRole="alert"
+                >
+                  <Text style={[styles.reviewFeedbackText, { color: colors.success }]}>
+                    Thank you! Your review has been submitted.
+                  </Text>
+                  <TouchableOpacity
+                    onPress={clearReviewSubmitStatus}
+                    testID="dismiss-review-success"
+                    accessibilityLabel="Dismiss success message"
+                  >
+                    <Text style={[styles.dismissText, { color: colors.success }]}>×</Text>
+                  </TouchableOpacity>
+                </View>
+              )}
+
               {!showReviewForm ? (
                 <TouchableOpacity
                   style={[
@@ -767,7 +793,10 @@ export function ProductDetailScreen({
                       borderRadius: borderRadius.button,
                     },
                   ]}
-                  onPress={() => setShowReviewForm(true)}
+                  onPress={() => {
+                    clearReviewSubmitStatus();
+                    setShowReviewForm(true);
+                  }}
                   testID="write-review-button"
                   accessibilityLabel="Write a review"
                   accessibilityRole="button"
@@ -793,6 +822,23 @@ export function ProductDetailScreen({
                       <Text style={[styles.cancelText, { color: colors.muted }]}>Cancel</Text>
                     </TouchableOpacity>
                   </View>
+
+                  {/* Error banner */}
+                  {reviewSubmitError && (
+                    <View
+                      style={[
+                        styles.reviewFeedback,
+                        { backgroundColor: colors.error + '1A', borderColor: colors.error },
+                      ]}
+                      testID="review-submit-error"
+                      accessibilityRole="alert"
+                    >
+                      <Text style={[styles.reviewFeedbackText, { color: colors.error }]}>
+                        {reviewSubmitError}
+                      </Text>
+                    </View>
+                  )}
+
                   <ReviewForm
                     onSubmit={submitReview}
                     isSubmitting={isReviewSubmitting}
@@ -1595,6 +1641,25 @@ const styles = StyleSheet.create({
   cancelText: {
     fontSize: 14,
     fontWeight: '500',
+  },
+  reviewFeedback: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    padding: 12,
+    borderWidth: 1,
+    borderRadius: 8,
+    marginBottom: 12,
+  },
+  reviewFeedbackText: {
+    fontSize: 14,
+    fontWeight: '500',
+    flex: 1,
+  },
+  dismissText: {
+    fontSize: 20,
+    fontWeight: '700',
+    paddingLeft: 8,
   },
   // Size Guide
   sizeGuideToggle: {


### PR DESCRIPTION
## Summary
- Wires useReviews hook to wixClient.createReview() with optimistic UI
- Adds submitError, submitSuccess, clearSubmitStatus to hook return
- ProductDetailScreen shows success banner and inline error feedback
- Falls back to mock submission when Wix is not configured

## Test plan
- [x] 30 unit tests pass
- [x] TypeScript strict check passes
- [x] ESLint passes on changed files

Closes hq-s6q12