### PR TITLE
feat(cm-486): mini-cart persistent drawer — CartFAB trigger from any screen

### DIFF
--- a/src/components/CartFAB.tsx
+++ b/src/components/CartFAB.tsx
@@ -1,0 +1,79 @@
+/**
+ * @module CartFAB
+ *
+ * Floating cart button — cm-486.
+ *
+ * Appears on any screen when the cart has items. Tapping opens the
+ * mini-cart slide-up drawer preview without navigating away from the
+ * current screen.
+ *
+ * Positioned bottom-left to avoid overlap with the CompareFAB (bottom-right).
+ * Hidden when the cart is empty.
+ */
+import React from 'react';
+import { TouchableOpacity, Text, View, StyleSheet } from 'react-native';
+import { useCart } from '@/hooks/useCart';
+import { useMiniCartDrawer } from '@/hooks/useMiniCartDrawer';
+import { colors, shadows } from '@/theme/tokens';
+
+/** Floating action button that opens the mini-cart drawer. */
+export function CartFAB() {
+  const { itemCount } = useCart();
+  const { open } = useMiniCartDrawer();
+
+  if (itemCount === 0) return null;
+
+  const badgeText = itemCount > 99 ? '99+' : String(itemCount);
+
+  return (
+    <TouchableOpacity
+      onPress={open}
+      accessibilityRole="button"
+      accessibilityLabel={`View cart, ${itemCount} ${itemCount === 1 ? 'item' : 'items'}`}
+      testID="cart-fab"
+      style={styles.fab}
+    >
+      <Text style={styles.icon}>🛒</Text>
+      <View style={styles.badge} testID="cart-fab-badge-container">
+        <Text style={styles.badgeText} testID="cart-fab-badge">
+          {badgeText}
+        </Text>
+      </View>
+    </TouchableOpacity>
+  );
+}
+
+const styles = StyleSheet.create({
+  fab: {
+    position: 'absolute',
+    bottom: 24,
+    left: 24,
+    width: 56,
+    height: 56,
+    borderRadius: 28,
+    backgroundColor: colors.espresso,
+    alignItems: 'center',
+    justifyContent: 'center',
+    ...shadows.card,
+  },
+  icon: {
+    fontSize: 22,
+  },
+  badge: {
+    position: 'absolute',
+    top: 2,
+    right: 2,
+    backgroundColor: colors.sunsetCoral,
+    borderRadius: 10,
+    minWidth: 18,
+    height: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    paddingHorizontal: 4,
+  },
+  badgeText: {
+    color: '#FFFFFF',
+    fontSize: 10,
+    fontWeight: '700',
+  },
+});

--- a/src/components/__tests__/CartFAB.test.tsx
+++ b/src/components/__tests__/CartFAB.test.tsx
@@ -1,0 +1,97 @@
+/**
+ * Tests for CartFAB — cm-486.
+ *
+ * Floating cart button that opens the mini-cart drawer.
+ * Visible from any screen when the cart has items.
+ *
+ * Covers: hidden when empty, visible with items, badge text, opens drawer,
+ * accessibility, item count cap at 99+.
+ */
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { CartFAB } from '../CartFAB';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const mockOpen = jest.fn();
+jest.mock('@/hooks/useMiniCartDrawer', () => ({
+  useMiniCartDrawer: () => ({ open: mockOpen, close: jest.fn(), toggle: jest.fn(), isOpen: false }),
+}));
+
+const mockUseCart = jest.fn();
+jest.mock('@/hooks/useCart', () => ({
+  useCart: () => mockUseCart(),
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderFAB() {
+  return render(<CartFAB />);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseCart.mockReturnValue({ itemCount: 1, items: [], subtotal: 0 });
+});
+
+// ── Section 1: Visibility ─────────────────────────────────────────────────────
+
+describe('CartFAB visibility', () => {
+  it('renders when cart has items', () => {
+    const { getByTestId } = renderFAB();
+    expect(getByTestId('cart-fab')).toBeTruthy();
+  });
+
+  it('does not render when cart is empty', () => {
+    mockUseCart.mockReturnValue({ itemCount: 0, items: [], subtotal: 0 });
+    const { queryByTestId } = renderFAB();
+    expect(queryByTestId('cart-fab')).toBeNull();
+  });
+});
+
+// ── Section 2: Badge ──────────────────────────────────────────────────────────
+
+describe('CartFAB badge', () => {
+  it('shows badge with item count', () => {
+    mockUseCart.mockReturnValue({ itemCount: 3, items: [], subtotal: 0 });
+    const { getByTestId } = renderFAB();
+    expect(getByTestId('cart-fab-badge').props.children).toBe('3');
+  });
+
+  it('caps badge at 99+ when count exceeds 99', () => {
+    mockUseCart.mockReturnValue({ itemCount: 100, items: [], subtotal: 0 });
+    const { getByTestId } = renderFAB();
+    expect(getByTestId('cart-fab-badge').props.children).toBe('99+');
+  });
+
+  it('shows exact count for exactly 99 items', () => {
+    mockUseCart.mockReturnValue({ itemCount: 99, items: [], subtotal: 0 });
+    const { getByTestId } = renderFAB();
+    expect(getByTestId('cart-fab-badge').props.children).toBe('99');
+  });
+});
+
+// ── Section 3: Interaction ────────────────────────────────────────────────────
+
+describe('CartFAB interaction', () => {
+  it('calls open() when pressed', () => {
+    const { getByTestId } = renderFAB();
+    fireEvent.press(getByTestId('cart-fab'));
+    expect(mockOpen).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── Section 4: Accessibility ──────────────────────────────────────────────────
+
+describe('CartFAB accessibility', () => {
+  it('has button accessibility role', () => {
+    const { getByTestId } = renderFAB();
+    expect(getByTestId('cart-fab').props.accessibilityRole).toBe('button');
+  });
+
+  it('has descriptive accessibility label', () => {
+    mockUseCart.mockReturnValue({ itemCount: 2, items: [], subtotal: 0 });
+    const { getByTestId } = renderFAB();
+    expect(getByTestId('cart-fab').props.accessibilityLabel).toMatch(/2/);
+  });
+});

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -19,6 +19,7 @@ import { AccountScreen } from '@/screens/AccountScreen';
 import { CompareFAB } from '@/components/CompareFAB';
 import { AnimatedTabBar } from './AnimatedTabBar';
 import { withScreenErrorBoundary } from './withScreenErrorBoundary';
+import { CartFAB } from '@/components/CartFAB';
 import type { RootStackParamList } from './AppNavigator';
 
 const HomeScreenWithBoundary = withScreenErrorBoundary(HomeScreen, 'Home');
@@ -114,6 +115,7 @@ export function TabNavigator() {
         />
       </Tab.Navigator>
       <CompareFAB testID="compare-fab" />
+      <CartFAB />
     </View>
   );
 }

--- a/src/navigation/__tests__/ErrorBoundaryAudit.test.tsx
+++ b/src/navigation/__tests__/ErrorBoundaryAudit.test.tsx
@@ -44,6 +44,9 @@ jest.mock('expo-haptics', () => ({
 jest.mock('@/components/CompareFAB', () => ({
   CompareFAB: () => null,
 }));
+jest.mock('@/components/CartFAB', () => ({
+  CartFAB: () => null,
+}));
 
 jest.mock('@/hooks/useCart', () => ({
   useCart: () => ({

--- a/src/navigation/__tests__/Navigation.test.tsx
+++ b/src/navigation/__tests__/Navigation.test.tsx
@@ -91,6 +91,9 @@ const mockCartState = {
 jest.mock('@/components/CompareFAB', () => ({
   CompareFAB: () => null,
 }));
+jest.mock('@/components/CartFAB', () => ({
+  CartFAB: () => null,
+}));
 
 jest.mock('@/hooks/useCart', () => ({
   useCart: () => mockCartState,

--- a/src/navigation/__tests__/TabNavigator.test.tsx
+++ b/src/navigation/__tests__/TabNavigator.test.tsx
@@ -1,0 +1,86 @@
+/**
+ * Tests for TabNavigator — CartFAB integration (cm-486).
+ *
+ * Verifies CartFAB is present in the tab navigator so it's accessible
+ * from any tab screen when the cart has items.
+ */
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { ThemeProvider } from '@/theme/ThemeProvider';
+import { TabNavigator } from '../TabNavigator';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+jest.mock('@react-navigation/bottom-tabs', () => {
+  const { View, Text, TouchableOpacity } = require('react-native');
+  const createBottomTabNavigator = () => ({
+    Navigator: ({ children, screenOptions: _so, tabBar: _tb }: any) => (
+      <View testID="tab-navigator">{children}</View>
+    ),
+    Screen: ({ name, component: Comp }: any) => (
+      <View testID={`tab-screen-${name}`} />
+    ),
+  });
+  return { createBottomTabNavigator };
+});
+
+jest.mock('../AnimatedTabBar', () => ({ AnimatedTabBar: () => null }));
+jest.mock('../withScreenErrorBoundary', () => ({
+  withScreenErrorBoundary: (C: any) => C,
+}));
+jest.mock('@/screens/HomeScreen', () => ({ HomeScreen: () => null }));
+jest.mock('@/screens/ShopScreen', () => ({ ShopScreen: () => null }));
+jest.mock('@/screens/CartScreen', () => ({ CartScreen: () => null }));
+jest.mock('@/screens/AccountScreen', () => ({ AccountScreen: () => null }));
+jest.mock('@/contexts/CompareContext', () => ({
+  useCompareContext: () => ({ compareList: [], count: 0 }),
+  CompareProvider: ({ children }: any) => children,
+}));
+
+const mockOpen = jest.fn();
+jest.mock('@/hooks/useMiniCartDrawer', () => ({
+  useMiniCartDrawer: () => ({ open: mockOpen, close: jest.fn(), toggle: jest.fn(), isOpen: false }),
+  MiniCartDrawerProvider: ({ children }: any) => children,
+}));
+
+const mockUseCart = jest.fn();
+jest.mock('@/hooks/useCart', () => ({
+  useCart: () => mockUseCart(),
+  CartProvider: ({ children }: any) => children,
+}));
+
+jest.mock('@react-navigation/native', () => ({
+  ...jest.requireActual('@react-navigation/native'),
+  useNavigation: () => ({ navigate: jest.fn() }),
+}));
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+function renderTabs() {
+  return render(
+    <ThemeProvider>
+      <NavigationContainer>
+        <TabNavigator />
+      </NavigationContainer>
+    </ThemeProvider>,
+  );
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseCart.mockReturnValue({ itemCount: 2, items: [], subtotal: 0, itemCount: 2 });
+});
+
+describe('TabNavigator — CartFAB integration', () => {
+  it('renders CartFAB when cart has items', () => {
+    const { getByTestId } = renderTabs();
+    expect(getByTestId('cart-fab')).toBeTruthy();
+  });
+
+  it('does not render CartFAB when cart is empty', () => {
+    mockUseCart.mockReturnValue({ itemCount: 0, items: [], subtotal: 0 });
+    const { queryByTestId } = renderTabs();
+    expect(queryByTestId('cart-fab')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `CartFAB` floating action button to `TabNavigator` — persistent mini-cart trigger accessible from any tab screen
- Opens existing `MiniCartDrawer` slide-up sheet (provider/host already in App.tsx)
- 10 new tests: 8 CartFAB unit + 2 TabNavigator integration
- Full suite: 5021 tests passing

## Test plan
- [ ] CartFAB visible on Home, Shop, Cart, Account tabs
- [ ] Tapping FAB opens mini-cart drawer slide-up
- [ ] Drawer shows cart item count badge on FAB
- [ ] Drawer dismisses on backdrop tap and swipe-down
- [ ] All 5021 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)