### PR TITLE
fix(cm-3jz): replace useNavigationState/useNavigation with navigationRef props in MiniCartDrawerHost

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,5 +1,5 @@
 import 'react-native-url-polyfill/auto';
-import React, { useCallback, useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import { View, StyleSheet } from 'react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
@@ -65,7 +65,13 @@ const preventHidePromise = SplashScreen.preventAutoHideAsync();
 prefetchCriticalData();
 
 function App() {
-  const { navigationRef, onStateChange, onReady: onScreenTrackingReady } = useScreenTracking();
+  const { navigationRef, onStateChange: trackState, onReady: onScreenTrackingReady } = useScreenTracking();
+  const [currentRoute, setCurrentRoute] = useState<string | undefined>();
+
+  const onStateChange = useCallback(() => {
+    trackState();
+    setCurrentRoute(navigationRef.getCurrentRoute()?.name);
+  }, [trackState, navigationRef]);
   const forceUpdate = useForceUpdate();
 
   // Defer non-critical service init to after first render for faster cold start
@@ -140,7 +146,7 @@ function App() {
                                 <DeepLinkProvider>
                                   <OfflineBanner />
                                   <AppNavigator />
-                                  <MiniCartDrawerHost />
+                                  <MiniCartDrawerHost navigationRef={navigationRef} currentRoute={currentRoute} />
                                   <ForceUpdateModal
                                     visible={forceUpdate.visible}
                                     required={forceUpdate.required}

--- a/src/navigation/MiniCartDrawerHost.tsx
+++ b/src/navigation/MiniCartDrawerHost.tsx
@@ -2,37 +2,41 @@
  * @module MiniCartDrawerHost
  *
  * Renders the MiniCartDrawer at the root navigation level, suppressed on
- * the Checkout screen. Consumes useMiniCartDrawer() for open/close state
- * and navigates to Checkout when the drawer's CTA is pressed.
+ * the Checkout screen. Receives navigationRef and currentRoute as props
+ * (instead of useNavigation/useNavigationState) so it can be rendered as a
+ * sibling of AppNavigator without requiring NavigationStateListenerContext.
+ *
+ * cm-3jz: useNavigation + useNavigationState both throw
+ * "Couldn't get the navigation state" in React Navigation v7 when called
+ * outside a navigator screen. Using the navigationRef directly avoids this.
  */
 import React, { useCallback } from 'react';
-import { useNavigationState, useNavigation } from '@react-navigation/native';
-import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
+import type { NavigationContainerRef } from '@react-navigation/native';
 import { MiniCartDrawer } from '@/components/MiniCartDrawer';
 import { useMiniCartDrawer } from '@/hooks/useMiniCartDrawer';
 import type { RootStackParamList } from './AppNavigator';
+
+interface Props {
+  /** The navigation container ref — used to call navigate() without hooks. */
+  navigationRef: NavigationContainerRef<RootStackParamList>;
+  /** Current top-level route name, tracked by App.tsx via onStateChange. */
+  currentRoute?: string;
+}
 
 /**
  * Root-level host that renders the slide-up mini-cart on all screens except
  * Checkout. Must be rendered inside NavigationContainer + MiniCartDrawerProvider.
  */
-export function MiniCartDrawerHost() {
+export function MiniCartDrawerHost({ navigationRef, currentRoute }: Props) {
   const { isOpen, close } = useMiniCartDrawer();
-  const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
-
-  // Determine current top-level route name to suppress drawer on Checkout
-  const currentRouteName = useNavigationState((state) => {
-    if (!state || !state.routes || state.routes.length === 0) return undefined;
-    return state.routes[state.index]?.name;
-  });
 
   const handleCheckout = useCallback(() => {
     close();
-    navigation.navigate('Checkout');
-  }, [close, navigation]);
+    navigationRef.navigate('Checkout');
+  }, [close, navigationRef]);
 
-  // Do not render on Checkout screen
-  if (currentRouteName === 'Checkout') return null;
+  // Suppress drawer on Checkout screen
+  if (currentRoute === 'Checkout') return null;
 
   return (
     <MiniCartDrawer

--- a/src/navigation/__tests__/MiniCartDrawerHost.test.tsx
+++ b/src/navigation/__tests__/MiniCartDrawerHost.test.tsx
@@ -1,20 +1,39 @@
 /**
  * @module MiniCartDrawerHost.test
  *
- * Tests for MiniCartDrawerHost navigation integration — cm-jec.
- * Verifies that pressing Checkout calls close() then navigate('Checkout').
+ * Tests for MiniCartDrawerHost navigation integration — cm-3jz.
+ * Verifies checkout navigation, close ordering, and Checkout-screen suppression.
+ * Uses navigationRef prop instead of useNavigation/useNavigationState hooks
+ * to avoid the NavigationStateListenerContext crash outside a navigator (RN v7).
  */
 import React from 'react';
 import { render, fireEvent } from '@testing-library/react-native';
 import { MiniCartDrawerHost } from '../MiniCartDrawerHost';
 import { ThemeProvider } from '@/theme/ThemeProvider';
+import type { NavigationContainerRef } from '@react-navigation/native';
+import type { RootStackParamList } from '../AppNavigator';
 
 const mockNavigate = jest.fn();
-jest.mock('@react-navigation/native', () => ({
-  useNavigation: () => ({ navigate: mockNavigate }),
-  useNavigationState: (selector: (state: unknown) => unknown) =>
-    selector({ routes: [{ name: 'Home' }], index: 0 }),
-}));
+
+function makeNavRef(
+  overrides?: Partial<NavigationContainerRef<RootStackParamList>>,
+): NavigationContainerRef<RootStackParamList> {
+  return {
+    navigate: mockNavigate,
+    goBack: jest.fn(),
+    reset: jest.fn(),
+    dispatch: jest.fn(),
+    setParams: jest.fn(),
+    canGoBack: jest.fn(() => false),
+    getState: jest.fn(),
+    getCurrentRoute: jest.fn(() => ({ key: 'Home-1', name: 'Tabs' as const })),
+    getCurrentOptions: jest.fn(),
+    isReady: jest.fn(() => true),
+    addListener: jest.fn(),
+    removeListener: jest.fn(),
+    ...overrides,
+  } as unknown as NavigationContainerRef<RootStackParamList>;
+}
 
 const mockClose = jest.fn();
 const mockUseMiniCartDrawer = jest.fn();
@@ -38,10 +57,13 @@ jest.mock('@/components/MiniCartDrawer', () => ({
   },
 }));
 
-function renderHost() {
+function renderHost(
+  navRef: NavigationContainerRef<RootStackParamList> = makeNavRef(),
+  currentRoute?: string,
+) {
   return render(
     <ThemeProvider>
-      <MiniCartDrawerHost />
+      <MiniCartDrawerHost navigationRef={navRef} currentRoute={currentRoute} />
     </ThemeProvider>,
   );
 }
@@ -72,6 +94,33 @@ describe('MiniCartDrawerHost', () => {
       const { getByTestId } = renderHost();
       fireEvent.press(getByTestId('mock-checkout-btn'));
       expect(callOrder).toEqual(['close', 'navigate']);
+    });
+  });
+
+  describe('Checkout screen suppression', () => {
+    it('does not render drawer when currentRoute is Checkout', () => {
+      const { queryByTestId } = renderHost(makeNavRef(), 'Checkout');
+      expect(queryByTestId('mock-mini-cart-drawer')).toBeNull();
+    });
+
+    it('renders drawer when currentRoute is not Checkout', () => {
+      const { getByTestId } = renderHost(makeNavRef(), 'Tabs');
+      expect(getByTestId('mock-mini-cart-drawer')).toBeTruthy();
+    });
+
+    it('renders drawer when currentRoute is undefined', () => {
+      const { getByTestId } = renderHost(makeNavRef(), undefined);
+      expect(getByTestId('mock-mini-cart-drawer')).toBeTruthy();
+    });
+  });
+
+  describe('no navigation hook dependency', () => {
+    it('renders without useNavigation or useNavigationState context (no navigator wrapper needed)', () => {
+      // This test verifies the fix for cm-3jz: the component must render
+      // without NavigationStateListenerContext (i.e., outside a navigator).
+      // The previous implementation crashed here because useNavigationState
+      // threw "Couldn't get the navigation state."
+      expect(() => renderHost()).not.toThrow();
     });
   });
 });


### PR DESCRIPTION
## Problem
`MiniCartDrawerHost` calls `useNavigation()` and `useNavigationState()` but renders as a sibling of `AppNavigator` — inside `NavigationContainer` but outside any navigator screen. In React Navigation v7, `useNavigationState` requires `NavigationStateListenerContext` which is only provided inside a navigator, not at the container sibling level. This throws `"Couldn't get the navigation state. Is your component inside a navigator?"` on every app launch, crashing the entire app.

Confirmed via `node_modules/@react-navigation/core/lib/module/useNavigationState.js` — the hook immediately throws if `NavigationStateListenerContext` is null.

## Fix
- `MiniCartDrawerHost` now accepts `navigationRef` and `currentRoute` as props instead of calling navigation hooks directly
- `App.tsx` tracks the current route name via the existing `onStateChange` callback (`navigationRef.getCurrentRoute()?.name`) and passes it down
- No new hook dependencies — uses the `NavigationContainerRef` already available in `App.tsx`

## Test Plan
- [ ] 7 tests in `MiniCartDrawerHost.test.tsx` all pass (checkout press, route suppression, no-context regression)
- [ ] `__tests__/App.test.tsx` 8 tests pass
- [ ] App launches on iOS Simulator without crash

🤖 Generated with [Claude Code](https://claude.ai/code)