### PR TITLE
feat(cm-a31): LoyaltyCard component + useLoyaltyCard hook

### DIFF
--- a/src/components/LoyaltyCard.tsx
+++ b/src/components/LoyaltyCard.tsx
@@ -1,0 +1,137 @@
+/**
+ * @module LoyaltyCard
+ *
+ * Displays the current member's loyalty status:
+ *   - Points balance
+ *   - Tier badge (Bronze / Silver / Gold)
+ *   - Progress bar toward next tier
+ *   - "X points to <NextTier>" or "You've reached Gold!" text
+ *
+ * Returns null (renders nothing) when points = 0 and hasActivity = false.
+ *
+ * Tier thresholds per CF-yq80:
+ *   Bronze 0-499  (→ Silver at 500)
+ *   Silver 500-1499 (→ Gold at 1500)
+ *   Gold 1500+
+ *
+ * cm-a31
+ */
+import React from 'react';
+import { StyleSheet, View, Text } from 'react-native';
+import { useTheme } from '@/theme';
+import { LoyaltyBadge } from './LoyaltyBadge';
+import type { LoyaltyCardData } from '@/hooks/useLoyaltyCard';
+
+interface Props extends LoyaltyCardData {
+  testID?: string;
+}
+
+const NEXT_TIER_LABEL: Record<string, string | null> = {
+  bronze: 'Silver',
+  silver: 'Gold',
+  gold: null,
+};
+
+/** Loyalty points card with tier badge, progress bar, and next-tier prompt. */
+export function LoyaltyCard({ points, tier, nextTierThreshold, progressPercent, hasActivity, testID }: Props) {
+  const { colors, spacing, borderRadius, typography } = useTheme();
+
+  // Hide if no points and no prior activity
+  if (points === 0 && !hasActivity) return null;
+
+  const nextTierLabel = NEXT_TIER_LABEL[tier] ?? null;
+  const pointsToNext = Math.max(0, nextTierThreshold - points);
+  const nextTierText = nextTierLabel
+    ? `${pointsToNext} points to ${nextTierLabel}`
+    : "You've reached Gold!";
+
+  return (
+    <View
+      style={[
+        styles.card,
+        {
+          backgroundColor: colors.sandBase,
+          borderColor: colors.sandDark,
+          borderRadius: borderRadius.card,
+          padding: spacing.md,
+        },
+      ]}
+      testID={testID ?? 'loyalty-card'}
+      accessibilityRole="none"
+    >
+      {/* Header: points + tier badge */}
+      <View style={styles.header}>
+        <View>
+          <Text
+            style={[styles.pointsLabel, { color: colors.espressoLight, fontFamily: typography.bodyFamily }]}
+          >
+            Your Points
+          </Text>
+          <Text
+            style={[styles.pointsValue, { color: colors.espresso, fontFamily: typography.headingFamily }]}
+            testID="loyalty-points"
+          >
+            {points.toLocaleString()}
+          </Text>
+        </View>
+        <LoyaltyBadge tier={tier} testID={`loyalty-badge-${tier}`} />
+      </View>
+
+      {/* Progress bar */}
+      <View style={[styles.progressTrack, { backgroundColor: colors.sandDark, borderRadius: borderRadius.pill }]} testID="loyalty-progress-track">
+        <View
+          style={[
+            styles.progressFill,
+            {
+              width: `${progressPercent}%`,
+              backgroundColor: tier === 'gold' ? '#D4AF37' : tier === 'silver' ? '#A8A9AD' : '#CD7F32',
+              borderRadius: borderRadius.pill,
+            },
+          ]}
+          testID="loyalty-progress-bar"
+        />
+      </View>
+
+      {/* Next-tier text */}
+      <Text
+        style={[styles.nextTierText, { color: colors.espressoLight, fontFamily: typography.bodyFamily }]}
+        testID="loyalty-next-tier-text"
+      >
+        {nextTierText}
+      </Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    borderWidth: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'flex-start',
+    marginBottom: 12,
+  },
+  pointsLabel: {
+    fontSize: 12,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    marginBottom: 2,
+  },
+  pointsValue: {
+    fontSize: 32,
+    fontWeight: '700',
+  },
+  progressTrack: {
+    height: 8,
+    overflow: 'hidden',
+    marginBottom: 8,
+  },
+  progressFill: {
+    height: '100%',
+  },
+  nextTierText: {
+    fontSize: 13,
+  },
+});

--- a/src/components/__tests__/LoyaltyCard.test.tsx
+++ b/src/components/__tests__/LoyaltyCard.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * @module LoyaltyCard.test
+ *
+ * Component tests for LoyaltyCard — cm-a31 / CF-yq80.
+ * Tests tier display, progress bar, next-tier text, hidden state, and accessibility.
+ *
+ * Tier thresholds: Bronze 0-499, Silver 500-1499, Gold 1500+
+ */
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { ThemeProvider } from '@/theme/ThemeProvider';
+import { LoyaltyCard } from '../LoyaltyCard';
+
+function renderCard(overrides: Partial<React.ComponentProps<typeof LoyaltyCard>> = {}) {
+  const props = {
+    points: 250,
+    tier: 'bronze' as const,
+    nextTierThreshold: 500,
+    progressPercent: 50,
+    hasActivity: true,
+    ...overrides,
+  };
+  return render(
+    <ThemeProvider>
+      <LoyaltyCard {...props} />
+    </ThemeProvider>,
+  );
+}
+
+describe('LoyaltyCard', () => {
+  describe('hidden state', () => {
+    it('returns null when points=0 and hasActivity=false', () => {
+      const { queryByTestId } = renderCard({ points: 0, hasActivity: false, progressPercent: 0 });
+      expect(queryByTestId('loyalty-card')).toBeNull();
+    });
+
+    it('renders when points=0 but hasActivity=true', () => {
+      const { getByTestId } = renderCard({ points: 0, hasActivity: true, progressPercent: 0 });
+      expect(getByTestId('loyalty-card')).toBeTruthy();
+    });
+
+    it('renders when points>0', () => {
+      const { getByTestId } = renderCard({ points: 250 });
+      expect(getByTestId('loyalty-card')).toBeTruthy();
+    });
+
+    it('renders when points=1500 (Gold)', () => {
+      const { getByTestId } = renderCard({ points: 1500, tier: 'gold', nextTierThreshold: 1500, progressPercent: 100 });
+      expect(getByTestId('loyalty-card')).toBeTruthy();
+    });
+  });
+
+  describe('tier badge', () => {
+    it('shows Bronze tier badge', () => {
+      const { getByTestId } = renderCard({ tier: 'bronze' });
+      expect(getByTestId('loyalty-badge-bronze')).toBeTruthy();
+    });
+
+    it('shows Silver tier badge', () => {
+      const { getByTestId } = renderCard({ tier: 'silver', points: 750, nextTierThreshold: 1500, progressPercent: 50 });
+      expect(getByTestId('loyalty-badge-silver')).toBeTruthy();
+    });
+
+    it('shows Gold tier badge', () => {
+      const { getByTestId } = renderCard({ tier: 'gold', points: 1500, nextTierThreshold: 1500, progressPercent: 100 });
+      expect(getByTestId('loyalty-badge-gold')).toBeTruthy();
+    });
+
+    it('Bronze badge has accessible label', () => {
+      const { getByTestId } = renderCard({ tier: 'bronze' });
+      expect(getByTestId('loyalty-badge-bronze').props.accessibilityLabel).toBe('Bronze tier');
+    });
+  });
+
+  describe('points display', () => {
+    it('shows correct points count', () => {
+      const { getByTestId } = renderCard({ points: 250 });
+      expect(getByTestId('loyalty-points').props.children).toBe('250');
+    });
+
+    it('shows 0 points when hasActivity but points=0', () => {
+      const { getByTestId } = renderCard({ points: 0, hasActivity: true });
+      expect(getByTestId('loyalty-points').props.children).toBe('0');
+    });
+
+    it('testID loyalty-points is present', () => {
+      const { getByTestId } = renderCard();
+      expect(getByTestId('loyalty-points')).toBeTruthy();
+    });
+  });
+
+  describe('progress bar', () => {
+    it('testID loyalty-progress-bar is present', () => {
+      const { getByTestId } = renderCard();
+      expect(getByTestId('loyalty-progress-bar')).toBeTruthy();
+    });
+
+    it('progress bar width is 0% at 0 progressPercent', () => {
+      const { getByTestId } = renderCard({ progressPercent: 0 });
+      const bar = getByTestId('loyalty-progress-bar');
+      const width = Array.isArray(bar.props.style)
+        ? bar.props.style.find((s: Record<string, unknown>) => s?.width !== undefined)?.width
+        : bar.props.style?.width;
+      expect(width).toBe('0%');
+    });
+
+    it('progress bar width is 50% at 50 progressPercent', () => {
+      const { getByTestId } = renderCard({ progressPercent: 50 });
+      const bar = getByTestId('loyalty-progress-bar');
+      const width = Array.isArray(bar.props.style)
+        ? bar.props.style.find((s: Record<string, unknown>) => s?.width !== undefined)?.width
+        : bar.props.style?.width;
+      expect(width).toBe('50%');
+    });
+
+    it('progress bar width is 99% at 99 progressPercent', () => {
+      const { getByTestId } = renderCard({ progressPercent: 99 });
+      const bar = getByTestId('loyalty-progress-bar');
+      const width = Array.isArray(bar.props.style)
+        ? bar.props.style.find((s: Record<string, unknown>) => s?.width !== undefined)?.width
+        : bar.props.style?.width;
+      expect(width).toBe('99%');
+    });
+
+    it('progress bar width is 100% for Gold', () => {
+      const { getByTestId } = renderCard({ tier: 'gold', points: 1500, nextTierThreshold: 1500, progressPercent: 100 });
+      const bar = getByTestId('loyalty-progress-bar');
+      const width = Array.isArray(bar.props.style)
+        ? bar.props.style.find((s: Record<string, unknown>) => s?.width !== undefined)?.width
+        : bar.props.style?.width;
+      expect(width).toBe('100%');
+    });
+  });
+
+  describe('next-tier text', () => {
+    it('testID loyalty-next-tier-text is present', () => {
+      const { getByTestId } = renderCard();
+      expect(getByTestId('loyalty-next-tier-text')).toBeTruthy();
+    });
+
+    it('shows "250 points to Silver" for Bronze at 250 pts', () => {
+      const { getByTestId } = renderCard({ tier: 'bronze', points: 250, nextTierThreshold: 500 });
+      expect(getByTestId('loyalty-next-tier-text').props.children).toBe('250 points to Silver');
+    });
+
+    it('shows "750 points to Gold" for Silver at 750 pts', () => {
+      const { getByTestId } = renderCard({ tier: 'silver', points: 750, nextTierThreshold: 1500 });
+      expect(getByTestId('loyalty-next-tier-text').props.children).toBe('750 points to Gold');
+    });
+
+    it('shows "You\'ve reached Gold!" for Gold tier', () => {
+      const { getByTestId } = renderCard({ tier: 'gold', points: 1500, nextTierThreshold: 1500, progressPercent: 100 });
+      expect(getByTestId('loyalty-next-tier-text').props.children).toBe("You've reached Gold!");
+    });
+
+    it('shows "0 points to Silver" when at threshold', () => {
+      const { getByTestId } = renderCard({ tier: 'bronze', points: 500, nextTierThreshold: 500 });
+      expect(getByTestId('loyalty-next-tier-text').props.children).toBe('0 points to Silver');
+    });
+  });
+
+  describe('accessibility / testIDs', () => {
+    it('has testID loyalty-card', () => {
+      const { getByTestId } = renderCard();
+      expect(getByTestId('loyalty-card')).toBeTruthy();
+    });
+
+    it('accepts custom testID', () => {
+      const { getByTestId } = renderCard({ testID: 'my-card' });
+      expect(getByTestId('my-card')).toBeTruthy();
+    });
+
+    it('progress track is present', () => {
+      const { getByTestId } = renderCard();
+      expect(getByTestId('loyalty-progress-track')).toBeTruthy();
+    });
+  });
+});

--- a/src/hooks/__tests__/useLoyaltyCard.test.ts
+++ b/src/hooks/__tests__/useLoyaltyCard.test.ts
@@ -1,0 +1,112 @@
+/**
+ * @module useLoyaltyCard.test
+ *
+ * Hook tests for useLoyaltyCard — cm-a31 / CF-yq80.
+ * Covers API success, failure fallback, null memberId, null fields, and hasActivity.
+ */
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { useLoyaltyCard } from '../useLoyaltyCard';
+
+const mockGetLoyaltyData = jest.fn();
+const mockGetCurrentMember = jest.fn();
+
+jest.mock('@/services/wix/wixClientSingleton', () => ({
+  getWixClientSingleton: () => ({ getLoyaltyData: mockGetLoyaltyData }),
+}));
+
+jest.mock('@/services/wix/wixAuth', () => ({
+  WixAuthService: jest.fn().mockImplementation(() => ({
+    getCurrentMember: mockGetCurrentMember,
+  })),
+}));
+
+describe('useLoyaltyCard', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetCurrentMember.mockResolvedValue({ id: 'member-123' });
+  });
+
+  it('starts in loading state', () => {
+    mockGetLoyaltyData.mockResolvedValue({ points: 0, tier: 'Bronze', nextTierThreshold: 500, progressPercent: 0 });
+    const { result } = renderHook(() => useLoyaltyCard());
+    expect(result.current.isLoading).toBe(true);
+  });
+
+  it('returns loyalty data after fetch', async () => {
+    mockGetLoyaltyData.mockResolvedValue({ points: 250, tier: 'Bronze', nextTierThreshold: 500, progressPercent: 50 });
+    const { result } = renderHook(() => useLoyaltyCard());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.points).toBe(250);
+    expect(result.current.tier).toBe('bronze');
+    expect(result.current.progressPercent).toBe(50);
+  });
+
+  it('normalizes tier to lowercase', async () => {
+    mockGetLoyaltyData.mockResolvedValue({ points: 750, tier: 'Silver', nextTierThreshold: 1500, progressPercent: 50 });
+    const { result } = renderHook(() => useLoyaltyCard());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.tier).toBe('silver');
+  });
+
+  it('hasActivity=false when points=0 and totalEarned=0', async () => {
+    mockGetLoyaltyData.mockResolvedValue({ points: 0, tier: 'Bronze', nextTierThreshold: 500, progressPercent: 0, totalEarned: 0 });
+    const { result } = renderHook(() => useLoyaltyCard());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.hasActivity).toBe(false);
+  });
+
+  it('hasActivity=true when points=0 but totalEarned>0', async () => {
+    mockGetLoyaltyData.mockResolvedValue({ points: 0, tier: 'Bronze', nextTierThreshold: 500, progressPercent: 0, totalEarned: 100 });
+    const { result } = renderHook(() => useLoyaltyCard());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.hasActivity).toBe(true);
+  });
+
+  it('hasActivity=true when points>0', async () => {
+    mockGetLoyaltyData.mockResolvedValue({ points: 250, tier: 'Bronze', nextTierThreshold: 500, progressPercent: 50 });
+    const { result } = renderHook(() => useLoyaltyCard());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.hasActivity).toBe(true);
+  });
+
+  it('sets error and safe defaults on API failure', async () => {
+    mockGetLoyaltyData.mockRejectedValue(new Error('network error'));
+    const { result } = renderHook(() => useLoyaltyCard());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.error).not.toBeNull();
+    expect(result.current.points).toBe(0);
+    expect(result.current.tier).toBe('bronze');
+    expect(result.current.hasActivity).toBe(false);
+  });
+
+  it('returns safe defaults when memberId is null', async () => {
+    mockGetCurrentMember.mockResolvedValue(null);
+    const { result } = renderHook(() => useLoyaltyCard());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.points).toBe(0);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('handles null/missing points field gracefully', async () => {
+    mockGetLoyaltyData.mockResolvedValue({ tier: 'Bronze', nextTierThreshold: 500, progressPercent: 0 });
+    const { result } = renderHook(() => useLoyaltyCard());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.points).toBe(0);
+  });
+
+  it('clamps progressPercent to 0-100', async () => {
+    mockGetLoyaltyData.mockResolvedValue({ points: 200, tier: 'Bronze', nextTierThreshold: 500, progressPercent: 150 });
+    const { result } = renderHook(() => useLoyaltyCard());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.progressPercent).toBe(100);
+  });
+
+  it('refresh re-fetches data', async () => {
+    mockGetLoyaltyData.mockResolvedValue({ points: 250, tier: 'Bronze', nextTierThreshold: 500, progressPercent: 50 });
+    const { result } = renderHook(() => useLoyaltyCard());
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(mockGetLoyaltyData).toHaveBeenCalledTimes(1);
+    await act(async () => { await result.current.refresh(); });
+    expect(mockGetLoyaltyData).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/hooks/useLoyaltyCard.ts
+++ b/src/hooks/useLoyaltyCard.ts
@@ -1,0 +1,104 @@
+/**
+ * @module useLoyaltyCard
+ *
+ * Fetches the current member's loyalty data from GET /_functions/loyalty/{memberId}.
+ * Used by LoyaltyCard to display tier, points, progress bar, and next-tier text.
+ *
+ * Tier thresholds (CF-yq80 Phase 2.3):
+ *   Bronze  0–499 pts   → next threshold 500
+ *   Silver  500–1499    → next threshold 1500
+ *   Gold    1500+       → fully earned
+ *
+ * cm-a31
+ */
+import { useState, useEffect, useCallback } from 'react';
+import { getWixClientSingleton } from '@/services/wix/wixClientSingleton';
+import { WixAuthService } from '@/services/wix/wixAuth';
+import type { LoyaltyTier } from '@/hooks/useLoyalty';
+
+export interface LoyaltyCardData {
+  points: number;
+  tier: LoyaltyTier;
+  nextTierThreshold: number;
+  progressPercent: number;
+  /** True when the member has had any activity (points earned, even if spent back to 0). */
+  hasActivity: boolean;
+}
+
+export interface UseLoyaltyCardResult extends LoyaltyCardData {
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+const SAFE_DEFAULTS: LoyaltyCardData = {
+  points: 0,
+  tier: 'bronze',
+  nextTierThreshold: 500,
+  progressPercent: 0,
+  hasActivity: false,
+};
+
+function normalizeTier(raw: string): LoyaltyTier {
+  const lower = raw?.toLowerCase() ?? 'bronze';
+  if (lower === 'silver' || lower === 'gold') return lower;
+  return 'bronze';
+}
+
+export function useLoyaltyCard(): UseLoyaltyCardResult {
+  const [data, setData] = useState<LoyaltyCardData>(SAFE_DEFAULTS);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const auth = new WixAuthService();
+      const member = await auth.getCurrentMember();
+      const memberId = member?.id;
+      if (!memberId) {
+        setData(SAFE_DEFAULTS);
+        return;
+      }
+
+      const wixClient = getWixClientSingleton();
+      if (!wixClient) {
+        setError('[useLoyaltyCard] Wix service unavailable');
+        setData(SAFE_DEFAULTS);
+        return;
+      }
+
+      const raw = await wixClient.getLoyaltyData(memberId);
+      const points = typeof raw.points === 'number' ? raw.points : 0;
+      const totalEarned = typeof raw.totalEarned === 'number' ? raw.totalEarned : 0;
+      const hasActivity = raw.hasActivity ?? (points > 0 || totalEarned > 0);
+
+      setData({
+        points,
+        tier: normalizeTier(raw.tier),
+        nextTierThreshold: typeof raw.nextTierThreshold === 'number' ? raw.nextTierThreshold : 500,
+        progressPercent: typeof raw.progressPercent === 'number'
+          ? Math.min(100, Math.max(0, raw.progressPercent))
+          : 0,
+        hasActivity,
+      });
+    } catch (err) {
+      console.error('[useLoyaltyCard] Failed to fetch loyalty data:', err);
+      setError(err instanceof Error ? err.message : String(err));
+      setData(SAFE_DEFAULTS);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const refresh = useCallback(async () => {
+    await fetchData();
+  }, [fetchData]);
+
+  return { ...data, isLoading, error, refresh };
+}

--- a/src/services/wix/wixClient.ts
+++ b/src/services/wix/wixClient.ts
@@ -816,6 +816,19 @@ export class WixClient {
     return this.get<Record<string, unknown>>('/members/v1/members/' + encodeURIComponent(memberId));
   }
 
+  // ── Loyalty (Phase 2.3 / CF-yq80) ───────────────────────────
+
+  async getLoyaltyData(memberId: string): Promise<{
+    points: number;
+    tier: string;
+    nextTierThreshold: number;
+    progressPercent: number;
+    totalEarned?: number;
+    hasActivity?: boolean;
+  }> {
+    return this.get(`/_functions/loyalty/${encodeURIComponent(memberId)}`);
+  }
+
   // ── Wix Data Mutations ──────────────────────────────────────
 
   async insertDataItem(


### PR DESCRIPTION
## Summary
- New `useLoyaltyCard` hook fetches from `GET /_functions/loyalty/{memberId}` via `wixClient.getLoyaltyData()`; normalizes tier, derives `hasActivity`, clamps `progressPercent` 0–100, safe defaults on failure
- New `LoyaltyCard` component: tier badge, points display, progress bar, next-tier text or "You've reached Gold!", hidden when `points === 0 && !hasActivity`
- Added `getLoyaltyData(memberId)` to `WixClient` for clean API boundary

## Tests — 35/35 passing
- 24 `LoyaltyCard` component tests (tier badges, progress widths, next-tier text, accessibility, hidden state)
- 11 `useLoyaltyCard` hook tests (loading, data fetch, tier normalization, hasActivity derivation, API failure, null memberId, progressPercent clamping, refresh)

## Test plan
- [ ] `npx jest src/components/__tests__/LoyaltyCard.test.tsx src/hooks/__tests__/useLoyaltyCard.test.ts` → 35/35 green
- [ ] Bronze/Silver/Gold tiers render correct badges and thresholds
- [ ] Gold tier shows "You've reached Gold!" instead of next-tier prompt
- [ ] `points === 0 && !hasActivity` → component hidden (returns null)
- [ ] API failure → error state, safe defaults (0 pts, Bronze, no crash)

Closes cm-a31

🤖 Generated with [Claude Code](https://claude.com/claude-code)