### PR TITLE
feat(cm-e0r): useProductReviews hook — star rating + review data from Wix CF-k8hw

### DIFF
--- a/src/hooks/__tests__/useProductReviews.test.ts
+++ b/src/hooks/__tests__/useProductReviews.test.ts
@@ -371,3 +371,32 @@ describe('useProductReviews', () => {
     expect(result.current.reviews[0].rating).toBe(3);
   });
 });
+
+  // ── totalReviews from server totalResults ─────────────────────────────────
+
+  it('uses server totalResults for aggregate.totalReviews, not reviews.length', async () => {
+    // Simulate: server has 247 reviews but we only fetch 100
+    const fetchedItems = Array.from({ length: 100 }, (_, i) =>
+      makeItem({ id: `r${i}`, rating: 5 }),
+    );
+    mockQueryData.mockResolvedValue({ items: fetchedItems, totalResults: 247 });
+
+    const { result } = renderHook(() => useProductReviews('prod-popular'));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.reviews).toHaveLength(100);
+    // totalReviews must reflect the server total, not the fetched count
+    expect(result.current.aggregate.totalReviews).toBe(247);
+    // averageRating is computed from the 100 fetched items
+    expect(result.current.aggregate.averageRating).toBe(5.0);
+  });
+
+  it('uses totalResults=0 for aggregate when API returns empty results', async () => {
+    mockQueryData.mockResolvedValue({ items: [], totalResults: 0 });
+
+    const { result } = renderHook(() => useProductReviews('prod-new'));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.aggregate.totalReviews).toBe(0);
+    expect(result.current.aggregate.averageRating).toBe(0);
+  });

--- a/src/hooks/useProductReviews.ts
+++ b/src/hooks/useProductReviews.ts
@@ -6,8 +6,10 @@
  * WixClient is available (unauthenticated / not configured).
  *
  * Returns:
- *  - reviews: Review[] — fetched items, most recent first
+ *  - reviews: Review[] — fetched items, most recent first (up to 100)
  *  - aggregate: { averageRating, totalReviews }
+ *      averageRating — computed from fetched items
+ *      totalReviews  — server-reported total (may exceed 100 if paginated)
  *  - isLoading: boolean — true while the initial fetch is in-flight
  *  - error: string | null — error message on API failure, null otherwise
  *
@@ -24,6 +26,7 @@ const REVIEWS_COLLECTION = 'CF-k8hw';
 
 export interface ReviewAggregate {
   averageRating: number;
+  /** Server-reported total, may exceed the number of fetched reviews. */
   totalReviews: number;
 }
 
@@ -49,11 +52,11 @@ interface RawReviewItem {
   [key: string]: unknown;
 }
 
-function computeAggregate(reviews: Review[]): ReviewAggregate {
-  const totalReviews = reviews.length;
-  if (totalReviews === 0) return { averageRating: 0, totalReviews: 0 };
+/** Compute average rating from fetched reviews; count comes from the server total. */
+function computeAggregate(reviews: Review[], totalReviews: number): ReviewAggregate {
+  if (totalReviews === 0 || reviews.length === 0) return { averageRating: 0, totalReviews };
   const sum = reviews.reduce((acc, r) => acc + r.rating, 0);
-  const averageRating = Math.round((sum / totalReviews) * 10) / 10;
+  const averageRating = Math.round((sum / reviews.length) * 10) / 10;
   return { averageRating, totalReviews };
 }
 
@@ -86,15 +89,18 @@ function rawToReview(item: RawReviewItem): Review {
 export function useProductReviews(productId: string): UseProductReviewsResult {
   const wixClient = useOptionalWixClient();
   const [reviews, setReviews] = useState<Review[]>([]);
+  // Server-reported total — may exceed reviews.length when there are >100 reviews.
+  const [totalReviews, setTotalReviews] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  // Derive aggregate from reviews state -- stays in sync without extra state.
-  const aggregate = useMemo(() => computeAggregate(reviews), [reviews]);
+  // Derive aggregate from current state — stays in sync without extra state.
+  const aggregate = useMemo(() => computeAggregate(reviews, totalReviews), [reviews, totalReviews]);
 
   useEffect(() => {
     if (!wixClient) {
       setReviews([]);
+      setTotalReviews(0);
       setIsLoading(false);
       setError(null);
       return;
@@ -114,6 +120,7 @@ export function useProductReviews(productId: string): UseProductReviewsResult {
 
         if (cancelled) return;
         setReviews(result.items.map(rawToReview));
+        setTotalReviews(result.totalResults);
       } catch (err) {
         if (cancelled) return;
         const error = err instanceof Error ? err : new Error('Failed to load reviews');
@@ -123,6 +130,7 @@ export function useProductReviews(productId: string): UseProductReviewsResult {
         });
         setError(error.message);
         setReviews([]);
+        setTotalReviews(0);
       } finally {
         // finally always runs -- even after cancelled return in catch.
         // Guard here prevents state update on unmounted component.


### PR DESCRIPTION
## Summary

- New `useProductReviews(productId)` hook fetches from Wix CMS `CF-k8hw` collection via `wixClient.queryData`
- Filters by `productId`, sorts by `createdAt DESC`, limit 100
- `computeAggregate()` returns `{ averageRating, totalReviews }`
- Falls back to empty state when `wixClient` is null
- Cancellation guard on unmount / productId change

## AC coverage

| AC | Status |
|----|--------|
| Fetch reviews by productId from CF-k8hw | ✅ |
| Aggregate rating (avg + count) | ✅ |
| ReviewCard component | ✅ pre-existing |
| Loading state | ✅ `isLoading=true` during fetch |
| Empty state | ✅ `reviews=[], totalReviews=0` |
| Error state | ✅ `error` string set |
| Tests | ✅ 13 tests all passing |

🤖 Generated with [Claude Code](https://claude.com/claude-code)