### PR TITLE
feat(wix): activate Wix backend — mock to production (cm-khm)

### DIFF
--- a/eas.json
+++ b/eas.json
@@ -16,7 +16,9 @@
       "channel": "preview",
       "env": {
         "SENTRY_DISABLE_AUTO_UPLOAD": "true",
-        "EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY": "pk_test_placeholder_for_sandbox_testing"
+        "EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY": "pk_test_placeholder_for_sandbox_testing",
+        "EXPO_PUBLIC_WIX_SITE_ID": "3af610bf-06fb-410d-a406-c1258fa84372",
+        "EXPO_PUBLIC_WIX_API_KEY": "${EXPO_PUBLIC_WIX_API_KEY}"
       },
       "ios": {
         "simulator": false
@@ -30,7 +32,9 @@
       "channel": "preview",
       "env": {
         "SENTRY_DISABLE_AUTO_UPLOAD": "true",
-        "EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY": "pk_test_placeholder_for_sandbox_testing"
+        "EXPO_PUBLIC_STRIPE_PUBLISHABLE_KEY": "pk_test_placeholder_for_sandbox_testing",
+        "EXPO_PUBLIC_WIX_SITE_ID": "3af610bf-06fb-410d-a406-c1258fa84372",
+        "EXPO_PUBLIC_WIX_API_KEY": "${EXPO_PUBLIC_WIX_API_KEY}"
       },
       "ios": {
         "simulator": true

--- a/src/services/__tests__/prefetchWix.test.ts
+++ b/src/services/__tests__/prefetchWix.test.ts
@@ -1,0 +1,164 @@
+/**
+ * Tests for Wix-aware prefetch (mock → production path).
+ *
+ * Verifies that prefetchCriticalData:
+ * - Uses WixClient API when configured
+ * - Falls back to static mock data when not configured
+ * - Handles Wix API failures gracefully (non-fatal)
+ * - Respects the dedupe/one-shot semantics
+ */
+
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import {
+  prefetchCriticalData,
+  getPrefetchStatus,
+  resetPrefetchState,
+  PREFETCH_CACHE_KEY,
+  PREFETCH_COLLECTIONS_KEY,
+} from '../prefetch';
+import { PRODUCTS } from '@/data/products';
+import { COLLECTIONS } from '@/data/collections';
+
+// ── Mocks ────────────────────────────────────────────────────
+
+const mockQueryProducts = jest.fn();
+const mockQueryCollections = jest.fn();
+
+let mockConfigured = false;
+
+jest.mock('../wix/wixClientSingleton', () => ({
+  getWixClientSingleton: () =>
+    mockConfigured
+      ? { queryProducts: mockQueryProducts, queryCollections: mockQueryCollections }
+      : null,
+}));
+
+jest.mock('../wix/config', () => ({
+  isWixConfigured: () => mockConfigured,
+  getWixConfig: () => ({ apiKey: 'k', siteId: 's' }),
+}));
+
+const mockCaptureException = jest.fn();
+jest.mock('../crashReporting', () => ({
+  captureException: (...args: unknown[]) => mockCaptureException(...args),
+}));
+
+// ── Setup ────────────────────────────────────────────────────
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  resetPrefetchState();
+  (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+  mockConfigured = false;
+});
+
+// ── Tests ────────────────────────────────────────────────────
+
+describe('prefetchCriticalData — mock fallback', () => {
+  it('uses static PRODUCTS when Wix is not configured', async () => {
+    mockConfigured = false;
+    await prefetchCriticalData();
+
+    expect(getPrefetchStatus()).toBe('complete');
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      PREFETCH_CACHE_KEY,
+      expect.stringContaining(JSON.stringify(PRODUCTS).slice(0, 40)),
+    );
+  });
+
+  it('uses static COLLECTIONS when Wix is not configured', async () => {
+    mockConfigured = false;
+    await prefetchCriticalData();
+
+    expect(AsyncStorage.setItem).toHaveBeenCalledWith(
+      PREFETCH_COLLECTIONS_KEY,
+      expect.stringContaining(JSON.stringify(COLLECTIONS).slice(0, 40)),
+    );
+  });
+});
+
+describe('prefetchCriticalData — Wix API', () => {
+  const wixProducts = [
+    {
+      id: 'wix-p1',
+      name: 'Gemini Futon',
+      slug: 'gemini-futon',
+      price: 599,
+      images: [],
+      inStock: true,
+    },
+  ];
+  const wixCollections = [{ id: 'col-1', name: 'Futons', slug: 'futons', productCount: 10 }];
+
+  beforeEach(() => {
+    mockConfigured = true;
+    mockQueryProducts.mockResolvedValue({ products: wixProducts, totalResults: 1 });
+    mockQueryCollections.mockResolvedValue({ collections: wixCollections, totalResults: 1 });
+  });
+
+  it('fetches products from Wix API when configured', async () => {
+    await prefetchCriticalData();
+
+    expect(getPrefetchStatus()).toBe('complete');
+    expect(mockQueryProducts).toHaveBeenCalledWith({ limit: 100 });
+
+    const storedCall = (AsyncStorage.setItem as jest.Mock).mock.calls.find(
+      (c: unknown[]) => c[0] === PREFETCH_CACHE_KEY,
+    );
+    expect(storedCall).toBeDefined();
+    const parsed = JSON.parse(storedCall![1]);
+    expect(parsed.data).toEqual(wixProducts);
+  });
+
+  it('fetches collections from Wix API when configured', async () => {
+    await prefetchCriticalData();
+
+    expect(mockQueryCollections).toHaveBeenCalledWith({ limit: 100 });
+
+    const storedCall = (AsyncStorage.setItem as jest.Mock).mock.calls.find(
+      (c: unknown[]) => c[0] === PREFETCH_COLLECTIONS_KEY,
+    );
+    expect(storedCall).toBeDefined();
+    const parsed = JSON.parse(storedCall![1]);
+    expect(parsed.data).toEqual(wixCollections);
+  });
+
+  it('falls back to mock data when Wix API call fails', async () => {
+    mockQueryProducts.mockRejectedValue(new Error('Network error'));
+    mockQueryCollections.mockRejectedValue(new Error('Network error'));
+
+    await prefetchCriticalData();
+
+    // Should still complete with fallback data — not error status
+    expect(getPrefetchStatus()).toBe('complete');
+    expect(mockCaptureException).not.toHaveBeenCalled();
+
+    // Should have stored mock products as fallback
+    const storedCall = (AsyncStorage.setItem as jest.Mock).mock.calls.find(
+      (c: unknown[]) => c[0] === PREFETCH_CACHE_KEY,
+    );
+    const parsed = JSON.parse(storedCall![1]);
+    expect(parsed.data).toEqual(PRODUCTS);
+  });
+
+  it('deduplicates concurrent calls', async () => {
+    const p1 = prefetchCriticalData();
+    const p2 = prefetchCriticalData();
+    await Promise.all([p1, p2]);
+
+    // queryProducts should only be called once
+    expect(mockQueryProducts).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('prefetchCriticalData — AsyncStorage failure', () => {
+  it('captures exception when storage write fails', async () => {
+    mockConfigured = false;
+    (AsyncStorage.setItem as jest.Mock).mockRejectedValue(new Error('Storage full'));
+
+    await prefetchCriticalData();
+
+    expect(getPrefetchStatus()).toBe('error');
+    expect(mockCaptureException).toHaveBeenCalled();
+  });
+});

--- a/src/services/prefetch.ts
+++ b/src/services/prefetch.ts
@@ -12,6 +12,7 @@ import AsyncStorage from '@react-native-async-storage/async-storage';
 import { PRODUCTS } from '@/data/products';
 import { COLLECTIONS } from '@/data/collections';
 import { captureException } from '@/services/crashReporting';
+import { getWixClientSingleton } from '@/services/wix/wixClientSingleton';
 
 /** Must match the keys used by useDataCache('products', ...) and useDataCache('editorial-collections', ...) */
 export const PREFETCH_CACHE_KEY = '@cfutons/cache/products';
@@ -49,18 +50,35 @@ export function prefetchCriticalData(): Promise<void> {
   inflightPromise = (async () => {
     try {
       const now = Date.now();
+      const wix = getWixClientSingleton();
 
-      // Prefetch products and collections in parallel.
-      // In mock mode, data is available synchronously.
-      // When Wix is wired up, these would become API calls.
+      let products: unknown = PRODUCTS;
+      let collections: unknown = COLLECTIONS;
+
+      if (wix) {
+        // Wix configured — fetch live data, fall back to mock on failure
+        try {
+          const [prodResult, colResult] = await Promise.all([
+            wix.queryProducts({ limit: 100 }),
+            wix.queryCollections({ limit: 100 }),
+          ]);
+          products = prodResult.products;
+          collections = colResult.collections;
+        } catch {
+          // Non-fatal: fall back to static mock data
+          products = PRODUCTS;
+          collections = COLLECTIONS;
+        }
+      }
+
       await Promise.all([
         AsyncStorage.setItem(
           PREFETCH_CACHE_KEY,
-          JSON.stringify({ data: PRODUCTS, timestamp: now }),
+          JSON.stringify({ data: products, timestamp: now }),
         ),
         AsyncStorage.setItem(
           PREFETCH_COLLECTIONS_KEY,
-          JSON.stringify({ data: COLLECTIONS, timestamp: now }),
+          JSON.stringify({ data: collections, timestamp: now }),
         ),
       ]);
 

--- a/src/services/wix/__tests__/wixClientSingleton.test.ts
+++ b/src/services/wix/__tests__/wixClientSingleton.test.ts
@@ -1,0 +1,45 @@
+import { getWixClientSingleton, resetWixClientSingleton } from '../wixClientSingleton';
+import { WixClient } from '../wixClient';
+
+// Control isWixConfigured and getWixConfig from tests
+let mockConfigured = true;
+jest.mock('../config', () => ({
+  isWixConfigured: () => mockConfigured,
+  getWixConfig: () => ({
+    apiKey: 'test-api-key',
+    siteId: 'test-site-id',
+    baseUrl: 'https://www.wixapis.com',
+  }),
+}));
+
+beforeEach(() => {
+  mockConfigured = true;
+  resetWixClientSingleton();
+});
+
+describe('getWixClientSingleton', () => {
+  it('returns a WixClient when configured', () => {
+    const client = getWixClientSingleton();
+    expect(client).toBeInstanceOf(WixClient);
+  });
+
+  it('returns null when not configured', () => {
+    mockConfigured = false;
+    const client = getWixClientSingleton();
+    expect(client).toBeNull();
+  });
+
+  it('returns the same instance on repeated calls', () => {
+    const a = getWixClientSingleton();
+    const b = getWixClientSingleton();
+    expect(a).toBe(b);
+  });
+
+  it('creates a new instance after reset', () => {
+    const a = getWixClientSingleton();
+    resetWixClientSingleton();
+    const b = getWixClientSingleton();
+    expect(a).not.toBe(b);
+    expect(b).toBeInstanceOf(WixClient);
+  });
+});

--- a/src/services/wix/index.ts
+++ b/src/services/wix/index.ts
@@ -39,6 +39,8 @@ export {
 
 export { getWixConfig, isWixConfigured } from './config';
 
+export { getWixClientSingleton, resetWixClientSingleton } from './wixClientSingleton';
+
 export { getWixSdkClient, resetWixSdkClient } from './wixSdkClient';
 
 export { WixAuthService, type AuthResult, type AuthUser } from './wixAuth';

--- a/src/services/wix/wixClientSingleton.ts
+++ b/src/services/wix/wixClientSingleton.ts
@@ -1,0 +1,32 @@
+/**
+ * Singleton accessor for WixClient.
+ *
+ * Module-level code (like prefetchCriticalData) runs outside the React tree
+ * and cannot call useWixClient(). This module provides a shared WixClient
+ * instance that is lazily created from environment variables.
+ *
+ * The React WixProvider creates its own instance — this singleton is only
+ * for non-React code paths (prefetch, background sync, etc.).
+ */
+
+import { WixClient } from './wixClient';
+import { getWixConfig, isWixConfigured } from './config';
+
+let instance: WixClient | null = null;
+
+/**
+ * Returns a shared WixClient configured from EXPO_PUBLIC_WIX_* env vars.
+ * Returns null if Wix is not configured (missing API key or site ID).
+ * The instance is lazily created on first call and reused thereafter.
+ */
+export function getWixClientSingleton(): WixClient | null {
+  if (instance) return instance;
+  if (!isWixConfigured()) return null;
+  instance = new WixClient(getWixConfig());
+  return instance;
+}
+
+/** Reset the singleton (for tests). */
+export function resetWixClientSingleton(): void {
+  instance = null;
+}


### PR DESCRIPTION
## Summary
- **WixClient singleton** (`wixClientSingleton.ts`) for non-React code paths (prefetch, background sync) — lazily created from env vars
- **Wix-aware prefetch** — `prefetchCriticalData()` now queries Wix REST API when configured, with graceful fallback to static mock data on API failure
- **EAS build config** — Wix site ID + API key added to preview/simulator profiles (API key via EAS secret)
- **11 new tests** (4 singleton + 7 prefetch), all 4000+ existing tests pass

## Test plan
- [x] `wixClientSingleton.test.ts` — 4 cases: configured, unconfigured, memoization, reset
- [x] `prefetchWix.test.ts` — 7 cases: mock fallback, Wix API fetch, API failure fallback, dedupe, storage failure
- [x] Full test suite: 240 suites, 4000 tests passing
- [ ] Manual: verify products load from Wix on Android emulator with real env vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)