### PR TITLE
test: WixProductDetail component tests (38 cases)

### DIFF
--- a/src/components/__tests__/WixProductDetail.test.tsx
+++ b/src/components/__tests__/WixProductDetail.test.tsx
@@ -8,7 +8,7 @@
  */
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
-import { Share, Platform } from 'react-native';
+import { Share } from 'react-native';
 import { WixProductDetail } from '../WixProductDetail';
 import { ThemeProvider } from '@/theme/ThemeProvider';
 import { WishlistProvider } from '@/hooks/useWishlist';
@@ -83,9 +83,7 @@ describe('WixProductDetail', () => {
 
     it('displays product description', () => {
       const { getByTestId } = renderComponent();
-      expect(getByTestId('product-description').props.children).toContain(
-        'handcrafted futon',
-      );
+      expect(getByTestId('product-description').props.children).toContain('handcrafted futon');
     });
 
     it('omits tagline when shortDescription is empty', () => {
@@ -185,7 +183,7 @@ describe('WixProductDetail', () => {
 
   describe('Fullscreen modal', () => {
     it('opens fullscreen modal when gallery slide is pressed', () => {
-      const { getByTestId, queryByTestId } = renderComponent();
+      const { getByTestId } = renderComponent();
       fireEvent.press(getByTestId('gallery-slide-0'));
       // ImageGalleryModal should become visible
       // The modal renders with testID from ImageGalleryModal — check it appears


### PR DESCRIPTION
## Summary
- 38 tests for WixProductDetail component (hq-6g4fi)
- Covers: gallery rendering, pagination dots, fullscreen modal, share/wishlist buttons, price display (with discount, call for price), stock badge, fabric options, category badge, skeleton loading, empty images fallback, back button, accessibility
- Author: ripley (cherry-picked from cm-wix-product-detail branch)

## Test plan
- [x] All 38 tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)