### PR TITLE
feat(cm-cm1): DB-driven product recommendations with 5-min cache

### DIFF
--- a/src/hooks/__tests__/useProductRecommendations.test.ts
+++ b/src/hooks/__tests__/useProductRecommendations.test.ts
@@ -1,0 +1,197 @@
+/**
+ * @module useProductRecommendations.test
+ *
+ * TDD tests for DB-driven product recommendations — cm-cm1.
+ * Hook: useProductRecommendations(productId) → { recommendations, isLoading, error }
+ *
+ * Covered:
+ *   - invalid productId → empty result
+ *   - category match (same category returned, source excluded)
+ *   - price-range filter (±50% of source price)
+ *   - cache hit (no refetch within 5-min TTL)
+ *   - Wix API failure → fallback to static PRODUCTS
+ *   - empty result when no category matches found
+ */
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import {
+  useProductRecommendations,
+  clearRecommendationsCache,
+} from '../useProductRecommendations';
+import { PRODUCTS } from '@/data/products';
+
+const mockQueryProducts = jest.fn();
+let mockWixClient: { queryProducts: jest.Mock } | null = null;
+
+jest.mock('@/services/wix/wixProvider', () => ({
+  useOptionalWixClient: () => mockWixClient,
+}));
+
+// product1 is a futon ~$349
+const product1 = PRODUCTS[0];
+
+describe('useProductRecommendations', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    clearRecommendationsCache();
+    mockWixClient = null;
+  });
+
+  describe('invalid productId', () => {
+    it('returns empty array and no error for unknown productId', async () => {
+      const { result } = renderHook(() => useProductRecommendations('not-a-real-id'));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.recommendations).toEqual([]);
+      expect(result.current.error).toBeNull();
+    });
+
+    it('returns empty array for empty string productId', async () => {
+      const { result } = renderHook(() => useProductRecommendations(''));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.recommendations).toEqual([]);
+    });
+  });
+
+  describe('category match', () => {
+    it('returns only products in same category as source', async () => {
+      const { result } = renderHook(() => useProductRecommendations(product1.id));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.recommendations.length).toBeGreaterThan(0);
+      expect(
+        result.current.recommendations.every((p) => p.category === product1.category),
+      ).toBe(true);
+    });
+
+    it('excludes the source product itself from results', async () => {
+      const { result } = renderHook(() => useProductRecommendations(product1.id));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.recommendations.find((p) => p.id === product1.id)).toBeUndefined();
+    });
+  });
+
+  describe('price-range filter', () => {
+    it('includes products within ±50% of source price', async () => {
+      const inRange = {
+        ...product1,
+        id: 'p-in-range',
+        price: Math.round(product1.price * 1.2),
+        category: product1.category,
+      };
+      mockWixClient = { queryProducts: mockQueryProducts };
+      mockQueryProducts.mockResolvedValue({ products: [inRange], totalResults: 1 });
+
+      const { result } = renderHook(() => useProductRecommendations(product1.id));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.recommendations.map((p) => p.id)).toContain('p-in-range');
+    });
+
+    it('excludes products cheaper than 50% of source price', async () => {
+      const tooChEAP = {
+        ...product1,
+        id: 'p-too-cheap',
+        price: Math.round(product1.price * 0.49),
+        category: product1.category,
+      };
+      mockWixClient = { queryProducts: mockQueryProducts };
+      mockQueryProducts.mockResolvedValue({ products: [tooChEAP], totalResults: 1 });
+
+      const { result } = renderHook(() => useProductRecommendations(product1.id));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.recommendations.map((p) => p.id)).not.toContain('p-too-cheap');
+    });
+
+    it('excludes products more expensive than 150% of source price', async () => {
+      const tooExpensive = {
+        ...product1,
+        id: 'p-too-expensive',
+        price: Math.round(product1.price * 1.51),
+        category: product1.category,
+      };
+      mockWixClient = { queryProducts: mockQueryProducts };
+      mockQueryProducts.mockResolvedValue({ products: [tooExpensive], totalResults: 1 });
+
+      const { result } = renderHook(() => useProductRecommendations(product1.id));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.recommendations.map((p) => p.id)).not.toContain('p-too-expensive');
+    });
+  });
+
+  describe('cache hit', () => {
+    it('does not refetch when called again within TTL', async () => {
+      mockWixClient = { queryProducts: mockQueryProducts };
+      mockQueryProducts.mockResolvedValue({ products: [], totalResults: 0 });
+
+      // First render
+      const { unmount } = renderHook(() => useProductRecommendations(product1.id));
+      await waitFor(() => expect(mockQueryProducts).toHaveBeenCalledTimes(1));
+      unmount();
+
+      // Second render with same productId — should use cache
+      renderHook(() => useProductRecommendations(product1.id));
+      await act(async () => {});
+      expect(mockQueryProducts).toHaveBeenCalledTimes(1);
+    });
+
+    it('refetches after TTL expires', async () => {
+      mockWixClient = { queryProducts: mockQueryProducts };
+      mockQueryProducts.mockResolvedValue({ products: [], totalResults: 0 });
+
+      const realDateNow = Date.now;
+      try {
+        Date.now = jest.fn().mockReturnValue(0);
+        const { unmount } = renderHook(() => useProductRecommendations(product1.id));
+        await waitFor(() => expect(mockQueryProducts).toHaveBeenCalledTimes(1));
+        unmount();
+
+        // Advance time past TTL
+        Date.now = jest.fn().mockReturnValue(6 * 60 * 1000);
+        renderHook(() => useProductRecommendations(product1.id));
+        await waitFor(() => expect(mockQueryProducts).toHaveBeenCalledTimes(2));
+      } finally {
+        Date.now = realDateNow;
+      }
+    });
+  });
+
+  describe('Wix API failure — fallback to static', () => {
+    it('returns recommendations from static PRODUCTS on Wix error', async () => {
+      mockWixClient = { queryProducts: mockQueryProducts };
+      mockQueryProducts.mockRejectedValue(new Error('network error'));
+
+      const { result } = renderHook(() => useProductRecommendations(product1.id));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.recommendations.length).toBeGreaterThanOrEqual(0);
+    });
+
+    it('sets error field on Wix failure', async () => {
+      mockWixClient = { queryProducts: mockQueryProducts };
+      mockQueryProducts.mockRejectedValue(new Error('network error'));
+
+      const { result } = renderHook(() => useProductRecommendations(product1.id));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.error).not.toBeNull();
+    });
+
+    it('static fallback only returns same-category products', async () => {
+      mockWixClient = { queryProducts: mockQueryProducts };
+      mockQueryProducts.mockRejectedValue(new Error('timeout'));
+
+      const { result } = renderHook(() => useProductRecommendations(product1.id));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(
+        result.current.recommendations.every((p) => p.category === product1.category),
+      ).toBe(true);
+    });
+  });
+
+  describe('empty result', () => {
+    it('returns empty array when Wix returns no same-category products', async () => {
+      const otherProduct = PRODUCTS.find((p) => p.category !== product1.category)!;
+      mockWixClient = { queryProducts: mockQueryProducts };
+      mockQueryProducts.mockResolvedValue({ products: [otherProduct], totalResults: 1 });
+
+      const { result } = renderHook(() => useProductRecommendations(product1.id));
+      await waitFor(() => expect(result.current.isLoading).toBe(false));
+      expect(result.current.recommendations).toEqual([]);
+    });
+  });
+});

--- a/src/hooks/useProductRecommendations.ts
+++ b/src/hooks/useProductRecommendations.ts
@@ -1,0 +1,176 @@
+/**
+ * @module useProductRecommendations
+ *
+ * DB-driven product recommendation hook — cm-cm1 (Phase 2.2).
+ *
+ * Fetches related products by querying Wix CMS (or falling back to the
+ * static PRODUCTS catalog) filtered by same category and ±50% price range,
+ * then sorted by relevance score (category + fabric overlap + price proximity).
+ *
+ * Results are cached in memory for 5 minutes per productId.
+ */
+import { useState, useEffect, useRef } from 'react';
+import { PRODUCTS, type Product } from '@/data/products';
+import { useOptionalWixClient } from '@/services/wix/wixProvider';
+
+/** Cache TTL: 5 minutes in milliseconds. */
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+/** Maximum number of recommendations to return. */
+const MAX_RESULTS = 8;
+
+interface CacheEntry {
+  data: Product[];
+  expiresAt: number;
+}
+
+/** Module-level cache keyed by productId. Cleared between tests via clearRecommendationsCache(). */
+const recommendationsCache = new Map<string, CacheEntry>();
+
+/** Clears the in-memory cache. Intended for use in tests. */
+export function clearRecommendationsCache(): void {
+  recommendationsCache.clear();
+}
+
+/** Shape of the value returned by useProductRecommendations. */
+export interface ProductRecommendationsResult {
+  recommendations: Product[];
+  isLoading: boolean;
+  /** Non-null when Wix failed and results are from static fallback. */
+  error: string | null;
+}
+
+/**
+ * Compute a relevance score for a candidate product relative to the source.
+ * Higher score = more relevant.
+ *
+ * Scoring:
+ *  +10  same category
+ *  +1   per overlapping fabric option
+ *  +3   price within ±20%
+ *  +1   price within ±50%
+ */
+function relevanceScore(source: Product, candidate: Product): number {
+  let score = 0;
+  if (candidate.category === source.category) score += 10;
+  const sourceFabrics = new Set(source.fabricOptions);
+  for (const fabric of candidate.fabricOptions) {
+    if (sourceFabrics.has(fabric)) score += 1;
+  }
+  const priceDiff = Math.abs(candidate.price - source.price) / source.price;
+  if (priceDiff <= 0.2) score += 3;
+  else if (priceDiff <= 0.5) score += 1;
+  return score;
+}
+
+/**
+ * Filter and sort products relative to source using static PRODUCTS catalog.
+ * Returns up to MAX_RESULTS products in the same category within ±50% price.
+ */
+function getStaticRecommendations(source: Product): Product[] {
+  const minPrice = source.price * 0.5;
+  const maxPrice = source.price * 1.5;
+  return PRODUCTS.filter(
+    (p) => p.id !== source.id && p.category === source.category && p.price >= minPrice && p.price <= maxPrice,
+  )
+    .sort((a, b) => relevanceScore(source, b) - relevanceScore(source, a))
+    .slice(0, MAX_RESULTS);
+}
+
+/**
+ * Fetches product recommendations for a given product.
+ *
+ * Queries Wix CMS when a WixClient is available; falls back to the static
+ * PRODUCTS array on failure or when offline. Results are cached for 5 minutes.
+ *
+ * @param productId - The ID of the product to fetch recommendations for.
+ * @returns { recommendations, isLoading, error }
+ *
+ * @example
+ * const { recommendations, isLoading } = useProductRecommendations(product.id);
+ */
+export function useProductRecommendations(productId: string): ProductRecommendationsResult {
+  const [recommendations, setRecommendations] = useState<Product[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const wixClient = useOptionalWixClient();
+  const wixClientRef = useRef(wixClient);
+  wixClientRef.current = wixClient;
+
+  const mountedRef = useRef(true);
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    const source = PRODUCTS.find((p) => p.id === productId);
+
+    if (!source) {
+      setRecommendations([]);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+
+    // Serve from cache if still valid
+    const cached = recommendationsCache.get(productId);
+    if (cached && Date.now() < cached.expiresAt) {
+      setRecommendations(cached.data);
+      setIsLoading(false);
+      setError(null);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    (async () => {
+      const client = wixClientRef.current;
+      try {
+        let recs: Product[];
+        if (client) {
+          const minPrice = source.price * 0.5;
+          const maxPrice = source.price * 1.5;
+          const { products: wixProducts } = await client.queryProducts({ limit: 100 });
+          recs = wixProducts
+            .filter(
+              (p) =>
+                p.id !== source.id &&
+                p.category === source.category &&
+                p.price >= minPrice &&
+                p.price <= maxPrice,
+            )
+            .sort((a, b) => relevanceScore(source, b) - relevanceScore(source, a))
+            .slice(0, MAX_RESULTS);
+        } else {
+          recs = getStaticRecommendations(source);
+        }
+
+        recommendationsCache.set(productId, { data: recs, expiresAt: Date.now() + CACHE_TTL_MS });
+
+        if (mountedRef.current) {
+          setRecommendations(recs);
+          setIsLoading(false);
+          setError(null);
+        }
+      } catch {
+        // Wix unavailable — fall back to static catalog
+        const recs = getStaticRecommendations(source);
+        recommendationsCache.set(productId, { data: recs, expiresAt: Date.now() + CACHE_TTL_MS });
+        if (mountedRef.current) {
+          setRecommendations(recs);
+          setIsLoading(false);
+          setError('[useProductRecommendations] Wix fetch failed — showing local recommendations');
+        }
+      }
+    })();
+    // wixClient intentionally omitted — accessed via ref to prevent infinite loops
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [productId]);
+
+  return { recommendations, isLoading, error };
+}


### PR DESCRIPTION
## Summary
- New hook `useProductRecommendations(productId)` replaces static curation with DB-driven results
- Queries Wix CMS for products in same category within ±50% price range
- Sorts by relevance: category match + fabric option overlap + price proximity
- In-memory 5-min TTL cache per productId (no redundant API calls)
- Graceful fallback to static `PRODUCTS` catalog on Wix failure with `error` field set

## API
```ts
const { recommendations, isLoading, error } = useProductRecommendations(productId);
```

## Test plan
- [x] Invalid/empty productId → `recommendations: []`, `error: null`
- [x] Category match — returns only same-category products, excludes source
- [x] Price-range filter — in-range included; <50% and >150% excluded
- [x] Cache hit — second call within TTL skips Wix fetch (1 call total)
- [x] Cache expiry — refetch after TTL (mocked `Date.now`)
- [x] Wix failure → static fallback, `error` is non-null
- [x] Static fallback same-category only
- [x] Empty result when Wix returns no category matches
- 13/13 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)