### PR TITLE
feat: Compare button on ProductCard — surface CompareScreen (cm-c4w)

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -25,6 +25,7 @@ import { useImageLoadTracking } from '@/hooks/useImageLoadTracking';
 import { WishlistButton } from './WishlistButton';
 import { FinancingBadge } from './FinancingBadge';
 import { ProductCardVideo } from './ProductCardVideo';
+import { CompareButton } from './CompareButton';
 
 interface Props {
   product: Product;
@@ -155,6 +156,8 @@ export const ProductCard = memo(function ProductCard({
             <Text style={styles.stockBadgeText}>{stockBadge.label}</Text>
           </View>
         )}
+
+        <CompareButton product={product} testID={`compare-btn-${product.id}`} />
       </View>
     </TouchableOpacity>
   );

--- a/src/components/__tests__/ProductCard.test.tsx
+++ b/src/components/__tests__/ProductCard.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent } from '@testing-library/react-native';
 import { ProductCard } from '../ProductCard';
 import { ThemeProvider } from '@/theme/ThemeProvider';
 import { WishlistProvider } from '@/hooks/useWishlist';
+import { CompareProvider } from '@/contexts/CompareContext';
 import { PRODUCTS, type Product } from '@/data/products';
 import { productId } from '@/data/productId';
 
@@ -16,7 +17,9 @@ function renderCard(overrides: { product?: Product; onPress?: jest.Mock } = {}) 
     ...render(
       <ThemeProvider>
         <WishlistProvider>
-          <ProductCard product={overrides.product ?? futon} onPress={onPress} />
+          <CompareProvider>
+            <ProductCard product={overrides.product ?? futon} onPress={onPress} />
+          </CompareProvider>
         </WishlistProvider>
       </ThemeProvider>,
     ),
@@ -102,7 +105,9 @@ describe('ProductCard', () => {
       const { getByTestId } = render(
         <ThemeProvider>
           <WishlistProvider>
-            <ProductCard product={futon} />
+            <CompareProvider>
+              <ProductCard product={futon} />
+            </CompareProvider>
           </WishlistProvider>
         </ThemeProvider>,
       );
@@ -222,6 +227,60 @@ describe('ProductCard', () => {
       const { getByTestId } = renderCard({ product: videoProduct, onPress });
       fireEvent.press(getByTestId(`product-card-${videoProduct.id}`));
       expect(onPress).toHaveBeenCalledWith(videoProduct);
+    });
+  });
+
+  // =========================================================================
+  // Compare Button (cm-c4w)
+  // =========================================================================
+  describe('compare button', () => {
+    it('renders compare button on each card', () => {
+      const { getByTestId } = renderCard();
+      expect(getByTestId(`compare-btn-${futon.id}`)).toBeTruthy();
+    });
+
+    it('compare button shows "Compare" label by default', () => {
+      const { getByText } = renderCard();
+      expect(getByText('Compare')).toBeTruthy();
+    });
+
+    it('compare button has correct accessibility label when not in compare list', () => {
+      const { getByTestId } = renderCard();
+      const btn = getByTestId(`compare-btn-${futon.id}`);
+      expect(btn.props.accessibilityLabel).toBe('Add to compare');
+    });
+
+    it('compare button has button role', () => {
+      const { getByTestId } = renderCard();
+      const btn = getByTestId(`compare-btn-${futon.id}`);
+      expect(btn.props.accessibilityRole).toBe('button');
+    });
+
+    it('pressing compare button adds product to compare list (shows "Remove")', () => {
+      const { getByTestId, getByText } = renderCard();
+      fireEvent.press(getByTestId(`compare-btn-${futon.id}`));
+      expect(getByText('Remove')).toBeTruthy();
+    });
+
+    it('compare button accessibility label updates when product is in compare list', () => {
+      const { getByTestId } = renderCard();
+      fireEvent.press(getByTestId(`compare-btn-${futon.id}`));
+      const btn = getByTestId(`compare-btn-${futon.id}`);
+      expect(btn.props.accessibilityLabel).toBe('Remove from compare');
+    });
+
+    it('pressing compare button again removes product from compare list', () => {
+      const { getByTestId, getByText } = renderCard();
+      fireEvent.press(getByTestId(`compare-btn-${futon.id}`));
+      fireEvent.press(getByTestId(`compare-btn-${futon.id}`));
+      expect(getByText('Compare')).toBeTruthy();
+    });
+
+    it('tapping compare button does not fire card onPress', () => {
+      const onPress = jest.fn();
+      const { getByTestId } = renderCard({ onPress });
+      fireEvent.press(getByTestId(`compare-btn-${futon.id}`));
+      expect(onPress).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/screens/__tests__/CategoryScreen.test.tsx
+++ b/src/screens/__tests__/CategoryScreen.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent, act } from '@testing-library/react-native';
 import { CategoryScreen } from '../CategoryScreen';
 import { ThemeProvider } from '@/theme/ThemeProvider';
 import { WishlistProvider } from '@/hooks/useWishlist';
+import { CompareProvider } from '@/contexts/CompareContext';
 import { PRODUCTS } from '@/data/products';
 
 jest.useFakeTimers();
@@ -16,7 +17,9 @@ async function renderCategory(props: Partial<React.ComponentProps<typeof Categor
   const result = render(
     <ThemeProvider>
       <WishlistProvider>
-        <CategoryScreen onProductPress={onProductPress} onBack={onBack} {...props} />
+        <CompareProvider>
+          <CategoryScreen onProductPress={onProductPress} onBack={onBack} {...props} />
+        </CompareProvider>
       </WishlistProvider>
     </ThemeProvider>,
   );

--- a/src/screens/__tests__/ListVirtualization.test.tsx
+++ b/src/screens/__tests__/ListVirtualization.test.tsx
@@ -11,6 +11,7 @@ import { render, act } from '@testing-library/react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { ThemeProvider } from '@/theme/ThemeProvider';
 import { WishlistProvider, type WishlistItem } from '@/hooks/useWishlist';
+import { CompareProvider } from '@/contexts/CompareContext';
 import { PRODUCTS } from '@/data/products';
 import { ShopScreen } from '../ShopScreen';
 import { CategoryScreen } from '../CategoryScreen';
@@ -48,7 +49,9 @@ async function renderShop() {
   const result = render(
     <ThemeProvider>
       <WishlistProvider>
-        <ShopScreen onProductPress={jest.fn()} />
+        <CompareProvider>
+          <ShopScreen onProductPress={jest.fn()} />
+        </CompareProvider>
       </WishlistProvider>
     </ThemeProvider>,
   );
@@ -61,7 +64,9 @@ function renderCategory() {
   return render(
     <ThemeProvider>
       <WishlistProvider>
-        <CategoryScreen categoryId="futons" onProductPress={jest.fn()} />
+        <CompareProvider>
+          <CategoryScreen categoryId="futons" onProductPress={jest.fn()} />
+        </CompareProvider>
       </WishlistProvider>
     </ThemeProvider>,
   );
@@ -88,7 +93,9 @@ function renderWishlist(items?: WishlistItem[]) {
           ]
         }
       >
-        <WishlistScreen onProductPress={jest.fn()} />
+        <CompareProvider>
+          <WishlistScreen onProductPress={jest.fn()} />
+        </CompareProvider>
       </WishlistProvider>
     </ThemeProvider>,
   );

--- a/src/screens/__tests__/SearchScreen.test.tsx
+++ b/src/screens/__tests__/SearchScreen.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent, act, waitFor } from '@testing-library/react-native';
 import { SearchScreen } from '../SearchScreen';
 import { ThemeProvider } from '@/theme/ThemeProvider';
 import { WishlistProvider } from '@/hooks/useWishlist';
+import { CompareProvider } from '@/contexts/CompareContext';
 import { PRODUCTS } from '@/data/products';
 
 const mockNavigate = jest.fn();
@@ -39,7 +40,9 @@ function renderSearchScreen() {
   return render(
     <ThemeProvider>
       <WishlistProvider>
-        <SearchScreen />
+        <CompareProvider>
+          <SearchScreen />
+        </CompareProvider>
       </WishlistProvider>
     </ThemeProvider>,
   );
@@ -79,7 +82,9 @@ describe('SearchScreen', () => {
       const { getByTestId } = render(
         <ThemeProvider>
           <WishlistProvider>
-            <SearchScreen testID="custom-search" />
+            <CompareProvider>
+              <SearchScreen testID="custom-search" />
+            </CompareProvider>
           </WishlistProvider>
         </ThemeProvider>,
       );

--- a/src/screens/__tests__/ShopScreen.test.tsx
+++ b/src/screens/__tests__/ShopScreen.test.tsx
@@ -3,6 +3,7 @@ import { render, fireEvent, act } from '@testing-library/react-native';
 import { ShopScreen } from '../ShopScreen';
 import { ThemeProvider } from '@/theme/ThemeProvider';
 import { WishlistProvider } from '@/hooks/useWishlist';
+import { CompareProvider } from '@/contexts/CompareContext';
 import { PRODUCTS } from '@/data/products';
 
 async function renderShop(props: { onProductPress?: jest.Mock } = {}) {
@@ -10,7 +11,9 @@ async function renderShop(props: { onProductPress?: jest.Mock } = {}) {
   const result = render(
     <ThemeProvider>
       <WishlistProvider>
-        <ShopScreen onProductPress={onProductPress} />
+        <CompareProvider>
+          <ShopScreen onProductPress={onProductPress} />
+        </CompareProvider>
       </WishlistProvider>
     </ThemeProvider>,
   );

--- a/src/screens/__tests__/WishlistScreen.test.tsx
+++ b/src/screens/__tests__/WishlistScreen.test.tsx
@@ -4,6 +4,7 @@ import { Alert, Share } from 'react-native';
 import { WishlistScreen } from '../WishlistScreen';
 import { ThemeProvider } from '@/theme/ThemeProvider';
 import { WishlistProvider, type WishlistItem } from '@/hooks/useWishlist';
+import { CompareProvider } from '@/contexts/CompareContext';
 import { PRODUCTS } from '@/data/products';
 
 const product1 = PRODUCTS[0];
@@ -30,7 +31,9 @@ function renderScreen(
     ...render(
       <ThemeProvider>
         <WishlistProvider initialItems={opts.items ?? []}>
-          <WishlistScreen onProductPress={onProductPress} onBrowse={onBrowse} />
+          <CompareProvider>
+            <WishlistScreen onProductPress={onProductPress} onBrowse={onBrowse} />
+          </CompareProvider>
         </WishlistProvider>
       </ThemeProvider>,
     ),


### PR DESCRIPTION
## Summary

- Wires `CompareButton` into `ProductCard` (component was built but never added to the card)
- CompareProvider already at App.tsx root — no tree changes needed
- Completes the full compare flow end-to-end: ProductCard → CompareContext → CompareScreen

## What was hidden

`CompareScreen` was feature-complete and registered in navigation. `CompareButton` existed on `ProductDetailScreen`. Neither was accessible from `ProductCard` — the entry point users actually browse from.

## Changes

- `src/components/ProductCard.tsx` — add `CompareButton` below stock badge
- `src/components/__tests__/ProductCard.test.tsx` — 8 new tests: renders, a11y labels, add/remove toggle, isolation from card onPress
- 5 screen test helpers updated to include `CompareProvider` wrapper (Shop, Category, Wishlist, Search, ListVirtualization)

## Test plan

- [x] Compare button renders on ProductCard
- [x] Accessibility labels correct
- [x] Add/remove toggle works
- [x] Card onPress not affected by compare button tap
- [x] 4348/4348 tests passing

🤖 Generated with [Claude Code](https://claude.ai/code)