### PR TITLE
feat: wire product compare entry points (hq-xdi3)

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,7 @@ import { NotificationProvider } from '@/hooks/useNotifications';
 import { DeepLinkProvider } from '@/hooks/DeepLinkProvider';
 import { PremiumProvider } from '@/hooks/usePremium';
 import { RecommendationsProvider } from '@/hooks/useRecommendations';
+import { CompareProvider } from '@/contexts/CompareContext';
 import { CartAbandonmentBridge } from '@/components/CartAbandonmentBridge';
 import { WixProvider } from '@/services/wix/wixProvider';
 import { getWixConfig, isWixConfigured } from '@/services/wix/config';
@@ -116,6 +117,7 @@ function App() {
                     <CartAbandonmentBridge />
                     <PremiumProvider>
                       <RecommendationsProvider>
+                      <CompareProvider>
                       <ErrorBoundary>
                         <NavigationContainer
                           ref={navigationRef}
@@ -143,6 +145,7 @@ function App() {
                           </DeepLinkProvider>
                         </NavigationContainer>
                       </ErrorBoundary>
+                      </CompareProvider>
                       </RecommendationsProvider>
                     </PremiumProvider>
                   </NotificationProvider>

--- a/src/components/CompareButton.tsx
+++ b/src/components/CompareButton.tsx
@@ -1,0 +1,60 @@
+/**
+ * CompareButton — toggle add/remove product from the shared compare list.
+ */
+import React from 'react';
+import { TouchableOpacity, Text, StyleSheet } from 'react-native';
+import { useCompareContext } from '@/contexts/CompareContext';
+import type { Product } from '@/data/products';
+
+interface CompareButtonProps {
+  product: Product;
+  testID?: string;
+}
+
+export function CompareButton({ product, testID }: CompareButtonProps) {
+  const { addToCompare, removeFromCompare, isInCompare } = useCompareContext();
+  const inList = isInCompare(product.id);
+
+  const handlePress = () => {
+    if (inList) {
+      removeFromCompare(product.id);
+    } else {
+      addToCompare(product);
+    }
+  };
+
+  return (
+    <TouchableOpacity
+      onPress={handlePress}
+      accessibilityRole="button"
+      accessibilityLabel={inList ? 'Remove from compare' : 'Add to compare'}
+      testID={testID}
+      style={[styles.button, inList && styles.active]}
+    >
+      <Text style={[styles.text, inList && styles.activeText]}>
+        {inList ? 'Remove' : 'Compare'}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  button: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#8B7355',
+  },
+  active: {
+    backgroundColor: '#8B7355',
+  },
+  text: {
+    fontSize: 13,
+    color: '#8B7355',
+    fontWeight: '600',
+  },
+  activeText: {
+    color: '#FFF',
+  },
+});

--- a/src/components/CompareFAB.tsx
+++ b/src/components/CompareFAB.tsx
@@ -1,0 +1,80 @@
+/**
+ * CompareFAB — floating action button with badge count.
+ *
+ * Appears when compare list has items. Navigates to CompareScreen on press.
+ */
+import React from 'react';
+import { TouchableOpacity, Text, View, StyleSheet } from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import { useCompareContext } from '@/contexts/CompareContext';
+
+interface CompareFABProps {
+  testID?: string;
+}
+
+export function CompareFAB({ testID }: CompareFABProps) {
+  const { compareList, count } = useCompareContext();
+  const navigation = useNavigation<any>();
+
+  if (count === 0) return null;
+
+  const handlePress = () => {
+    navigation.navigate('Compare', {
+      productSlugs: compareList.map((p) => p.slug),
+    });
+  };
+
+  return (
+    <TouchableOpacity
+      onPress={handlePress}
+      accessibilityRole="button"
+      accessibilityLabel={`Compare ${count} products`}
+      testID={testID}
+      style={styles.fab}
+    >
+      <Text style={styles.icon}>⚖</Text>
+      <View style={styles.badge}>
+        <Text style={styles.badgeText}>{count}</Text>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  fab: {
+    position: 'absolute',
+    bottom: 24,
+    right: 24,
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: '#E8845C',
+    justifyContent: 'center',
+    alignItems: 'center',
+    elevation: 6,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 3 },
+    shadowOpacity: 0.3,
+    shadowRadius: 4,
+  },
+  icon: {
+    fontSize: 24,
+  },
+  badge: {
+    position: 'absolute',
+    top: -4,
+    right: -4,
+    backgroundColor: '#8B7355',
+    borderRadius: 10,
+    minWidth: 20,
+    height: 20,
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 4,
+  },
+  badgeText: {
+    color: '#FFF',
+    fontSize: 12,
+    fontWeight: '700',
+  },
+});

--- a/src/components/__tests__/CompareButton.test.tsx
+++ b/src/components/__tests__/CompareButton.test.tsx
@@ -1,0 +1,59 @@
+/**
+ * Tests for CompareButton — add/remove product from compare list.
+ *
+ * TDD: tests written first, CompareButton does not yet exist.
+ */
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { CompareButton } from '../CompareButton';
+import { CompareProvider } from '@/contexts/CompareContext';
+import { PRODUCTS } from '@/data/products';
+
+const [productA, productB, productC, productD] = PRODUCTS;
+
+function renderWithProvider(ui: React.ReactElement) {
+  return render(<CompareProvider>{ui}</CompareProvider>);
+}
+
+describe('CompareButton', () => {
+  it('renders with "Compare" label when product is not in list', () => {
+    const { getByText } = renderWithProvider(<CompareButton product={productA} />);
+    expect(getByText('Compare')).toBeTruthy();
+  });
+
+  it('renders with "Remove" label when product is in list', () => {
+    const { getByText, rerender } = renderWithProvider(
+      <CompareButton product={productA} />,
+    );
+    fireEvent.press(getByText('Compare'));
+    // After press, should flip to remove state
+    expect(getByText('Remove')).toBeTruthy();
+  });
+
+  it('adds product to compare list on press', () => {
+    const { getByText } = renderWithProvider(<CompareButton product={productA} />);
+    fireEvent.press(getByText('Compare'));
+    // Should now show "Remove" indicating product was added
+    expect(getByText('Remove')).toBeTruthy();
+  });
+
+  it('removes product from compare list when already added', () => {
+    const { getByText } = renderWithProvider(<CompareButton product={productA} />);
+    fireEvent.press(getByText('Compare'));
+    expect(getByText('Remove')).toBeTruthy();
+    fireEvent.press(getByText('Remove'));
+    expect(getByText('Compare')).toBeTruthy();
+  });
+
+  it('has accessible role button', () => {
+    const { getByRole } = renderWithProvider(<CompareButton product={productA} />);
+    expect(getByRole('button')).toBeTruthy();
+  });
+
+  it('uses provided testID', () => {
+    const { getByTestId } = renderWithProvider(
+      <CompareButton product={productA} testID="compare-btn" />,
+    );
+    expect(getByTestId('compare-btn')).toBeTruthy();
+  });
+});

--- a/src/components/__tests__/CompareFAB.test.tsx
+++ b/src/components/__tests__/CompareFAB.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Tests for CompareFAB — floating action button showing compare count + navigating to CompareScreen.
+ *
+ * TDD: tests written first, CompareFAB does not yet exist.
+ */
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { CompareFAB } from '../CompareFAB';
+import { CompareProvider, useCompareContext } from '@/contexts/CompareContext';
+import { PRODUCTS } from '@/data/products';
+
+const [productA, productB] = PRODUCTS;
+
+const mockNavigate = jest.fn();
+jest.mock('@react-navigation/native', () => ({
+  useNavigation: () => ({ navigate: mockNavigate }),
+}));
+
+/** Helper to pre-populate the compare list. */
+function Seed({ products }: { products: typeof PRODUCTS }) {
+  const { addToCompare } = useCompareContext();
+  React.useEffect(() => {
+    products.forEach((p) => addToCompare(p));
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  return null;
+}
+
+function renderWithProvider(ui: React.ReactElement, seedProducts: typeof PRODUCTS = []) {
+  return render(
+    <CompareProvider>
+      {seedProducts.length > 0 && <Seed products={seedProducts} />}
+      {ui}
+    </CompareProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockNavigate.mockClear();
+});
+
+describe('CompareFAB', () => {
+  it('does not render when compare list is empty', () => {
+    const { queryByTestId } = renderWithProvider(<CompareFAB testID="compare-fab" />);
+    expect(queryByTestId('compare-fab')).toBeNull();
+  });
+
+  it('renders when compare list has items', () => {
+    const { getByTestId } = renderWithProvider(
+      <CompareFAB testID="compare-fab" />,
+      [productA],
+    );
+    expect(getByTestId('compare-fab')).toBeTruthy();
+  });
+
+  it('displays the compare count as badge text', () => {
+    const { getByText } = renderWithProvider(
+      <CompareFAB testID="compare-fab" />,
+      [productA, productB],
+    );
+    expect(getByText('2')).toBeTruthy();
+  });
+
+  it('navigates to Compare screen with product slugs on press', () => {
+    const { getByTestId } = renderWithProvider(
+      <CompareFAB testID="compare-fab" />,
+      [productA, productB],
+    );
+    fireEvent.press(getByTestId('compare-fab'));
+    expect(mockNavigate).toHaveBeenCalledWith('Compare', {
+      productSlugs: [productA.slug, productB.slug],
+    });
+  });
+
+  it('has accessible label indicating compare action', () => {
+    const { getByLabelText } = renderWithProvider(
+      <CompareFAB testID="compare-fab" />,
+      [productA],
+    );
+    expect(getByLabelText(/compare/i)).toBeTruthy();
+  });
+});

--- a/src/contexts/CompareContext.tsx
+++ b/src/contexts/CompareContext.tsx
@@ -1,0 +1,23 @@
+/**
+ * CompareContext — shared compare-list state across screens.
+ *
+ * Wraps the useCompare hook in a React Context so that ProductDetailScreen,
+ * ShopScreen, and CompareFAB can all read/write the same compare list.
+ */
+import React, { createContext, useContext } from 'react';
+import { useCompare, type UseCompareReturn } from '@/hooks/useCompare';
+
+const CompareContext = createContext<UseCompareReturn | null>(null);
+
+export function CompareProvider({ children }: { children: React.ReactNode }) {
+  const compare = useCompare();
+  return <CompareContext.Provider value={compare}>{children}</CompareContext.Provider>;
+}
+
+export function useCompareContext(): UseCompareReturn {
+  const ctx = useContext(CompareContext);
+  if (!ctx) {
+    throw new Error('useCompareContext must be used within a CompareProvider');
+  }
+  return ctx;
+}

--- a/src/contexts/__tests__/CompareContext.test.tsx
+++ b/src/contexts/__tests__/CompareContext.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Tests for CompareProvider context — shared compare state across screens.
+ *
+ * TDD: tests written first, CompareProvider does not yet exist.
+ */
+import React from 'react';
+import { renderHook, act } from '@testing-library/react-native';
+import { CompareProvider, useCompareContext } from '../CompareContext';
+import { PRODUCTS } from '@/data/products';
+
+const [productA, productB, productC, productD] = PRODUCTS;
+
+function wrapper({ children }: { children: React.ReactNode }) {
+  return <CompareProvider>{children}</CompareProvider>;
+}
+
+describe('CompareProvider', () => {
+  it('provides an empty compare list by default', () => {
+    const { result } = renderHook(() => useCompareContext(), { wrapper });
+    expect(result.current.compareList).toEqual([]);
+    expect(result.current.count).toBe(0);
+    expect(result.current.isFull).toBe(false);
+  });
+
+  it('adds a product to the compare list', () => {
+    const { result } = renderHook(() => useCompareContext(), { wrapper });
+    act(() => {
+      result.current.addToCompare(productA);
+    });
+    expect(result.current.compareList).toEqual([productA]);
+    expect(result.current.count).toBe(1);
+  });
+
+  it('prevents duplicate products', () => {
+    const { result } = renderHook(() => useCompareContext(), { wrapper });
+    act(() => {
+      result.current.addToCompare(productA);
+      result.current.addToCompare(productA);
+    });
+    expect(result.current.count).toBe(1);
+  });
+
+  it('caps at 3 items', () => {
+    const { result } = renderHook(() => useCompareContext(), { wrapper });
+    act(() => {
+      result.current.addToCompare(productA);
+      result.current.addToCompare(productB);
+      result.current.addToCompare(productC);
+    });
+    expect(result.current.isFull).toBe(true);
+    act(() => {
+      result.current.addToCompare(productD);
+    });
+    expect(result.current.count).toBe(3);
+  });
+
+  it('removes a product by id', () => {
+    const { result } = renderHook(() => useCompareContext(), { wrapper });
+    act(() => {
+      result.current.addToCompare(productA);
+      result.current.addToCompare(productB);
+    });
+    act(() => {
+      result.current.removeFromCompare(productA.id);
+    });
+    expect(result.current.compareList).toEqual([productB]);
+  });
+
+  it('clears all products', () => {
+    const { result } = renderHook(() => useCompareContext(), { wrapper });
+    act(() => {
+      result.current.addToCompare(productA);
+      result.current.addToCompare(productB);
+    });
+    act(() => {
+      result.current.clearCompare();
+    });
+    expect(result.current.compareList).toEqual([]);
+    expect(result.current.count).toBe(0);
+  });
+
+  it('isInCompare returns correct boolean', () => {
+    const { result } = renderHook(() => useCompareContext(), { wrapper });
+    act(() => {
+      result.current.addToCompare(productA);
+    });
+    expect(result.current.isInCompare(productA.id)).toBe(true);
+    expect(result.current.isInCompare(productB.id)).toBe(false);
+  });
+
+  it('shares state between multiple consumers', () => {
+    const { result: consumer1 } = renderHook(() => useCompareContext(), { wrapper });
+    // Note: In a real tree both consumers share the same Provider.
+    // With renderHook, each gets its own wrapper instance.
+    // This test validates the API shape — integration tests cover shared state.
+    act(() => {
+      consumer1.current.addToCompare(productA);
+    });
+    expect(consumer1.current.count).toBe(1);
+  });
+
+  it('throws when used outside provider', () => {
+    // Suppress React error boundary noise
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    expect(() => {
+      renderHook(() => useCompareContext());
+    }).toThrow(/CompareProvider/);
+    spy.mockRestore();
+  });
+});

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -6,7 +6,7 @@
  * AnimatedTabBar for spring-press feedback.
  */
 import React from 'react';
-import { Text } from 'react-native';
+import { Text, View, StyleSheet } from 'react-native';
 import { createBottomTabNavigator } from '@react-navigation/bottom-tabs';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
@@ -16,6 +16,7 @@ import { HomeScreen } from '@/screens/HomeScreen';
 import { ShopScreen } from '@/screens/ShopScreen';
 import { CartScreen } from '@/screens/CartScreen';
 import { AccountScreen } from '@/screens/AccountScreen';
+import { CompareFAB } from '@/components/CompareFAB';
 import { AnimatedTabBar } from './AnimatedTabBar';
 import type { RootStackParamList } from './AppNavigator';
 
@@ -57,53 +58,62 @@ export function TabNavigator() {
   const { itemCount } = useCart();
 
   return (
-    <Tab.Navigator
-      tabBar={(props) => <AnimatedTabBar {...props} />}
-      screenOptions={{
-        headerShown: false,
-        tabBarActiveTintColor: colors.sunsetCoral,
-        tabBarInactiveTintColor: colors.espressoLight,
-      }}
-    >
-      <Tab.Screen
-        name="Home"
-        component={HomeScreen}
-        options={{
-          tabBarIcon: ({ focused, color }) => (
-            <TabIcon label="Home" focused={focused} color={color} />
-          ),
-        }}
-      />
-      <Tab.Screen
-        name="Shop"
-        component={ShopScreen}
-        options={{
-          tabBarIcon: ({ focused, color }) => (
-            <TabIcon label="Shop" focused={focused} color={color} />
-          ),
-        }}
-      />
-      <Tab.Screen
-        name="Cart"
-        component={CartScreen}
-        options={{
-          tabBarIcon: ({ focused, color }) => (
-            <TabIcon label="Cart" focused={focused} color={color} />
-          ),
-          tabBarBadge: itemCount > 0 ? itemCount : undefined,
-          tabBarBadgeStyle: { backgroundColor: colors.sunsetCoral },
-        }}
-      />
-      <Tab.Screen
-        name="Account"
-        options={{
-          tabBarIcon: ({ focused, color }) => (
-            <TabIcon label="Account" focused={focused} color={color} />
-          ),
+    <View style={tabStyles.container}>
+      <Tab.Navigator
+        tabBar={(props) => <AnimatedTabBar {...props} />}
+        screenOptions={{
+          headerShown: false,
+          tabBarActiveTintColor: colors.sunsetCoral,
+          tabBarInactiveTintColor: colors.espressoLight,
         }}
       >
-        {() => <AccountScreenWithNav />}
-      </Tab.Screen>
-    </Tab.Navigator>
+        <Tab.Screen
+          name="Home"
+          component={HomeScreen}
+          options={{
+            tabBarIcon: ({ focused, color }) => (
+              <TabIcon label="Home" focused={focused} color={color} />
+            ),
+          }}
+        />
+        <Tab.Screen
+          name="Shop"
+          component={ShopScreen}
+          options={{
+            tabBarIcon: ({ focused, color }) => (
+              <TabIcon label="Shop" focused={focused} color={color} />
+            ),
+          }}
+        />
+        <Tab.Screen
+          name="Cart"
+          component={CartScreen}
+          options={{
+            tabBarIcon: ({ focused, color }) => (
+              <TabIcon label="Cart" focused={focused} color={color} />
+            ),
+            tabBarBadge: itemCount > 0 ? itemCount : undefined,
+            tabBarBadgeStyle: { backgroundColor: colors.sunsetCoral },
+          }}
+        />
+        <Tab.Screen
+          name="Account"
+          options={{
+            tabBarIcon: ({ focused, color }) => (
+              <TabIcon label="Account" focused={focused} color={color} />
+            ),
+          }}
+        >
+          {() => <AccountScreenWithNav />}
+        </Tab.Screen>
+      </Tab.Navigator>
+      <CompareFAB testID="compare-fab" />
+    </View>
   );
 }
+
+const tabStyles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/src/navigation/__tests__/Navigation.test.tsx
+++ b/src/navigation/__tests__/Navigation.test.tsx
@@ -64,6 +64,10 @@ const mockCartState = {
   updateQuantity: jest.fn(),
   clearCart: jest.fn(),
 };
+jest.mock('@/components/CompareFAB', () => ({
+  CompareFAB: () => null,
+}));
+
 jest.mock('@/hooks/useCart', () => ({
   useCart: () => mockCartState,
 }));

--- a/src/screens/ProductDetailScreen.tsx
+++ b/src/screens/ProductDetailScreen.tsx
@@ -39,6 +39,7 @@ import { MountainSkyline } from '@/components/MountainSkyline';
 import { formatPrice, openARViewer, inchesToFeetDisplay } from '@/utils';
 import { type FutonModel, type Fabric } from '@/hooks/useFutonModels';
 import { WishlistButton } from '@/components/WishlistButton';
+import { CompareButton } from '@/components/CompareButton';
 import { useFutonModels } from '@/hooks/useFutonModels';
 import { useProduct } from '@/hooks/useProduct';
 import { ReviewCard } from '@/components/ReviewCard';
@@ -371,10 +372,13 @@ export function ProductDetailScreen({
         </TouchableOpacity>
       </Animated.View>
 
-      {/* Floating wishlist button — above scroll */}
+      {/* Floating wishlist + compare buttons — above scroll */}
       {catalogProduct && (
         <Animated.View style={[styles.floatingWishlistButton, floatingButtonBgStyle]}>
           <WishlistButton product={catalogProduct} size="lg" testID="detail-wishlist-button" />
+          <View style={styles.compareButtonSpacer}>
+            <CompareButton product={catalogProduct} testID="detail-compare-button" />
+          </View>
         </Animated.View>
       )}
 
@@ -1346,6 +1350,10 @@ const styles = StyleSheet.create({
     top: 52,
     right: 16,
     zIndex: 20,
+    alignItems: 'flex-end',
+  },
+  compareButtonSpacer: {
+    marginTop: 8,
   },
   backButton: {
     width: 36,

--- a/src/screens/__tests__/ProductDetailScreen.test.tsx
+++ b/src/screens/__tests__/ProductDetailScreen.test.tsx
@@ -4,6 +4,7 @@ import { Platform, Dimensions } from 'react-native';
 import { ProductDetailScreen } from '../ProductDetailScreen';
 import { ThemeProvider } from '@/theme/ThemeProvider';
 import { WishlistProvider } from '@/hooks/useWishlist';
+import { CompareProvider } from '@/contexts/CompareContext';
 import { FUTON_MODELS, FABRICS } from '@/data/futons';
 import { PRODUCTS } from '@/data/products';
 
@@ -80,9 +81,11 @@ const mountainBlue = FABRICS.find((f) => f.id === 'mountain-blue')!; // $29
 function renderDetail(props: Partial<React.ComponentProps<typeof ProductDetailScreen>> = {}) {
   return render(
     <ThemeProvider>
-      <WishlistProvider>
-        <ProductDetailScreen {...props} />
-      </WishlistProvider>
+      <CompareProvider>
+        <WishlistProvider>
+          <ProductDetailScreen {...props} />
+        </WishlistProvider>
+      </CompareProvider>
     </ThemeProvider>,
   );
 }


### PR DESCRIPTION
## Summary
- **CompareProvider** context wraps `useCompare` hook for cross-screen shared state
- **CompareButton** on `ProductDetailScreen` (next to wishlist) — toggle add/remove from compare list
- **CompareFAB** floating action button on tab navigator with badge count, navigates to `CompareScreen`
- CompareScreen already existed with full comparison table (price, rating, dimensions, fabrics, stock)

## Test plan
- [x] 9 CompareProvider context tests
- [x] 6 CompareButton tests
- [x] 5 CompareFAB tests
- [x] All 3892+ existing tests pass (233 suites)

🤖 Generated with [Claude Code](https://claude.com/claude-code)