### PR TITLE
feat: add request timeout to Wix API client (cm-08o)

### DIFF
--- a/src/services/wix/__tests__/wixClientTimeout.test.ts
+++ b/src/services/wix/__tests__/wixClientTimeout.test.ts
@@ -1,0 +1,143 @@
+import { WixClient, type WixClientConfig, WixApiError } from '../wixClient';
+
+// --- Mock fetch globally ---
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const TEST_CONFIG: WixClientConfig = {
+  apiKey: 'test-api-key-12345',
+  siteId: 'test-site-id-67890',
+};
+
+afterEach(() => {
+  mockFetch.mockReset();
+});
+
+describe('WixClient request timeout', () => {
+  it('aborts request after default timeout (10s)', async () => {
+    // Mock fetch that rejects when signal is aborted
+    mockFetch.mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            reject(new DOMException('The operation was aborted.', 'AbortError'));
+          });
+        }),
+    );
+
+    // Use a very short timeout to avoid slow tests
+    const client = new WixClient({ ...TEST_CONFIG, timeoutMs: 50 });
+    await expect(client.queryProducts({})).rejects.toThrow(/timeout/i);
+  }, 10_000);
+
+  it('succeeds when response arrives before timeout', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ products: [], totalResults: 0 }),
+    });
+
+    const client = new WixClient(TEST_CONFIG);
+    const result = await client.queryProducts({});
+    expect(result).toBeDefined();
+  });
+
+  it('passes AbortSignal to fetch', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ products: [], totalResults: 0 }),
+    });
+
+    const client = new WixClient(TEST_CONFIG);
+    await client.queryProducts({});
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        signal: expect.any(AbortSignal),
+      }),
+    );
+  });
+
+  it('wraps abort error as WixApiError with timeout message', async () => {
+    mockFetch.mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          init.signal?.addEventListener('abort', () => {
+            reject(new DOMException('The operation was aborted.', 'AbortError'));
+          });
+        }),
+    );
+
+    const client = new WixClient({ ...TEST_CONFIG, timeoutMs: 50 });
+
+    try {
+      await client.queryProducts({});
+      fail('Expected WixApiError');
+    } catch (err) {
+      expect(err).toBeInstanceOf(WixApiError);
+      expect((err as WixApiError).message).toMatch(/timeout/i);
+    }
+  }, 10_000);
+
+  it('allows custom timeout via config', async () => {
+    const callTimes: number[] = [];
+
+    mockFetch.mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          callTimes.push(Date.now());
+          init.signal?.addEventListener('abort', () => {
+            reject(new DOMException('The operation was aborted.', 'AbortError'));
+          });
+        }),
+    );
+
+    // 100ms should time out quickly
+    const client = new WixClient({ ...TEST_CONFIG, timeoutMs: 100 });
+    const start = Date.now();
+
+    await expect(client.queryProducts({})).rejects.toThrow(/timeout/i);
+
+    const elapsed = Date.now() - start;
+    // Should timeout around 100ms, not 10s
+    expect(elapsed).toBeLessThan(2_000);
+  }, 10_000);
+
+  it('does not retry timeout errors', async () => {
+    let fetchCallCount = 0;
+
+    mockFetch.mockImplementation(
+      (_url: string, init: RequestInit) =>
+        new Promise((_resolve, reject) => {
+          fetchCallCount++;
+          init.signal?.addEventListener('abort', () => {
+            reject(new DOMException('The operation was aborted.', 'AbortError'));
+          });
+        }),
+    );
+
+    const client = new WixClient({ ...TEST_CONFIG, timeoutMs: 50 });
+    await expect(client.queryProducts({})).rejects.toThrow(/timeout/i);
+
+    // Should only be called once — no retries for timeouts
+    expect(fetchCallCount).toBe(1);
+  }, 10_000);
+
+  it('cleans up timer on successful response', async () => {
+    const clearTimeoutSpy = jest.spyOn(global, 'clearTimeout');
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ products: [], totalResults: 0 }),
+    });
+
+    const client = new WixClient(TEST_CONFIG);
+    await client.queryProducts({});
+
+    expect(clearTimeoutSpy).toHaveBeenCalled();
+    clearTimeoutSpy.mockRestore();
+  });
+});

--- a/src/services/wix/wixClient.ts
+++ b/src/services/wix/wixClient.ts
@@ -27,7 +27,10 @@ export interface WixClientConfig {
   apiKey: string;
   siteId: string;
   baseUrl?: string;
+  timeoutMs?: number;
 }
+
+const DEFAULT_TIMEOUT_MS = 10_000;
 
 const DEFAULT_BASE_URL = 'https://www.wixapis.com';
 
@@ -329,11 +332,13 @@ export class WixClient {
   readonly baseUrl: string;
   private readonly apiKey: string;
   private readonly siteId: string;
+  private readonly timeoutMs: number;
 
   constructor(config: WixClientConfig) {
     this.apiKey = config.apiKey;
     this.siteId = config.siteId;
     this.baseUrl = config.baseUrl ?? DEFAULT_BASE_URL;
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   }
 
   // ── Products ───────────────────────────────────────────────
@@ -940,19 +945,31 @@ export class WixClient {
 
   private async rawRequest<T>(path: string, method: string, body?: unknown): Promise<T> {
     const url = `${this.baseUrl}${path}`;
+    const controller = new AbortController();
+    const timer = setTimeout(() => controller.abort(), this.timeoutMs);
     let response: Response;
     try {
       response = await fetch(url, {
         method,
         headers: this.headers(),
+        signal: controller.signal,
         ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
       });
     } catch (err) {
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        throw new WixApiError(
+          `Request timeout after ${this.timeoutMs}ms`,
+          undefined,
+          path,
+        );
+      }
       throw new WixApiError(
         `Network error: ${err instanceof Error ? err.message : String(err)}`,
         undefined,
         path,
       );
+    } finally {
+      clearTimeout(timer);
     }
 
     if (!response.ok) {
@@ -972,6 +989,8 @@ export class WixClient {
 
 function isRetryableError(err: Error): boolean {
   if (err instanceof WixApiError) {
+    // Don't retry timeouts — the server is unresponsive, retrying wastes time
+    if (err.message.startsWith('Request timeout')) return false;
     // Don't retry client errors (4xx) — they won't resolve with retry
     if (err.statusCode && err.statusCode >= 400 && err.statusCode < 500) {
       return false;


### PR DESCRIPTION
## Summary
- Add `AbortController`-based request timeout (default 10s) to `WixClient.rawRequest()`
- Configurable via new `timeoutMs` option in `WixClientConfig`
- Timeout errors are wrapped as `WixApiError` and excluded from retry policy for fast failure
- Timer cleanup in `finally` block prevents leaks

## Test plan
- [x] 7 new tests in `wixClientTimeout.test.ts` — all pass
- [x] Existing 546 `wixClient.test.ts` tests — all pass
- [x] Existing 72 `retry.test.ts` tests — all pass
- [ ] Manual: verify timeout fires on slow network (throttle in dev tools)

🤖 Generated with [Claude Code](https://claude.com/claude-code)