### PR TITLE
fix(cm-qlb): correct loyalty tier threshold docs and test fixtures

### DIFF
--- a/src/hooks/__tests__/useLoyalty.test.ts
+++ b/src/hooks/__tests__/useLoyalty.test.ts
@@ -40,7 +40,7 @@ function makePointsRecord(overrides = {}) {
   return {
     memberId: MEMBER_ID,
     points: 500,
-    tier: 'bronze',
+    tier: 'silver',
     totalEarned: 500,
     ...overrides,
   };
@@ -99,7 +99,7 @@ describe('useLoyalty hook', () => {
     expect(result.current.totalEarned).toBe(2200);
   });
 
-  it('derives tier from points: 0→bronze, 500→silver, 1500→gold', async () => {
+  it('tier boundaries: 499→bronze, 500→silver, 1499→silver, 1500→gold', async () => {
     mockQueryData.mockImplementation((collection: string) => {
       if (collection === 'LoyaltyPoints')
         return Promise.resolve({ items: [makePointsRecord({ points: 499 })], totalResults: 1 });
@@ -120,6 +120,18 @@ describe('useLoyalty hook', () => {
     const { result: silver } = renderHook(() => useLoyalty());
     await waitFor(() => expect(silver.current.loading).toBe(false));
     expect(silver.current.tier).toBe('silver');
+
+    mockQueryData.mockImplementation((collection: string) => {
+      if (collection === 'LoyaltyPoints')
+        return Promise.resolve({
+          items: [makePointsRecord({ points: 1499, tier: 'silver' })],
+          totalResults: 1,
+        });
+      return Promise.resolve(EMPTY_TX);
+    });
+    const { result: silverHigh } = renderHook(() => useLoyalty());
+    await waitFor(() => expect(silverHigh.current.loading).toBe(false));
+    expect(silverHigh.current.tier).toBe('silver');
 
     mockQueryData.mockImplementation((collection: string) => {
       if (collection === 'LoyaltyPoints')

--- a/src/hooks/useLoyalty.ts
+++ b/src/hooks/useLoyalty.ts
@@ -9,7 +9,7 @@
  *   LoyaltyPoints       — { memberId, points, tier, totalEarned }
  *   LoyaltyTransactions — { _id, memberId, delta, reason, createdDate }
  *
- * Tier thresholds: bronze 0–999, silver 1000–4999, gold 5000+
+ * Tier thresholds: bronze 0–499, silver 500–1499, gold 1500+
  */
 
 import { useState, useCallback, useEffect } from 'react';


### PR DESCRIPTION
## Summary
- Corrected JSDoc in `useLoyalty.ts`: tier thresholds were documented as `bronze 0–999, silver 1000–4999, gold 5000+` — updated to match `deriveTier()` and canonical spec (`bronze 0–499, silver 500–1499, gold 1500+`)
- Fixed `makePointsRecord()` test factory default: `tier: 'bronze'` → `tier: 'silver'` (500 pts maps to silver)
- Added `1499→silver` boundary assertion to the tier-boundaries test

Note: `deriveTier()` logic itself was already correct — this is a docs/test-hygiene fix only.

## Test plan
- [ ] `useLoyalty` test suite: 11 tests all pass
- [ ] Tier boundaries test now covers all 4 cases: 499→bronze, 500→silver, 1499→silver, 1500→gold

🤖 Generated with [Claude Code](https://claude.com/claude-code)