### PR TITLE
feat(cm-qzd): gesture polish — ProductCard context menu + OrderHistory PTR

### DIFF
--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -7,10 +7,11 @@
  * to prevent unnecessary re-renders in FlatList/ScrollView contexts.
  */
 
-import React, { memo } from 'react';
-import { StyleSheet, View, Text, TouchableOpacity } from 'react-native';
+import React, { memo, useState, useCallback } from 'react';
+import { StyleSheet, View, Text, TouchableOpacity, Platform } from 'react-native';
 import Animated from 'react-native-reanimated';
 import { Image } from 'expo-image';
+import * as Haptics from 'expo-haptics';
 import { useTheme } from '@/theme';
 import {
   type Product,
@@ -28,11 +29,21 @@ import { ProductCardVideo } from './ProductCardVideo';
 import { CompareButton } from './CompareButton';
 import { InventoryBadge } from './InventoryBadge';
 import { useInventoryBadge } from '@/hooks/useInventoryBadge';
+import { ProductContextMenu } from './ProductContextMenu';
+
+/** Optional context menu actions shown on long-press. */
+export interface ProductContextMenuActions {
+  onAddToCart?: () => void;
+  onAddToWishlist?: () => void;
+  onShare?: () => void;
+}
 
 interface Props {
   product: Product;
   onPress?: (product: Product) => void;
   onLongPress?: (product: Product) => void;
+  /** When provided, long-press shows a context menu with these actions. */
+  contextMenu?: ProductContextMenuActions;
   testID?: string;
 }
 
@@ -41,10 +52,27 @@ export const ProductCard = memo(function ProductCard({
   product,
   onPress,
   onLongPress,
+  contextMenu,
   testID,
 }: Props) {
   const { colors, spacing, borderRadius, shadows } = useTheme();
   const imageTracking = useImageLoadTracking('ProductCard');
+  const [contextMenuVisible, setContextMenuVisible] = useState(false);
+
+  const handleLongPress = useCallback(() => {
+    if (contextMenu) {
+      if (Platform.OS !== 'web') {
+        Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+      }
+      setContextMenuVisible(true);
+    } else if (onLongPress) {
+      onLongPress(product);
+    }
+  }, [contextMenu, onLongPress, product]);
+
+  const handleContextMenuClose = useCallback(() => {
+    setContextMenuVisible(false);
+  }, []);
 
   const stockStatus = getStockStatus(product);
   const { badge: inventoryBadge, quantity: inventoryQuantity } = useInventoryBadge(product.id);
@@ -66,6 +94,7 @@ export const ProductCard = memo(function ProductCard({
           : colors.espressoLight;
 
   return (
+    <>
     <TouchableOpacity
       style={[
         styles.card,
@@ -73,7 +102,7 @@ export const ProductCard = memo(function ProductCard({
         { backgroundColor: colors.white, borderRadius: borderRadius.card },
       ]}
       onPress={() => onPress?.(product)}
-      onLongPress={onLongPress ? () => onLongPress(product) : undefined}
+      onLongPress={contextMenu || onLongPress ? handleLongPress : undefined}
       testID={testID ?? `product-card-${product.id}`}
       accessibilityLabel={`${product.name}, ${formatPrice(product.price)}`}
       accessibilityRole="button"
@@ -170,6 +199,32 @@ export const ProductCard = memo(function ProductCard({
         <CompareButton product={product} testID={`compare-btn-${product.id}`} />
       </View>
     </TouchableOpacity>
+
+    {/* ⋮ context menu trigger — tap-accessible fallback for long-press */}
+    {contextMenu && (
+      <TouchableOpacity
+        testID={`product-context-trigger-${product.id}`}
+        style={styles.contextTrigger}
+        onPress={() => setContextMenuVisible(true)}
+        accessibilityRole="button"
+        accessibilityLabel={`More options for ${product.name}`}
+        hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+      >
+        <Text style={[styles.contextTriggerText, { color: colors.espresso }]}>⋮</Text>
+      </TouchableOpacity>
+    )}
+
+    {contextMenu && (
+      <ProductContextMenu
+        visible={contextMenuVisible}
+        product={product}
+        onClose={handleContextMenuClose}
+        onAddToCart={contextMenu.onAddToCart}
+        onAddToWishlist={contextMenu.onAddToWishlist}
+        onShare={contextMenu.onShare}
+      />
+    )}
+    </>
   );
 });
 
@@ -265,5 +320,21 @@ const styles = StyleSheet.create({
     fontSize: 10,
     fontWeight: '700',
     letterSpacing: 0.3,
+  },
+  contextTrigger: {
+    position: 'absolute',
+    top: 8,
+    right: 8,
+    zIndex: 10,
+    padding: 4,
+    minWidth: 24,
+    minHeight: 24,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  contextTriggerText: {
+    fontSize: 18,
+    fontWeight: '600',
+    lineHeight: 22,
   },
 });

--- a/src/components/ProductContextMenu.tsx
+++ b/src/components/ProductContextMenu.tsx
@@ -1,0 +1,172 @@
+/**
+ * @module ProductContextMenu
+ *
+ * Action sheet shown on ProductCard long-press (cm-qzd).
+ * Provides quick access to: Add to Cart, Add to Wishlist, Share.
+ * Also accessible via a ⋮ trigger button on the card (a11y tap fallback).
+ */
+
+import React from 'react';
+import { StyleSheet, View, Text, TouchableOpacity, Pressable, Modal } from 'react-native';
+import { useTheme } from '@/theme';
+import type { Product } from '@/data/products';
+
+interface Props {
+  visible: boolean;
+  product: Product;
+  onClose: () => void;
+  onAddToCart?: () => void;
+  onAddToWishlist?: () => void;
+  onShare?: () => void;
+}
+
+/** Slide-up context menu modal for ProductCard actions. */
+export function ProductContextMenu({
+  visible,
+  product,
+  onClose,
+  onAddToCart,
+  onAddToWishlist,
+  onShare,
+}: Props) {
+  const { colors, borderRadius, spacing } = useTheme();
+
+  if (!visible) return null;
+
+  return (
+    <Modal
+      transparent
+      animationType="fade"
+      visible={visible}
+      onRequestClose={onClose}
+    >
+      <View
+        style={StyleSheet.absoluteFillObject}
+        testID="product-context-menu"
+        accessibilityViewIsModal={true}
+      >
+        {/* Backdrop */}
+        <Pressable
+          style={styles.backdrop}
+          onPress={onClose}
+          testID="product-context-menu-backdrop"
+          accessibilityLabel="Close menu"
+        />
+
+        {/* Action sheet panel */}
+        <View
+          style={[
+            styles.sheet,
+            {
+              backgroundColor: colors.sandBase,
+              borderTopLeftRadius: borderRadius.lg ?? 20,
+              borderTopRightRadius: borderRadius.lg ?? 20,
+              paddingHorizontal: spacing.lg,
+              paddingBottom: spacing.lg,
+            },
+          ]}
+        >
+          {/* Product name header */}
+          <Text
+            testID="context-menu-product-name"
+            style={[styles.productName, { color: colors.espressoLight }]}
+            numberOfLines={1}
+          >
+            {product.name}
+          </Text>
+
+          {onAddToCart && (
+            <TouchableOpacity
+              testID="context-add-to-cart"
+              style={[styles.action, { borderBottomColor: colors.sandDark }]}
+              onPress={() => {
+                onAddToCart();
+                onClose();
+              }}
+              accessibilityRole="button"
+              accessibilityLabel={`Add ${product.name} to cart`}
+            >
+              <Text style={[styles.actionText, { color: colors.espresso }]}>Add to Cart</Text>
+            </TouchableOpacity>
+          )}
+
+          {onAddToWishlist && (
+            <TouchableOpacity
+              testID="context-add-to-wishlist"
+              style={[styles.action, { borderBottomColor: colors.sandDark }]}
+              onPress={() => {
+                onAddToWishlist();
+                onClose();
+              }}
+              accessibilityRole="button"
+              accessibilityLabel={`Add ${product.name} to wishlist`}
+            >
+              <Text style={[styles.actionText, { color: colors.espresso }]}>Add to Wishlist</Text>
+            </TouchableOpacity>
+          )}
+
+          {onShare && (
+            <TouchableOpacity
+              testID="context-share"
+              style={[styles.action, { borderBottomColor: colors.sandDark }]}
+              onPress={() => {
+                onShare();
+                onClose();
+              }}
+              accessibilityRole="button"
+              accessibilityLabel={`Share ${product.name}`}
+            >
+              <Text style={[styles.actionText, { color: colors.espresso }]}>Share</Text>
+            </TouchableOpacity>
+          )}
+
+          {/* Cancel */}
+          <TouchableOpacity
+            testID="context-cancel"
+            style={styles.cancelAction}
+            onPress={onClose}
+            accessibilityRole="button"
+            accessibilityLabel="Cancel"
+          >
+            <Text style={[styles.cancelText, { color: colors.espressoLight }]}>Cancel</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.45)',
+  },
+  sheet: {
+    paddingTop: 12,
+  },
+  productName: {
+    fontSize: 13,
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+    paddingVertical: 12,
+    textAlign: 'center',
+  },
+  action: {
+    paddingVertical: 16,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    alignItems: 'center',
+  },
+  actionText: {
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  cancelAction: {
+    paddingVertical: 16,
+    alignItems: 'center',
+    marginTop: 4,
+  },
+  cancelText: {
+    fontSize: 16,
+    fontWeight: '400',
+  },
+});

--- a/src/components/__tests__/ProductCard.test.tsx
+++ b/src/components/__tests__/ProductCard.test.tsx
@@ -6,6 +6,12 @@ import { WishlistProvider } from '@/hooks/useWishlist';
 import { CompareProvider } from '@/contexts/CompareContext';
 import { PRODUCTS, type Product } from '@/data/products';
 import { productId } from '@/data/productId';
+import * as Haptics from 'expo-haptics';
+
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  ImpactFeedbackStyle: { Medium: 'Medium', Light: 'Light' },
+}));
 
 const futon = PRODUCTS.find((p) => p.category === 'futons')!;
 const saleProduct = PRODUCTS.find((p) => p.originalPrice !== undefined)!;
@@ -281,6 +287,74 @@ describe('ProductCard', () => {
       const { getByTestId } = renderCard({ onPress });
       fireEvent.press(getByTestId(`compare-btn-${futon.id}`));
       expect(onPress).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Long-press context menu', () => {
+    function renderWithContextMenu(contextMenu: {
+      onAddToCart?: jest.Mock;
+      onAddToWishlist?: jest.Mock;
+      onShare?: jest.Mock;
+    }) {
+      return render(
+        <ThemeProvider>
+          <WishlistProvider>
+            <CompareProvider>
+              <ProductCard
+                product={futon}
+                onPress={jest.fn()}
+                contextMenu={contextMenu}
+              />
+            </CompareProvider>
+          </WishlistProvider>
+        </ThemeProvider>,
+      );
+    }
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('shows context menu trigger button when contextMenu prop provided', () => {
+      const { getByTestId } = renderWithContextMenu({ onAddToCart: jest.fn() });
+      expect(getByTestId(`product-context-trigger-${futon.id}`)).toBeTruthy();
+    });
+
+    it('hides context menu trigger when contextMenu prop absent', () => {
+      const { queryByTestId } = renderCard();
+      expect(queryByTestId(`product-context-trigger-${futon.id}`)).toBeNull();
+    });
+
+    it('fires haptic on long press when contextMenu provided', () => {
+      const { getByTestId } = renderWithContextMenu({ onAddToCart: jest.fn() });
+      fireEvent(getByTestId(`product-card-${futon.id}`), 'longPress');
+      expect(Haptics.impactAsync).toHaveBeenCalledWith(
+        Haptics.ImpactFeedbackStyle.Medium,
+      );
+    });
+
+    it('shows context menu after long press', () => {
+      const { getByTestId } = renderWithContextMenu({ onAddToCart: jest.fn() });
+      fireEvent(getByTestId(`product-card-${futon.id}`), 'longPress');
+      expect(getByTestId('product-context-menu')).toBeTruthy();
+    });
+
+    it('shows context menu after pressing trigger button', () => {
+      const { getByTestId } = renderWithContextMenu({ onAddToCart: jest.fn() });
+      fireEvent.press(getByTestId(`product-context-trigger-${futon.id}`));
+      expect(getByTestId('product-context-menu')).toBeTruthy();
+    });
+
+    it('context menu trigger has accessibilityLabel', () => {
+      const { getByTestId } = renderWithContextMenu({ onAddToCart: jest.fn() });
+      const trigger = getByTestId(`product-context-trigger-${futon.id}`);
+      expect(trigger.props.accessibilityLabel).toBeTruthy();
+    });
+
+    it('context menu trigger has accessibilityRole=button', () => {
+      const { getByTestId } = renderWithContextMenu({ onAddToCart: jest.fn() });
+      const trigger = getByTestId(`product-context-trigger-${futon.id}`);
+      expect(trigger.props.accessibilityRole).toBe('button');
     });
   });
 });

--- a/src/components/__tests__/ProductContextMenu.test.tsx
+++ b/src/components/__tests__/ProductContextMenu.test.tsx
@@ -1,0 +1,158 @@
+/**
+ * @module ProductContextMenu.test
+ *
+ * TDD tests for the ProductContextMenu component — cm-qzd.
+ * Slide-up action sheet shown on ProductCard long-press.
+ * Actions: Add to Cart, Add to Wishlist, Share.
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { ProductContextMenu } from '../ProductContextMenu';
+import { ThemeProvider } from '@/theme/ThemeProvider';
+import { PRODUCTS } from '@/data/products';
+
+const product = PRODUCTS.find((p) => p.category === 'futons')!;
+
+function renderMenu(
+  props: Partial<React.ComponentProps<typeof ProductContextMenu>> = {},
+) {
+  return render(
+    <ThemeProvider>
+      <ProductContextMenu
+        visible={true}
+        product={product}
+        onClose={jest.fn()}
+        {...props}
+      />
+    </ThemeProvider>,
+  );
+}
+
+describe('ProductContextMenu', () => {
+  describe('Visibility', () => {
+    it('renders when visible=true', () => {
+      const { getByTestId } = renderMenu({ visible: true });
+      expect(getByTestId('product-context-menu')).toBeTruthy();
+    });
+
+    it('does not render when visible=false', () => {
+      const { queryByTestId } = renderMenu({ visible: false });
+      expect(queryByTestId('product-context-menu')).toBeNull();
+    });
+  });
+
+  describe('Content', () => {
+    it('shows product name in header', () => {
+      const { getByTestId } = renderMenu();
+      expect(getByTestId('context-menu-product-name').props.children).toBe(
+        product.name,
+      );
+    });
+
+    it('shows Add to Cart button when onAddToCart provided', () => {
+      const { getByTestId } = renderMenu({ onAddToCart: jest.fn() });
+      expect(getByTestId('context-add-to-cart')).toBeTruthy();
+    });
+
+    it('hides Add to Cart button when onAddToCart not provided', () => {
+      const { queryByTestId } = renderMenu({ onAddToCart: undefined });
+      expect(queryByTestId('context-add-to-cart')).toBeNull();
+    });
+
+    it('shows Add to Wishlist button when onAddToWishlist provided', () => {
+      const { getByTestId } = renderMenu({ onAddToWishlist: jest.fn() });
+      expect(getByTestId('context-add-to-wishlist')).toBeTruthy();
+    });
+
+    it('hides Add to Wishlist button when onAddToWishlist not provided', () => {
+      const { queryByTestId } = renderMenu({ onAddToWishlist: undefined });
+      expect(queryByTestId('context-add-to-wishlist')).toBeNull();
+    });
+
+    it('shows Share button when onShare provided', () => {
+      const { getByTestId } = renderMenu({ onShare: jest.fn() });
+      expect(getByTestId('context-share')).toBeTruthy();
+    });
+
+    it('hides Share button when onShare not provided', () => {
+      const { queryByTestId } = renderMenu({ onShare: undefined });
+      expect(queryByTestId('context-share')).toBeNull();
+    });
+
+    it('always shows Cancel button', () => {
+      const { getByTestId } = renderMenu();
+      expect(getByTestId('context-cancel')).toBeTruthy();
+    });
+  });
+
+  describe('Interactions', () => {
+    it('calls onAddToCart and onClose when Add to Cart pressed', () => {
+      const onAddToCart = jest.fn();
+      const onClose = jest.fn();
+      const { getByTestId } = renderMenu({ onAddToCart, onClose });
+      fireEvent.press(getByTestId('context-add-to-cart'));
+      expect(onAddToCart).toHaveBeenCalledTimes(1);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onAddToWishlist and onClose when Add to Wishlist pressed', () => {
+      const onAddToWishlist = jest.fn();
+      const onClose = jest.fn();
+      const { getByTestId } = renderMenu({ onAddToWishlist, onClose });
+      fireEvent.press(getByTestId('context-add-to-wishlist'));
+      expect(onAddToWishlist).toHaveBeenCalledTimes(1);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onShare and onClose when Share pressed', () => {
+      const onShare = jest.fn();
+      const onClose = jest.fn();
+      const { getByTestId } = renderMenu({ onShare, onClose });
+      fireEvent.press(getByTestId('context-share'));
+      expect(onShare).toHaveBeenCalledTimes(1);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when Cancel pressed', () => {
+      const onClose = jest.fn();
+      const { getByTestId } = renderMenu({ onClose });
+      fireEvent.press(getByTestId('context-cancel'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onClose when backdrop pressed', () => {
+      const onClose = jest.fn();
+      const { getByTestId } = renderMenu({ onClose });
+      fireEvent.press(getByTestId('product-context-menu-backdrop'));
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('menu has accessibilityViewIsModal', () => {
+      const { getByTestId } = renderMenu();
+      expect(getByTestId('product-context-menu').props.accessibilityViewIsModal).toBe(true);
+    });
+
+    it('Add to Cart button has accessibilityRole=button', () => {
+      const { getByTestId } = renderMenu({ onAddToCart: jest.fn() });
+      expect(getByTestId('context-add-to-cart').props.accessibilityRole).toBe('button');
+    });
+
+    it('Add to Wishlist button has accessibilityRole=button', () => {
+      const { getByTestId } = renderMenu({ onAddToWishlist: jest.fn() });
+      expect(getByTestId('context-add-to-wishlist').props.accessibilityRole).toBe('button');
+    });
+
+    it('Share button has accessibilityRole=button', () => {
+      const { getByTestId } = renderMenu({ onShare: jest.fn() });
+      expect(getByTestId('context-share').props.accessibilityRole).toBe('button');
+    });
+
+    it('Cancel button has accessibilityRole=button', () => {
+      const { getByTestId } = renderMenu();
+      expect(getByTestId('context-cancel').props.accessibilityRole).toBe('button');
+    });
+  });
+});

--- a/src/screens/OrderHistoryScreen.tsx
+++ b/src/screens/OrderHistoryScreen.tsx
@@ -49,9 +49,9 @@ export function OrderHistoryScreen({
 
   const handleRefresh = useCallback(() => {
     setRefreshing(true);
-    // Simulate network refresh — real implementation will call API
+    hookRefresh();
     setTimeout(() => setRefreshing(false), 800);
-  }, []);
+  }, [hookRefresh]);
 
   const formatDate = useCallback((iso: string) => {
     const d = new Date(iso);
@@ -195,25 +195,6 @@ export function OrderHistoryScreen({
     );
   }
 
-  if (orders.length === 0) {
-    return (
-      <View
-        style={[styles.root, { backgroundColor: darkPalette.background }]}
-        testID={testID ?? 'order-history-screen'}
-      >
-        <EmptyState
-          illustration={<CategoryIllustration testID="orders-illustration" />}
-          title="No orders yet"
-          message="Once you place your first order, it will appear here."
-          action={
-            onStartShopping ? { label: 'Start Shopping', onPress: onStartShopping } : undefined
-          }
-          testID="orders-empty-state"
-        />
-      </View>
-    );
-  }
-
   return (
     <View
       style={[styles.root, { backgroundColor: darkPalette.background }]}
@@ -241,6 +222,17 @@ export function OrderHistoryScreen({
         contentContainerStyle={styles.listContent}
         showsVerticalScrollIndicator={false}
         ListHeaderComponent={<MountainRefreshIndicator refreshing={refreshing} />}
+        ListEmptyComponent={
+          <EmptyState
+            illustration={<CategoryIllustration testID="orders-illustration" />}
+            title="No orders yet"
+            message="Once you place your first order, it will appear here."
+            action={
+              onStartShopping ? { label: 'Start Shopping', onPress: onStartShopping } : undefined
+            }
+            testID="orders-empty-state"
+          />
+        }
         refreshControl={
           <MountainRefreshControl
             refreshing={refreshing}

--- a/src/screens/__tests__/OrderHistoryScreen.test.tsx
+++ b/src/screens/__tests__/OrderHistoryScreen.test.tsx
@@ -315,4 +315,35 @@ describe('OrderHistoryScreen', () => {
       expect(mockRefresh).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('pull-to-refresh', () => {
+    it('FlatList has refreshControl configured', () => {
+      const { getByTestId } = renderOrderHistory();
+      const flatList = getByTestId('order-list');
+      expect(flatList.props.refreshControl).toBeTruthy();
+    });
+
+    it('FlatList has refreshControl on empty order list', () => {
+      mockUseOrders.mockReturnValue({
+        orders: [],
+        isLoading: false,
+        error: null,
+        refresh: mockRefresh,
+        statusFilter: null,
+        setStatusFilter: jest.fn(),
+        getOrder: jest.fn(),
+      });
+      const { getByTestId } = renderOrderHistory();
+      const flatList = getByTestId('order-list');
+      expect(flatList.props.refreshControl).toBeTruthy();
+    });
+
+    it('PTR onRefresh calls orders.refresh()', () => {
+      const { getByTestId } = renderOrderHistory();
+      const flatList = getByTestId('order-list');
+      const { onRefresh } = flatList.props.refreshControl.props;
+      onRefresh();
+      expect(mockRefresh).toHaveBeenCalledTimes(1);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- **ProductContextMenu** (new): Modal action sheet triggered by ProductCard long-press. Actions: Add to Cart, Add to Wishlist, Share, Cancel. Backdrop dismiss. `accessibilityViewIsModal`, `accessibilityRole`, `accessibilityLabel` on every action. 20 tests green.
- **ProductCard context menu**: Added `contextMenu?: ProductContextMenuActions` prop. Long-press fires `Haptics.impactAsync(Medium)` then opens menu. ⋮ button tap-accessible fallback (a11y). `handleLongPress` falls back to `onLongPress` callback when no contextMenu prop. 7 new tests.
- **OrderHistoryScreen PTR fixes**: `handleRefresh` now calls `hookRefresh()`. Empty state moved to `ListEmptyComponent` so `FlatList` (and `refreshControl`) is always mounted — enabling pull-to-refresh even on empty order list. 3 new PTR tests.

Closes cm-qzd (gesture polish pass — part 3/3).

## Test plan
- [ ] All 3 suites pass: `ProductContextMenu.test.tsx` (20), `ProductCard.test.tsx` (long-press group), `OrderHistoryScreen.test.tsx` (PTR group)
- [ ] `src/` test path: `npx jest --testPathPattern="^/Users/hal/gt/cfutons_mobile/src/" --no-coverage`
- [ ] Long-press on product card → haptic + action sheet appears
- [ ] ⋮ button taps → action sheet appears
- [ ] Backdrop press / Cancel → dismisses sheet
- [ ] Pull-to-refresh on OrderHistoryScreen calls refresh (including empty state)

🤖 Generated with [Claude Code](https://claude.com/claude-code)