### PR TITLE
test: useProductBySlug hook tests (31 cases)

### DIFF
--- a/src/hooks/__tests__/useProductBySlug.test.ts
+++ b/src/hooks/__tests__/useProductBySlug.test.ts
@@ -258,9 +258,7 @@ describe('useProductBySlug', () => {
       const firstPromise = new Promise<Product | null>((resolve) => {
         firstResolve = resolve;
       });
-      mockGetProductBySlug
-        .mockReturnValueOnce(firstPromise)
-        .mockResolvedValueOnce(wixOnlyProduct);
+      mockGetProductBySlug.mockReturnValueOnce(firstPromise).mockResolvedValueOnce(wixOnlyProduct);
 
       const { result, rerender } = renderHook(
         ({ slug }: { slug: string }) => useProductBySlug(slug),


### PR DESCRIPTION
## Summary
- 31 tests for useProductBySlug hook (hq-2qez4)
- Covers: static PRODUCTS match, empty slug, unknown slug without Wix, Wix API fetch, error handling (Error + non-Error), abort controller cleanup (unmount + slug change), refresh, loading state transitions, slug change behavior
- Author: hicks (cherry-picked onto main for clean diff)
- Supersedes #104

## Test plan
- [x] All 31 tests pass locally
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)