### PR TITLE
feat(auth): token refresh mutex — prevent concurrent refreshes (cm-t9v)

### DIFF
--- a/src/services/wix/__tests__/tokenRefreshMutex.test.ts
+++ b/src/services/wix/__tests__/tokenRefreshMutex.test.ts
@@ -1,0 +1,71 @@
+import { WixAuthService } from '../wixAuth';
+
+// Mock dependencies
+jest.mock('../wixSdkClient', () => ({
+  getWixSdkClient: () => ({
+    auth: {
+      getTokens: () => ({ refreshToken: 'rt_test', accessToken: 'at_test' }),
+      renewToken: jest.fn().mockResolvedValue({ refreshToken: 'rt_new', accessToken: 'at_new' }),
+      setTokens: jest.fn(),
+      loggedIn: () => true,
+    },
+  }),
+}));
+jest.mock('../tokenStorage', () => ({
+  saveTokens: jest.fn().mockResolvedValue(undefined),
+  loadTokens: jest.fn(),
+  clearTokens: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../../crashReporting', () => ({
+  captureException: jest.fn(),
+}));
+jest.mock('../../appleAuth', () => ({
+  signInWithApple: jest.fn(),
+}));
+
+describe('Token refresh mutex', () => {
+  it('deduplicates concurrent refresh calls', async () => {
+    const auth = new WixAuthService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const refreshSpy = jest.spyOn(auth as any, '_doRefresh');
+
+    // Fire 5 concurrent refresh calls
+    const results = await Promise.all([
+      auth.refreshSession(),
+      auth.refreshSession(),
+      auth.refreshSession(),
+      auth.refreshSession(),
+      auth.refreshSession(),
+    ]);
+
+    // Should only call the underlying refresh ONCE
+    expect(refreshSpy).toHaveBeenCalledTimes(1);
+    // All callers get the same result
+    results.forEach((r) => expect(r).toBe(true));
+  });
+
+  it('allows new refresh after previous completes', async () => {
+    const auth = new WixAuthService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const refreshSpy = jest.spyOn(auth as any, '_doRefresh');
+
+    await auth.refreshSession();
+    await auth.refreshSession();
+
+    expect(refreshSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('clears mutex on refresh failure so next call can retry', async () => {
+    const auth = new WixAuthService();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const refreshSpy = jest.spyOn(auth as any, '_doRefresh');
+    refreshSpy.mockRejectedValueOnce(new Error('Network error'));
+
+    const result1 = await auth.refreshSession();
+    expect(result1).toBe(false);
+
+    refreshSpy.mockRestore();
+    const result2 = await auth.refreshSession();
+    expect(result2).toBe(true);
+  });
+});

--- a/src/services/wix/wixAuth.ts
+++ b/src/services/wix/wixAuth.ts
@@ -58,6 +58,8 @@ const ERROR_MESSAGES: Record<string, string> = {
  * and persists tokens via tokenStorage for cross-session survival.
  */
 export class WixAuthService {
+  private refreshPromise: Promise<boolean> | null = null;
+
   private get auth() {
     return getWixSdkClient().auth;
   }
@@ -274,6 +276,21 @@ export class WixAuthService {
   }
 
   async refreshSession(): Promise<boolean> {
+    // Mutex: if a refresh is already in-flight, piggyback on it
+    if (this.refreshPromise) {
+      return this.refreshPromise;
+    }
+
+    this.refreshPromise = this._doRefresh().catch(() => false);
+
+    try {
+      return await this.refreshPromise;
+    } finally {
+      this.refreshPromise = null;
+    }
+  }
+
+  private async _doRefresh(): Promise<boolean> {
     try {
       const currentTokens = this.auth.getTokens();
       const newTokens = await this.auth.renewToken(currentTokens.refreshToken);


### PR DESCRIPTION
## Summary
- **Token refresh mutex** — concurrent `refreshSession()` calls coalesce into a single token renewal. All callers piggyback on the in-flight promise.
- Mutex auto-clears on completion (success or failure), allowing subsequent refresh calls
- Internal `_doRefresh()` extracted from `refreshSession()` for testability

## Test plan
- [x] `tokenRefreshMutex.test.ts` — 3 cases: concurrent deduplication (5 calls → 1 renewal), sequential re-entry, failure recovery
- [x] Full suite: 245 suites, 4032 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)