### PR TITLE
fix(cm-elo): correct loyalty tier thresholds — Silver≥500/Gold≥1500

### DIFF
--- a/src/hooks/__tests__/useLoyalty.test.ts
+++ b/src/hooks/__tests__/useLoyalty.test.ts
@@ -87,7 +87,7 @@ describe('useLoyalty hook', () => {
     mockQueryData.mockImplementation((collection: string) => {
       if (collection === 'LoyaltyPoints')
         return Promise.resolve({
-          items: [makePointsRecord({ points: 1500, tier: 'silver', totalEarned: 2200 })],
+          items: [makePointsRecord({ points: 1500, tier: 'gold', totalEarned: 2200 })],
           totalResults: 1,
         });
       return Promise.resolve(EMPTY_TX);
@@ -95,14 +95,14 @@ describe('useLoyalty hook', () => {
     const { result } = renderHook(() => useLoyalty());
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.points).toBe(1500);
-    expect(result.current.tier).toBe('silver');
+    expect(result.current.tier).toBe('gold');
     expect(result.current.totalEarned).toBe(2200);
   });
 
-  it('derives tier from points: 0→bronze, 1000→silver, 5000→gold', async () => {
+  it('derives tier from points: 0→bronze, 500→silver, 1500→gold', async () => {
     mockQueryData.mockImplementation((collection: string) => {
       if (collection === 'LoyaltyPoints')
-        return Promise.resolve({ items: [makePointsRecord({ points: 999 })], totalResults: 1 });
+        return Promise.resolve({ items: [makePointsRecord({ points: 499 })], totalResults: 1 });
       return Promise.resolve(EMPTY_TX);
     });
     const { result: bronze } = renderHook(() => useLoyalty());
@@ -112,7 +112,7 @@ describe('useLoyalty hook', () => {
     mockQueryData.mockImplementation((collection: string) => {
       if (collection === 'LoyaltyPoints')
         return Promise.resolve({
-          items: [makePointsRecord({ points: 1000, tier: 'silver' })],
+          items: [makePointsRecord({ points: 500, tier: 'silver' })],
           totalResults: 1,
         });
       return Promise.resolve(EMPTY_TX);
@@ -124,7 +124,7 @@ describe('useLoyalty hook', () => {
     mockQueryData.mockImplementation((collection: string) => {
       if (collection === 'LoyaltyPoints')
         return Promise.resolve({
-          items: [makePointsRecord({ points: 5000, tier: 'gold' })],
+          items: [makePointsRecord({ points: 1500, tier: 'gold' })],
           totalResults: 1,
         });
       return Promise.resolve(EMPTY_TX);
@@ -135,11 +135,11 @@ describe('useLoyalty hook', () => {
   });
 
   it('always derives tier client-side — ignores stale stored tier', async () => {
-    // Stored tier says gold but points are only 500 (bronze). Must use deriveTier.
+    // Stored tier says gold but points are only 200 (bronze). Must use deriveTier.
     mockQueryData.mockImplementation((collection: string) => {
       if (collection === 'LoyaltyPoints')
         return Promise.resolve({
-          items: [makePointsRecord({ points: 500, tier: 'gold' })],
+          items: [makePointsRecord({ points: 200, tier: 'gold' })],
           totalResults: 1,
         });
       return Promise.resolve(EMPTY_TX);

--- a/src/hooks/useLoyalty.ts
+++ b/src/hooks/useLoyalty.ts
@@ -37,8 +37,8 @@ export interface UseLoyaltyResult {
 }
 
 function deriveTier(points: number): LoyaltyTier {
-  if (points >= 5000) return 'gold';
-  if (points >= 1000) return 'silver';
+  if (points >= 1500) return 'gold';
+  if (points >= 500) return 'silver';
   return 'bronze';
 }
 


### PR DESCRIPTION
## Summary

- Fixes `deriveTier()` in `useLoyalty.ts`: was Silver≥1000/Gold≥5000, now Silver≥500/Gold≥1500
- Aligns with canonical thresholds in `loyaltyService.web.js` (web rig) and the v2 feature roadmap spec
- Updates tests with correct boundary values (499→bronze, 500→silver, 1500→gold)
- Caught via cross-PM sync with melania

## Test plan
- [x] All 33 useLoyalty tests pass
- [x] Boundary coverage: 499→bronze, 500→silver, 1499→silver, 1500→gold
- [x] No change to display components

🤖 Generated with [Claude Code](https://claude.com/claude-code)