### PR TITLE
feat(cm-12g): add sku and variantId to CartItem for Wix lineItem alignment

### DIFF
--- a/src/hooks/__tests__/useCart.test.tsx
+++ b/src/hooks/__tests__/useCart.test.tsx
@@ -1,7 +1,13 @@
 import React from 'react';
 import { Text, TouchableOpacity, View } from 'react-native';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
-import { CartProvider, useCart, mergeCartItems, type CartItem } from '../useCart';
+import {
+  CartProvider,
+  useCart,
+  mergeCartItems,
+  serverLineItemToCartItem,
+  type CartItem,
+} from '../useCart';
 import { AuthContext } from '@/hooks/useAuth';
 import { ConnectivityProvider } from '../useConnectivity';
 import { FUTON_MODELS, FABRICS } from '@/data/futons';
@@ -1039,6 +1045,88 @@ describe('Computed values', () => {
     fireEvent.press(getByTestId('add-asheville-linen-2')); // qty 2
     fireEvent.press(getByTestId('add-blueridge-blue')); // qty 1
     expect(getByTestId('item-count').props.children).toBe(3);
+  });
+});
+
+describe('CartItem sku + variantId fields (cm-12g)', () => {
+  const { isWixConfigured } = require('@/services/wix/config');
+
+  beforeEach(() => {
+    (isWixConfigured as jest.Mock).mockReturnValue(true);
+    mockGetCart.mockClear();
+  });
+
+  it('serverLineItemToCartItem preserves variantId from catalogReference.options', () => {
+    const variantId = FABRICS[2].id;
+    const item = serverLineItemToCartItem({
+      _id: 'wix-variant',
+      catalogReference: {
+        catalogItemId: FUTON_MODELS[0].id,
+        appId: 'wix-stores',
+        options: { variantId },
+      },
+      quantity: 1,
+    });
+    expect(item).not.toBeNull();
+    expect(item?.variantId).toBe(variantId);
+  });
+
+  it('serverLineItemToCartItem sets variantId to undefined when options has no variantId', () => {
+    const item = serverLineItemToCartItem({
+      _id: 'wix-no-variant',
+      catalogReference: {
+        catalogItemId: FUTON_MODELS[0].id,
+        appId: 'wix-stores',
+        options: {},
+      },
+      quantity: 1,
+    });
+    expect(item).not.toBeNull();
+    expect(item?.variantId).toBeUndefined();
+  });
+
+  it('serverLineItemToCartItem populates sku from lineItem.sku when present', () => {
+    const item = serverLineItemToCartItem({
+      _id: 'wix-sku',
+      catalogReference: {
+        catalogItemId: FUTON_MODELS[0].id,
+        appId: 'wix-stores',
+        options: { variantId: FABRICS[0].id },
+      },
+      quantity: 1,
+      sku: 'CF-ASH-LIN-001',
+    });
+    expect(item).not.toBeNull();
+    expect(item?.sku).toBe('CF-ASH-LIN-001');
+  });
+
+  it('serverLineItemToCartItem leaves sku undefined when lineItem.sku is absent', () => {
+    const item = serverLineItemToCartItem({
+      _id: 'wix-no-sku',
+      catalogReference: {
+        catalogItemId: FUTON_MODELS[0].id,
+        appId: 'wix-stores',
+        options: { variantId: FABRICS[0].id },
+      },
+      quantity: 1,
+    });
+    expect(item).not.toBeNull();
+    expect(item?.sku).toBeUndefined();
+  });
+
+  it('CartItem interface accepts sku and variantId fields without TypeScript error', () => {
+    // Compile-time check: constructing a CartItem with sku+variantId is valid
+    const item: import('@/hooks/useCart').CartItem = {
+      id: `${FUTON_MODELS[0].id}:${FABRICS[0].id}`,
+      model: FUTON_MODELS[0],
+      fabric: FABRICS[0],
+      quantity: 1,
+      unitPrice: FUTON_MODELS[0].basePrice,
+      sku: 'CF-TEST-001',
+      variantId: FABRICS[0].id,
+    };
+    expect(item.sku).toBe('CF-TEST-001');
+    expect(item.variantId).toBe(FABRICS[0].id);
   });
 });
 

--- a/src/hooks/useCart.tsx
+++ b/src/hooks/useCart.tsx
@@ -44,6 +44,8 @@ export interface CartItem {
   quantity: number;
   unitPrice: number; // basePrice + fabric.price
   imageUrl?: string; // CDN image URL (~150px); absent for local-only items
+  sku?: string; // Wix catalog SKU; absent for local-only items
+  variantId?: string; // Wix variant ID (from catalogReference.options.variantId); absent for local-only items
 }
 
 /** Internal state managed by the cart reducer. */
@@ -139,15 +141,17 @@ const CART_STORAGE_KEY = 'cfutons_cart';
 /**
  * Convert a Wix server cart line item to a local CartItem, if the
  * referenced product and variant exist in the local catalog.
+ *
+ * @internal Exported for unit testing only.
  */
-function serverLineItemToCartItem(lineItem: WixCartLineItem): CartItem | null {
+export function serverLineItemToCartItem(lineItem: WixCartLineItem): CartItem | null {
   const modelId = lineItem.catalogReference.catalogItemId;
-  const fabricId = lineItem.catalogReference.options?.variantId;
+  const variantId = lineItem.catalogReference.options?.variantId;
 
   const model = FUTON_MODELS.find((m) => m.id === modelId);
   if (!model) return null;
 
-  const fabric = fabricId ? FABRICS.find((f) => f.id === fabricId) : FABRICS[0];
+  const fabric = variantId ? FABRICS.find((f) => f.id === variantId) : FABRICS[0];
   if (!fabric) return null;
 
   return {
@@ -157,6 +161,8 @@ function serverLineItemToCartItem(lineItem: WixCartLineItem): CartItem | null {
     fabricName: fabric.name,
     quantity: Math.min(10, Math.max(1, lineItem.quantity)),
     unitPrice: model.basePrice + fabric.price,
+    ...(lineItem.sku !== undefined ? { sku: lineItem.sku } : {}),
+    ...(variantId !== undefined ? { variantId } : {}),
   };
 }
 

--- a/src/services/affirmService.ts
+++ b/src/services/affirmService.ts
@@ -132,7 +132,7 @@ export async function initiateAffirmCheckout(
     order_id: orderId,
     amount: Math.round(amountDollars * 100),
     items: items.map((item) => ({
-      sku: item.id,
+      sku: item.sku ?? item.id,
       display_name: `${item.model.name} — ${item.fabric.name}`,
       quantity: item.quantity,
       unit_price: Math.round(item.unitPrice * 100),

--- a/src/services/wix/wixClient.ts
+++ b/src/services/wix/wixClient.ts
@@ -159,6 +159,7 @@ export interface WixCartLineItem {
     options?: { variantId?: string };
   };
   quantity: number;
+  sku?: string; // Wix catalog SKU for the line item (may be absent for older catalog items)
 }
 
 export interface WixCart {


### PR DESCRIPTION
## Summary

- Add `sku?: string` and `variantId?: string` to `CartItem` interface for Wix catalog alignment
- `serverLineItemToCartItem` now preserves `variantId` from `catalogReference.options.variantId`
- `affirmService` uses `item.sku ?? item.id` as line item SKU (prefers Wix catalog SKU when available)
- Export `serverLineItemToCartItem` for direct unit testing

## Test plan

- [x] 3 new TDD unit tests: variantId preserved, variantId undefined when missing, CartItem interface accepts new fields
- [x] All 107 useCart tests pass
- [x] All 19 affirmService tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)