### PR TITLE
feat(cm-s1y): branded error illustrations on HomeScreen, OrderHistory, RoomGallery

### DIFF
--- a/src/hooks/useCollections.ts
+++ b/src/hooks/useCollections.ts
@@ -54,18 +54,14 @@ function transformCmsCollection(item: WixEditorialItem): EditorialCollection {
 
 function createFetcher(client: WixClient | null) {
   return async (): Promise<EditorialCollection[]> => {
-    if (client) {
-      try {
-        const result = await client.queryData<WixEditorialItem>(CMS_COLLECTION_ID, {
-          limit: 50,
-          sort: [{ fieldName: 'featured', order: 'DESC' }],
-        });
-        if (result.items.length > 0) {
-          return result.items.map(transformCmsCollection);
-        }
-      } catch {
-        // CMS fetch failed — fall back to static data
-      }
+    if (!client) return COLLECTIONS;
+
+    const result = await client.queryData<WixEditorialItem>(CMS_COLLECTION_ID, {
+      limit: 50,
+      sort: [{ fieldName: 'featured', order: 'DESC' }],
+    });
+    if (result.items.length > 0) {
+      return result.items.map(transformCmsCollection);
     }
     return COLLECTIONS;
   };
@@ -76,7 +72,7 @@ export function useCollections() {
   const client = useOptionalWixClient();
   const fetcher = useCallback(() => createFetcher(client)(), [client]);
 
-  const { data, isLoading, isStale, refresh } = useDataCache<EditorialCollection[]>(
+  const { data, isLoading, isStale, error, refresh } = useDataCache<EditorialCollection[]>(
     'editorial-collections',
     fetcher,
     { maxAge: COLLECTION_CACHE_MAX_AGE },
@@ -90,9 +86,10 @@ export function useCollections() {
       featured: collections.filter((c) => c.featured),
       isLoading,
       isStale,
+      error,
       refresh,
     }),
-    [collections, isLoading, isStale, refresh],
+    [collections, isLoading, isStale, error, refresh],
   );
 }
 

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -53,7 +53,7 @@ export function HomeScreen({ onOpenAR, onOpenShop, onCollectionPress }: Props) {
   const { colors, spacing, typography, borderRadius } = useTheme();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const insets = useSafeAreaInsets();
-  const { featured, isLoading: collectionsLoading } = useCollections();
+  const { featured, isLoading: collectionsLoading, error: collectionsError } = useCollections();
   const { recentProducts } = useRecentlyViewed();
 
   const handleOpenAR = useCallback(() => {
@@ -364,6 +364,29 @@ export function HomeScreen({ onOpenAR, onOpenShop, onCollectionPress }: Props) {
           Since 1985 · Hendersonville, NC
         </Text>
       </View>
+
+      {/* Connection error banner — shows when Wix fetch fails but static content is visible */}
+      {collectionsError ? (
+        <View
+          style={[styles.connectionErrorBanner, { backgroundColor: colors.espresso + 'E6' }]}
+          testID="home-connection-error"
+        >
+          <View
+            testID="home-connection-error-illustration"
+            style={styles.connectionErrorIllustration}
+          >
+            <MountainSkyline variant="sunset" height={40} testID="home-error-skyline" />
+          </View>
+          <Text
+            style={[
+              styles.connectionErrorText,
+              { color: colors.sandBase, fontFamily: typography.bodyFamily },
+            ]}
+          >
+            Couldn't refresh content. Showing saved data.
+          </Text>
+        </View>
+      ) : null}
     </ScrollView>
   );
 }
@@ -462,5 +485,22 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     letterSpacing: 0.8,
     textTransform: 'uppercase',
+  },
+  connectionErrorBanner: {
+    width: '100%',
+    borderRadius: 12,
+    overflow: 'hidden',
+    marginTop: 16,
+    paddingBottom: 12,
+    alignItems: 'center',
+  },
+  connectionErrorIllustration: {
+    width: '100%',
+  },
+  connectionErrorText: {
+    fontSize: 13,
+    textAlign: 'center',
+    paddingHorizontal: 16,
+    marginTop: 8,
   },
 });

--- a/src/screens/OrderHistoryScreen.tsx
+++ b/src/screens/OrderHistoryScreen.tsx
@@ -13,6 +13,7 @@ import { useTheme } from '@/theme';
 import { darkPalette } from '@/theme/tokens';
 import { EmptyState } from '@/components/EmptyState';
 import { CategoryIllustration } from '@/components/illustrations/CategoryIllustration';
+import { MountainSkyline } from '@/components/MountainSkyline';
 import { useOrders, ORDER_STATUS_CONFIG, type Order } from '@/hooks/useOrders';
 import {
   MountainRefreshControl,
@@ -36,7 +37,7 @@ export function OrderHistoryScreen({
 }: Props) {
   const { colors, spacing, borderRadius, shadows, typography } = useTheme();
   const [refreshing, setRefreshing] = useState(false);
-  const { orders: hookOrders } = useOrders();
+  const { orders: hookOrders, error: hookError, refresh: hookRefresh } = useOrders();
 
   // Use prop orders or fall back to hook data (already sorted newest-first)
   const orders = ordersProp
@@ -143,6 +144,44 @@ export function OrderHistoryScreen({
     },
     [colors, spacing, borderRadius, shadows, onSelectOrder, formatDate],
   );
+
+  if (hookError && !ordersProp) {
+    return (
+      <View
+        style={[styles.root, styles.centered, { backgroundColor: darkPalette.background }]}
+        testID={testID ?? 'order-history-screen'}
+      >
+        <View testID="order-history-error-illustration" style={styles.illustrationContainer}>
+          <MountainSkyline variant="sunset" height={100} testID="order-history-error-skyline" />
+        </View>
+        <Text
+          style={[
+            styles.errorTitle,
+            { color: darkPalette.textPrimary, fontFamily: typography.bodyFamilyBold },
+          ]}
+          testID="order-history-error"
+        >
+          Couldn't load your orders
+        </Text>
+        <Text
+          style={[
+            styles.errorMessage,
+            { color: darkPalette.textMuted, fontFamily: typography.bodyFamily },
+          ]}
+        >
+          Check your connection and try again.
+        </Text>
+        <TouchableOpacity
+          style={[styles.retryButton, { backgroundColor: colors.sunsetCoral }]}
+          onPress={hookRefresh}
+          testID="order-history-retry"
+          accessibilityRole="button"
+        >
+          <Text style={[styles.retryText, { fontFamily: typography.bodyFamilyBold }]}>Retry</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
 
   if (orders.length === 0) {
     return (
@@ -260,6 +299,37 @@ const styles = StyleSheet.create({
   },
   orderTotal: {
     fontSize: 18,
+    fontWeight: '700',
+  },
+  centered: {
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  illustrationContainer: {
+    marginBottom: 16,
+    width: '80%',
+    overflow: 'hidden',
+    borderRadius: 12,
+  },
+  errorTitle: {
+    fontSize: 17,
+    textAlign: 'center',
+    marginBottom: 8,
+  },
+  errorMessage: {
+    fontSize: 14,
+    textAlign: 'center',
+    marginHorizontal: 32,
+    marginBottom: 20,
+  },
+  retryButton: {
+    paddingVertical: 12,
+    paddingHorizontal: 32,
+    borderRadius: 8,
+  },
+  retryText: {
+    color: '#FFFFFF',
+    fontSize: 15,
     fontWeight: '700',
   },
 });

--- a/src/screens/RoomGalleryScreen.tsx
+++ b/src/screens/RoomGalleryScreen.tsx
@@ -20,6 +20,7 @@ import {
 } from 'react-native';
 import { useTheme } from '@/theme';
 import { useRoomGallery, type RoomGalleryItem } from '@/hooks/useRoomGallery';
+import { MountainSkyline } from '@/components/MountainSkyline';
 
 interface Props {
   /** Called when a room card is tapped with the first productId of that room. */
@@ -119,14 +120,25 @@ export function RoomGalleryScreen({ onProductPress, testID }: Props) {
         style={[styles.root, styles.centered, { backgroundColor: colors.sandBase }]}
         testID={testID ?? 'room-gallery-screen'}
       >
+        <View testID="room-gallery-error-illustration" style={styles.illustrationContainer}>
+          <MountainSkyline variant="sunset" height={100} testID="room-gallery-error-skyline" />
+        </View>
+        <Text
+          style={[
+            styles.errorTitle,
+            { color: colors.espresso, fontFamily: typography.bodyFamilyBold },
+          ]}
+          testID="room-gallery-error"
+        >
+          Couldn't load the gallery
+        </Text>
         <Text
           style={[
             styles.errorText,
             { color: colors.espressoLight, fontFamily: typography.bodyFamily },
           ]}
-          testID="room-gallery-error"
         >
-          Unable to load gallery. Check your connection.
+          Check your connection and try again.
         </Text>
         <TouchableOpacity
           style={[styles.retryButton, { backgroundColor: colors.sunsetCoral }]}
@@ -240,8 +252,19 @@ const styles = StyleSheet.create({
     fontSize: 11,
     marginTop: 2,
   },
+  illustrationContainer: {
+    marginBottom: 16,
+    width: '80%',
+    overflow: 'hidden',
+    borderRadius: 12,
+  },
+  errorTitle: {
+    fontSize: 17,
+    textAlign: 'center',
+    marginBottom: 8,
+  },
   errorText: {
-    fontSize: 15,
+    fontSize: 14,
     textAlign: 'center',
     marginHorizontal: 32,
     marginBottom: 20,

--- a/src/screens/__tests__/HomeScreen.test.tsx
+++ b/src/screens/__tests__/HomeScreen.test.tsx
@@ -4,6 +4,15 @@ import { NavigationContainer } from '@react-navigation/native';
 import { HomeScreen } from '../HomeScreen';
 import { ThemeProvider } from '@/theme/ThemeProvider';
 
+const mockUseCollections = jest.fn();
+jest.mock('@/hooks/useCollections', () => {
+  const actual = jest.requireActual('@/hooks/useCollections');
+  return {
+    ...actual,
+    useCollections: () => mockUseCollections(),
+  };
+});
+
 jest.mock('@/services/wix', () => ({
   useOptionalWixClient: () => ({
     queryData: jest.fn().mockResolvedValue({ items: [], totalResults: 0 }),
@@ -32,6 +41,65 @@ function renderHomeScreen(
 }
 
 describe('HomeScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: collections load with realistic featured data matching static COLLECTIONS
+    mockUseCollections.mockReturnValue({
+      collections: [
+        {
+          id: 'c1',
+          slug: 'mountain-lodge-living',
+          title: 'Mountain Lodge Living',
+          subtitle: 'Warm tones, solid wood, peak comfort',
+          description: '',
+          heroImage: { uri: '', alt: '' },
+          mood: [],
+          featured: true,
+          productIds: [],
+        },
+        {
+          id: 'c2',
+          slug: 'guest-room-ready',
+          title: 'Guest Room Ready',
+          subtitle: 'Impress every overnight visitor',
+          description: '',
+          heroImage: { uri: '', alt: '' },
+          mood: [],
+          featured: true,
+          productIds: [],
+        },
+      ],
+      featured: [
+        {
+          id: 'c1',
+          slug: 'mountain-lodge-living',
+          title: 'Mountain Lodge Living',
+          subtitle: 'Warm tones, solid wood, peak comfort',
+          description: '',
+          heroImage: { uri: '', alt: '' },
+          mood: [],
+          featured: true,
+          productIds: [],
+        },
+        {
+          id: 'c2',
+          slug: 'guest-room-ready',
+          title: 'Guest Room Ready',
+          subtitle: 'Impress every overnight visitor',
+          description: '',
+          heroImage: { uri: '', alt: '' },
+          mood: [],
+          featured: true,
+          productIds: [],
+        },
+      ],
+      isLoading: false,
+      isStale: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+  });
+
   it('renders hero content', () => {
     const { getByText } = renderHomeScreen();
     expect(getByText('Handcrafted in NC')).toBeTruthy();
@@ -117,5 +185,46 @@ describe('HomeScreen', () => {
     expect(onCollectionPress).toHaveBeenCalledWith(
       expect.objectContaining({ slug: 'mountain-lodge-living' }),
     );
+  });
+
+  describe('Error state (cm-s1y — branded illustration)', () => {
+    it('shows connection error banner when collections fetch fails', () => {
+      mockUseCollections.mockReturnValue({
+        collections: [],
+        featured: [],
+        isLoading: false,
+        isStale: true,
+        error: new Error('Network error'),
+        refresh: jest.fn(),
+      });
+      const { getByTestId } = renderHomeScreen();
+      expect(getByTestId('home-connection-error')).toBeTruthy();
+    });
+
+    it('shows branded mountain illustration in error banner', () => {
+      mockUseCollections.mockReturnValue({
+        collections: [],
+        featured: [],
+        isLoading: false,
+        isStale: true,
+        error: new Error('Network error'),
+        refresh: jest.fn(),
+      });
+      const { getByTestId } = renderHomeScreen();
+      expect(getByTestId('home-connection-error-illustration')).toBeTruthy();
+    });
+
+    it('does not show error banner when collections load successfully', () => {
+      mockUseCollections.mockReturnValue({
+        collections: [],
+        featured: [],
+        isLoading: false,
+        isStale: false,
+        error: null,
+        refresh: jest.fn(),
+      });
+      const { queryByTestId } = renderHomeScreen();
+      expect(queryByTestId('home-connection-error')).toBeNull();
+    });
   });
 });

--- a/src/screens/__tests__/OrderHistoryScreen.test.tsx
+++ b/src/screens/__tests__/OrderHistoryScreen.test.tsx
@@ -6,6 +6,13 @@ import { MOCK_ORDERS, type Order } from '@/data/orders';
 import { futonModelId } from '@/data/productId';
 import { darkPalette, typography } from '@/theme/tokens';
 
+const mockRefresh = jest.fn();
+const mockUseOrders = jest.fn();
+jest.mock('@/hooks/useOrders', () => ({
+  ...jest.requireActual('@/hooks/useOrders'),
+  useOrders: () => mockUseOrders(),
+}));
+
 function renderOrderHistory(props: Partial<React.ComponentProps<typeof OrderHistoryScreen>> = {}) {
   return render(
     <ThemeProvider>
@@ -15,6 +22,23 @@ function renderOrderHistory(props: Partial<React.ComponentProps<typeof OrderHist
 }
 
 describe('OrderHistoryScreen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Real useOrders returns orders sorted newest-first
+    const sortedOrders = [...MOCK_ORDERS].sort(
+      (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime(),
+    );
+    mockUseOrders.mockReturnValue({
+      orders: sortedOrders,
+      isLoading: false,
+      error: null,
+      refresh: mockRefresh,
+      statusFilter: null,
+      setStatusFilter: jest.fn(),
+      getOrder: jest.fn(),
+    });
+  });
+
   describe('With orders (default mock data)', () => {
     it('renders with default testID', () => {
       const { getByTestId } = renderOrderHistory();
@@ -230,6 +254,65 @@ describe('OrderHistoryScreen', () => {
       });
       expect(getByTestId('order-card-custom-1')).toBeTruthy();
       expect(queryByTestId('order-card-ord-001')).toBeNull();
+    });
+  });
+
+  describe('Error state (cm-s1y — branded illustration)', () => {
+    it('shows error state when useOrders returns an error', () => {
+      mockUseOrders.mockReturnValue({
+        orders: [],
+        isLoading: false,
+        error: new Error('API unavailable'),
+        refresh: mockRefresh,
+        statusFilter: null,
+        setStatusFilter: jest.fn(),
+        getOrder: jest.fn(),
+      });
+      const { getByTestId } = renderOrderHistory();
+      expect(getByTestId('order-history-error')).toBeTruthy();
+    });
+
+    it('shows branded mountain illustration in error state', () => {
+      mockUseOrders.mockReturnValue({
+        orders: [],
+        isLoading: false,
+        error: new Error('API unavailable'),
+        refresh: mockRefresh,
+        statusFilter: null,
+        setStatusFilter: jest.fn(),
+        getOrder: jest.fn(),
+      });
+      const { getByTestId } = renderOrderHistory();
+      expect(getByTestId('order-history-error-illustration')).toBeTruthy();
+    });
+
+    it('shows retry button in error state', () => {
+      mockUseOrders.mockReturnValue({
+        orders: [],
+        isLoading: false,
+        error: new Error('API unavailable'),
+        refresh: mockRefresh,
+        statusFilter: null,
+        setStatusFilter: jest.fn(),
+        getOrder: jest.fn(),
+      });
+      const { getByTestId } = renderOrderHistory();
+      expect(getByTestId('order-history-retry')).toBeTruthy();
+    });
+
+    it('calls refresh when retry is pressed', () => {
+      mockUseOrders.mockReturnValue({
+        orders: [],
+        isLoading: false,
+        error: new Error('API unavailable'),
+        refresh: mockRefresh,
+        statusFilter: null,
+        setStatusFilter: jest.fn(),
+        getOrder: jest.fn(),
+      });
+      const { getByTestId } = renderOrderHistory();
+      fireEvent.press(getByTestId('order-history-retry'));
+      expect(mockRefresh).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/src/screens/__tests__/RoomGalleryScreen.test.tsx
+++ b/src/screens/__tests__/RoomGalleryScreen.test.tsx
@@ -129,6 +129,39 @@ describe('RoomGalleryScreen', () => {
       fireEvent.press(getByTestId('room-gallery-retry'));
       expect(mockRefresh).toHaveBeenCalledTimes(1);
     });
+
+    it('shows branded mountain illustration on error', () => {
+      mockUseRoomGallery.mockReturnValue({
+        rooms: [],
+        isLoading: false,
+        error: new Error('Network error'),
+        refresh: mockRefresh,
+      });
+      const { getByTestId } = renderGallery();
+      expect(getByTestId('room-gallery-error-illustration')).toBeTruthy();
+    });
+
+    it('does not show raw error string in error state', () => {
+      mockUseRoomGallery.mockReturnValue({
+        rooms: [],
+        isLoading: false,
+        error: new Error('Network error'),
+        refresh: mockRefresh,
+      });
+      const { queryByText } = renderGallery();
+      expect(queryByText('Unable to load gallery. Check your connection.')).toBeNull();
+    });
+
+    it('shows friendly error copy in error state', () => {
+      mockUseRoomGallery.mockReturnValue({
+        rooms: [],
+        isLoading: false,
+        error: new Error('Network error'),
+        refresh: mockRefresh,
+      });
+      const { getByTestId } = renderGallery();
+      expect(getByTestId('room-gallery-error')).toBeTruthy();
+    });
   });
 
   describe('Grid with rooms', () => {


### PR DESCRIPTION
## Summary
- Adds MountainSkyline branded error illustrations (variant=sunset) to HomeScreen, OrderHistoryScreen, RoomGalleryScreen
- `useCollections` now surfaces errors instead of swallowing them
- OrderHistoryScreen shows hookError state with illustration
- HomeScreen shows non-blocking connection error banner

## Test plan
- [ ] HomeScreen: trigger network error, confirm non-blocking banner appears
- [ ] OrderHistoryScreen: verify error state with branded illustration renders
- [ ] RoomGalleryScreen: verify error state with branded illustration renders
- [ ] All existing tests pass

Closes cm-s1y

🤖 Generated with [Claude Code](https://claude.ai/code)