### PR TITLE
feat(stores): wire useStores to Wix CMS with fallback (cm-49g)

### DIFF
--- a/src/hooks/__tests__/useStoresWix.test.ts
+++ b/src/hooks/__tests__/useStoresWix.test.ts
@@ -1,0 +1,105 @@
+/**
+ * Tests for Wix CMS-aware useStores hook.
+ * Verifies that store data comes from Wix when configured,
+ * falls back to static data when not.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react-native';
+
+const mockQueryData = jest.fn();
+let mockConfigured = false;
+
+jest.mock('@/services/wix/wixClientSingleton', () => ({
+  getWixClientSingleton: () => (mockConfigured ? { queryData: mockQueryData } : null),
+}));
+
+// Need to import AFTER mocks
+import { useStores } from '../useStores';
+import { STORES } from '@/data/stores';
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockConfigured = false;
+});
+
+describe('useStores — mock fallback (Wix not configured)', () => {
+  it('returns static STORES data when Wix is not configured', () => {
+    mockConfigured = false;
+    const { result } = renderHook(() => useStores());
+    expect(result.current.stores).toEqual(STORES);
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('does not call Wix API when not configured', () => {
+    mockConfigured = false;
+    renderHook(() => useStores());
+    expect(mockQueryData).not.toHaveBeenCalled();
+  });
+});
+
+describe('useStores — Wix CMS', () => {
+  const wixStores = [
+    {
+      id: 's1',
+      name: 'Downtown Showroom',
+      address: '100 Main St',
+      city: 'Charlotte',
+      state: 'NC',
+      zip: '28202',
+      phone: '704-555-0100',
+      email: 'charlotte@carolinafutons.com',
+      latitude: 35.227,
+      longitude: -80.843,
+      hours: [],
+      photos: [],
+      features: [],
+      description: 'Our flagship showroom',
+    },
+  ];
+
+  beforeEach(() => {
+    mockConfigured = true;
+    mockQueryData.mockResolvedValue({
+      items: wixStores,
+      totalResults: 1,
+    });
+  });
+
+  it('fetches stores from Wix CMS when configured', async () => {
+    const { result } = renderHook(() => useStores());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(mockQueryData).toHaveBeenCalledWith('Showrooms', expect.any(Object));
+    expect(result.current.stores).toEqual(wixStores);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('falls back to static data on Wix API error', async () => {
+    mockQueryData.mockRejectedValue(new Error('CMS unavailable'));
+
+    const { result } = renderHook(() => useStores());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    // Should fall back to static stores, not error out
+    expect(result.current.stores).toEqual(STORES);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('provides working getStoreById for Wix data', async () => {
+    const { result } = renderHook(() => useStores());
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    const store = result.current.getStoreById('s1');
+    expect(store).toBeDefined();
+    expect(store?.city).toBe('Charlotte');
+  });
+});

--- a/src/hooks/useStores.ts
+++ b/src/hooks/useStores.ts
@@ -2,11 +2,12 @@
  * @module useStores
  *
  * Provides showroom/store data for the store locator and detail screens.
- * Static data today; shaped for a drop-in replacement with the Wix CMS
- * (Content Management System) API when the backend integration lands.
+ * Queries Wix CMS "Showrooms" collection when configured, falls back to
+ * static mock data when Wix is not available.
  */
-import { useMemo, useCallback } from 'react';
+import { useMemo, useCallback, useState, useEffect } from 'react';
 import { STORES, APPOINTMENT_TYPES, type Store, type AppointmentType } from '@/data/stores';
+import { getWixClientSingleton } from '@/services/wix/wixClientSingleton';
 
 // Re-export for screens — avoids direct src/data imports
 export { APPOINTMENT_TYPES };
@@ -21,14 +22,43 @@ interface UseStoresReturn {
 
 /**
  * Provides store/showroom data for locator and detail screens.
- * Uses static data now; designed for drop-in Wix CMS API replacement.
+ * Queries Wix CMS when configured, falls back to static data.
  */
 export function useStores(): UseStoresReturn {
-  const stores = useMemo(() => STORES, []);
+  const wix = useMemo(() => getWixClientSingleton(), []);
+  const [stores, setStores] = useState<Store[]>(wix ? [] : STORES);
+  const [isLoading, setIsLoading] = useState(!!wix);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!wix) return;
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const result = await wix.queryData<Store>('Showrooms', { limit: 100 });
+        if (!cancelled) {
+          setStores(result.items);
+          setIsLoading(false);
+        }
+      } catch {
+        // Non-fatal: fall back to static data
+        if (!cancelled) {
+          setStores(STORES);
+          setIsLoading(false);
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [wix]);
 
   const getStoreById = useCallback((id: string) => stores.find((s) => s.id === id), [stores]);
 
-  return { stores, isLoading: false, error: null, getStoreById };
+  return { stores, isLoading, error, getStoreById };
 }
 
 interface UseStoreByIdReturn {
@@ -41,10 +71,12 @@ interface UseStoreByIdReturn {
  * Looks up a single store by ID.
  */
 export function useStoreById(storeId: string | undefined): UseStoreByIdReturn {
+  const { stores, isLoading, error } = useStores();
+
   const store = useMemo(() => {
     if (!storeId) return null;
-    return STORES.find((s) => s.id === storeId) ?? null;
-  }, [storeId]);
+    return stores.find((s) => s.id === storeId) ?? null;
+  }, [storeId, stores]);
 
-  return { store, isLoading: false, error: null };
+  return { store, isLoading, error };
 }


### PR DESCRIPTION
## Summary
- **useStores** now queries Wix CMS "Showrooms" collection when Wix is configured
- Falls back to static mock data when Wix is unavailable or on API error
- **useStoreById** now derives from useStores for consistent data source
- Zero breaking changes — existing static data path unchanged

## Test plan
- [x] `useStoresWix.test.ts` — 5 cases: Wix CMS fetch, mock fallback, API error graceful fallback, getStoreById with Wix data, no API call when unconfigured
- [x] `useStores.test.ts` — existing 10 tests pass unchanged
- [x] Full suite: 246 suites, 4037 tests passing (1 pre-existing flaky sentry test excluded)

🤖 Generated with [Claude Code](https://claude.com/claude-code)