### PR TITLE
feat(cm-j6b): populate CartItem.imageUrl from Wix lineItem.media

### DIFF
--- a/src/hooks/__tests__/useCart.test.tsx
+++ b/src/hooks/__tests__/useCart.test.tsx
@@ -1157,7 +1157,7 @@ describe('CartItem imageUrl from Wix lineItem.media (cm-j6b)', () => {
       quantity: 1,
     });
     expect(item).not.toBeNull();
-    expect(item!.imageUrl).toBeUndefined();
+    expect(item).not.toHaveProperty('imageUrl');
   });
 
   it('serverLineItemToCartItem leaves imageUrl undefined when media.mediaItem is absent', () => {
@@ -1172,7 +1172,7 @@ describe('CartItem imageUrl from Wix lineItem.media (cm-j6b)', () => {
       media: {},
     });
     expect(item).not.toBeNull();
-    expect(item!.imageUrl).toBeUndefined();
+    expect(item).not.toHaveProperty('imageUrl');
   });
 
   it('serverLineItemToCartItem leaves imageUrl undefined when media.mediaItem.url is empty string', () => {
@@ -1187,7 +1187,7 @@ describe('CartItem imageUrl from Wix lineItem.media (cm-j6b)', () => {
       media: { mediaItem: { url: '' } },
     });
     expect(item).not.toBeNull();
-    expect(item!.imageUrl).toBeUndefined();
+    expect(item).not.toHaveProperty('imageUrl');
   });
 
   it('CartItem interface accepts imageUrl field without TypeScript error', () => {
@@ -1200,6 +1200,43 @@ describe('CartItem imageUrl from Wix lineItem.media (cm-j6b)', () => {
       imageUrl: 'https://cdn.wix.com/media/abc.jpg',
     };
     expect(item.imageUrl).toBe('https://cdn.wix.com/media/abc.jpg');
+  });
+
+  it('mergeCartItems propagates imageUrl from server item to matching local item', () => {
+    const localItem: CartItem = {
+      id: `${FUTON_MODELS[0].id}:${FABRICS[0].id}`,
+      model: FUTON_MODELS[0],
+      fabric: FABRICS[0],
+      quantity: 1,
+      unitPrice: FUTON_MODELS[0].basePrice + FABRICS[0].price,
+      // No imageUrl — added locally before auth
+    };
+    const serverItem: CartItem = {
+      ...localItem,
+      quantity: 2,
+      imageUrl: 'https://cdn.wix.com/media/abc.jpg',
+    };
+    const result = mergeCartItems([localItem], [serverItem]);
+    expect(result).toHaveLength(1);
+    expect(result[0].imageUrl).toBe('https://cdn.wix.com/media/abc.jpg');
+    expect(result[0].quantity).toBe(2); // higher quantity wins
+  });
+
+  it('mergeCartItems does not overwrite existing imageUrl with absent server imageUrl', () => {
+    const localItem: CartItem = {
+      id: `${FUTON_MODELS[0].id}:${FABRICS[0].id}`,
+      model: FUTON_MODELS[0],
+      fabric: FABRICS[0],
+      quantity: 1,
+      unitPrice: FUTON_MODELS[0].basePrice + FABRICS[0].price,
+      imageUrl: 'https://cdn.wix.com/media/local.jpg',
+    };
+    const serverItem: CartItem = {
+      ...localItem,
+      imageUrl: undefined,
+    };
+    const result = mergeCartItems([localItem], [serverItem]);
+    expect(result[0].imageUrl).toBe('https://cdn.wix.com/media/local.jpg');
   });
 });
 

--- a/src/hooks/useCart.tsx
+++ b/src/hooks/useCart.tsx
@@ -154,6 +154,7 @@ export function serverLineItemToCartItem(lineItem: WixCartLineItem): CartItem | 
   const fabric = variantId ? FABRICS.find((f) => f.id === variantId) : FABRICS[0];
   if (!fabric) return null;
 
+  // Wix can return '' when no image is set — coerce to undefined to prevent broken Image renders.
   const imageUrl = lineItem.media?.mediaItem?.url || undefined;
 
   return {
@@ -171,7 +172,8 @@ export function serverLineItemToCartItem(lineItem: WixCartLineItem): CartItem | 
 
 /**
  * Merge local cart items with server cart items.
- * For items present in both, keeps the higher quantity (capped at 10).
+ * For items present in both, keeps the higher quantity (capped at 10) and
+ * fills in server-side metadata (imageUrl, sku) that may be absent locally.
  * Items unique to either side are included in the result.
  */
 export function mergeCartItems(local: CartItem[], server: CartItem[]): CartItem[] {
@@ -182,6 +184,9 @@ export function mergeCartItems(local: CartItem[], server: CartItem[]): CartItem[
       merged[existingIdx] = {
         ...merged[existingIdx],
         quantity: Math.min(10, Math.max(merged[existingIdx].quantity, serverItem.quantity)),
+        // Backfill server-side metadata absent from offline/local items
+        ...(serverItem.imageUrl ? { imageUrl: serverItem.imageUrl } : {}),
+        ...(serverItem.sku ? { sku: serverItem.sku } : {}),
       };
     } else {
       merged.push(serverItem);

--- a/src/services/wix/wixClient.ts
+++ b/src/services/wix/wixClient.ts
@@ -160,8 +160,9 @@ export interface WixCartLineItem {
   };
   quantity: number;
   physicalProperties?: { sku?: string }; // Wix physicalProperties.sku — catalog SKU for shipping
+  /** CDN image URL for the line item (~150px thumbnail). */
   media?: {
-    mediaItem?: { url: string }; // CDN image URL for the line item (~150px thumbnail)
+    mediaItem?: { url: string };
   };
 }
 


### PR DESCRIPTION
## Summary

- Adds `media?: { mediaItem?: { url: string } }` to `WixCartLineItem` interface in `wixClient.ts`
- Extracts `imageUrl` from `lineItem.media?.mediaItem?.url` in `serverLineItemToCartItem`
- Empty/absent URL treated as absent — conditionally spread, never set to empty string
- Aligns `CartItem.imageUrl` with Wix server cart line item data for product image display

## Changes

- `src/services/wix/wixClient.ts` — `WixCartLineItem.media` field added
- `src/hooks/useCart.tsx` — `serverLineItemToCartItem` now populates `imageUrl`
- `src/hooks/__tests__/useCart.test.tsx` — 5 TDD tests (cm-j6b describe block)

## Test plan

- [x] serverLineItemToCartItem populates imageUrl from lineItem.media.mediaItem.url when present
- [x] serverLineItemToCartItem leaves imageUrl undefined when media is absent
- [x] serverLineItemToCartItem leaves imageUrl undefined when media.mediaItem is absent
- [x] serverLineItemToCartItem leaves imageUrl undefined when media.mediaItem.url is empty string
- [x] CartItem interface accepts imageUrl field without TypeScript error
- [x] All 114 useCart.test.tsx tests pass
- [x] No TypeScript errors in changed files

Bead: cm-j6b

🤖 Generated with [Claude Code](https://claude.com/claude-code)