### PR TITLE
feat: wire cart abandonment cancellation to checkout flow

### DIFF
--- a/src/hooks/__tests__/useCartAbandonmentReminder.test.ts
+++ b/src/hooks/__tests__/useCartAbandonmentReminder.test.ts
@@ -7,7 +7,10 @@
 import { renderHook, act } from '@testing-library/react-native';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import * as Notifications from 'expo-notifications';
-import { useCartAbandonmentReminder } from '../useCartAbandonmentReminder';
+import {
+  useCartAbandonmentReminder,
+  cancelCartAbandonmentForOrder,
+} from '../useCartAbandonmentReminder';
 
 // Mock dependencies
 jest.mock('expo-notifications', () => ({
@@ -314,5 +317,52 @@ describe('useCartAbandonmentReminder', () => {
     await act(async () => {
       await result.current.onCartChanged();
     });
+  });
+});
+
+describe('cancelCartAbandonmentForOrder', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('cancels existing notification and removes storage', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(
+      JSON.stringify({
+        scheduledNotificationId: 'order-notif-123',
+        lastModifiedAt: 999999990000,
+        lastReminderSentAt: 999999000000,
+      }),
+    );
+
+    await cancelCartAbandonmentForOrder();
+
+    expect(Notifications.cancelScheduledNotificationAsync).toHaveBeenCalledWith('order-notif-123');
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEY);
+  });
+
+  it('handles no existing state gracefully', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+
+    await cancelCartAbandonmentForOrder();
+
+    expect(Notifications.cancelScheduledNotificationAsync).not.toHaveBeenCalled();
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEY);
+  });
+
+  it('handles storage errors gracefully', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockRejectedValueOnce(new Error('Storage error'));
+
+    // Should not throw
+    await cancelCartAbandonmentForOrder();
+
+    expect(AsyncStorage.removeItem).toHaveBeenCalledWith(STORAGE_KEY);
+  });
+
+  it('handles removeItem errors gracefully', async () => {
+    (AsyncStorage.getItem as jest.Mock).mockResolvedValueOnce(null);
+    (AsyncStorage.removeItem as jest.Mock).mockRejectedValueOnce(new Error('Remove error'));
+
+    // Should not throw
+    await cancelCartAbandonmentForOrder();
   });
 });

--- a/src/hooks/useCartAbandonmentReminder.ts
+++ b/src/hooks/useCartAbandonmentReminder.ts
@@ -61,6 +61,20 @@ async function cancelExisting(state: AbandonmentState | null): Promise<void> {
   }
 }
 
+/**
+ * Standalone function to cancel any pending cart abandonment notification
+ * and reset throttle state. Call from checkout on successful order.
+ */
+export async function cancelCartAbandonmentForOrder(): Promise<void> {
+  const state = await loadState();
+  await cancelExisting(state);
+  try {
+    await AsyncStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // Fire-and-forget cleanup
+  }
+}
+
 export function useCartAbandonmentReminder({
   itemCount,
   cartRemindersEnabled,

--- a/src/screens/CheckoutScreen.tsx
+++ b/src/screens/CheckoutScreen.tsx
@@ -42,6 +42,7 @@ import { events } from '@/services/analytics';
 import { PremiumBadge } from '@/components/PremiumBadge';
 import { usePremium } from '@/hooks/usePremium';
 import { useAddressBook } from '@/hooks/useAddressBook';
+import { cancelCartAbandonmentForOrder } from '@/hooks/useCartAbandonmentReminder';
 
 const SHIPPING_THRESHOLD = 499;
 
@@ -350,6 +351,7 @@ export function CheckoutScreen({ onOrderComplete, onBack, testID }: Props) {
     if (order) {
       events.purchase(order.orderId, totals.total, items.length);
       addressBook.saveFromCheckout(shippingAddress);
+      cancelCartAbandonmentForOrder();
       if (Platform.OS !== 'web') {
         Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       }
@@ -382,6 +384,7 @@ export function CheckoutScreen({ onOrderComplete, onBack, testID }: Props) {
 
     if (order) {
       events.purchase(order.orderId, totals.total, items.length);
+      cancelCartAbandonmentForOrder();
       if (Platform.OS !== 'web') {
         Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       }
@@ -404,6 +407,7 @@ export function CheckoutScreen({ onOrderComplete, onBack, testID }: Props) {
 
     if (order) {
       events.purchase(order.orderId, totals.total, items.length);
+      cancelCartAbandonmentForOrder();
       if (Platform.OS !== 'web') {
         Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       }

--- a/src/screens/__tests__/CheckoutScreen.test.tsx
+++ b/src/screens/__tests__/CheckoutScreen.test.tsx
@@ -32,6 +32,12 @@ jest.mock('expo-haptics', () => ({
   NotificationFeedbackType: { Success: 'Success' },
 }));
 
+// Mock cart abandonment
+const mockCancelCartAbandonment = jest.fn().mockResolvedValue(undefined);
+jest.mock('@/hooks/useCartAbandonmentReminder', () => ({
+  cancelCartAbandonmentForOrder: (...args: any[]) => mockCancelCartAbandonment(...args),
+}));
+
 // Mock analytics
 jest.mock('@/services/analytics', () => ({
   events: {
@@ -651,6 +657,31 @@ describe('CheckoutScreen', () => {
         orderId: 'order_123',
         status: 'confirmed',
       });
+    });
+
+    it('cancels cart abandonment notification on successful order', async () => {
+      const utils = renderCheckout({}, seed);
+      fillAndSelectCard(utils);
+
+      await act(async () => {
+        fireEvent.press(utils.getByTestId('place-order-button'));
+      });
+
+      expect(mockCancelCartAbandonment).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not cancel cart abandonment on payment failure', async () => {
+      const { PaymentError } = jest.requireMock('@/services/payment');
+      mockCreatePaymentIntent.mockRejectedValue(new PaymentError('Card declined', 'STRIPE_ERROR'));
+
+      const utils = renderCheckout({}, seed);
+      fillAndSelectCard(utils);
+
+      await act(async () => {
+        fireEvent.press(utils.getByTestId('place-order-button'));
+      });
+
+      expect(mockCancelCartAbandonment).not.toHaveBeenCalled();
     });
 
     it('does not submit when no payment method is selected', async () => {


### PR DESCRIPTION
## Summary
- Export standalone `cancelCartAbandonmentForOrder()` from `useCartAbandonmentReminder` — cancels pending notification and clears throttle state
- Call it from `CheckoutScreen` on all successful order paths (card, Apple Pay, Google Pay)
- Fixes: after completing a purchase, the weekly throttle state is now reset so future cart reminders work correctly

## What was the gap?
The `useCartAbandonmentReminder` hook had `onOrderPlaced()` defined but never called from production code. When a user completed checkout, the abandonment notification was cancelled (via `onCartChanged` with `itemCount=0`), but `lastReminderSentAt` throttle state persisted — suppressing future reminders within the same week.

## Test plan
- [x] 4 new tests for `cancelCartAbandonmentForOrder` standalone function (success, no state, storage error, removeItem error)
- [x] 2 new tests for CheckoutScreen integration (cancels on success, does not cancel on failure)
- [x] All 17 hook tests pass
- [x] All 67 checkout tests pass
- [x] Full suite: 229 suites, 3800 tests pass (0 regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)