### PR TITLE
feat(cm-exw): Bundle Builder — Pairs Well With scroll row on PDP

### DIFF
--- a/src/components/BundleRow.tsx
+++ b/src/components/BundleRow.tsx
@@ -22,9 +22,7 @@ interface Props {
 export const BundleRow = memo(function BundleRow({ products, onProductPress, testID }: Props) {
   if (products.length === 0) return null;
 
-  return (
-    <BundleRowInner products={products} onProductPress={onProductPress} testID={testID} />
-  );
+  return <BundleRowInner products={products} onProductPress={onProductPress} testID={testID} />;
 });
 
 function BundleRowInner({ products, onProductPress, testID }: Props) {

--- a/src/components/__tests__/BundleRow.test.tsx
+++ b/src/components/__tests__/BundleRow.test.tsx
@@ -30,21 +30,13 @@ jest.mock('expo-haptics', () => ({
 const futons = PRODUCTS.filter((p) => p.category === 'futons').slice(0, 3);
 const [productA, productB, productC] = futons;
 
-function renderBundleRow(
-  products: Product[],
-  onProductPress = jest.fn(),
-  testID = 'bundle-row',
-) {
+function renderBundleRow(products: Product[], onProductPress = jest.fn(), testID = 'bundle-row') {
   return {
     ...render(
       <ThemeProvider>
         <WishlistProvider>
           <CompareProvider>
-            <BundleRow
-              products={products}
-              onProductPress={onProductPress}
-              testID={testID}
-            />
+            <BundleRow products={products} onProductPress={onProductPress} testID={testID} />
           </CompareProvider>
         </WishlistProvider>
       </ThemeProvider>,

--- a/src/hooks/__tests__/useBundleDeals.test.ts
+++ b/src/hooks/__tests__/useBundleDeals.test.ts
@@ -14,10 +14,7 @@ const PRODUCT_A = PRODUCTS[0];
 const PRODUCT_B = PRODUCTS[1];
 
 /** A BundleDeals data item for a given productId */
-function makeBundleData(
-  productId: string,
-  relatedProductIds: string[],
-): Record<string, unknown> {
+function makeBundleData(productId: string, relatedProductIds: string[]): Record<string, unknown> {
   return { productId, relatedProductIds };
 }
 


### PR DESCRIPTION
## Summary

- Adds `useBundleDeals` hook querying BundleDeals Wix collection by `productId`, mapping `relatedProductIds` to Product objects
- Renders `BundleRow` horizontal ProductCard scroll below fabric picker on ProductDetailScreen; hides automatically when no bundle deals exist
- Tap on bundle item shows Alert.alert confirmation then adds item with default fabric to cart

## Test plan

- [x] 15 hook tests (useBundleDeals — loading, data, empty, error states)
- [x] 10 component tests (BundleRow — render, empty hide, tap-to-add flow)
- [x] 4,955 total tests passing

Closes cm-exw

🤖 Generated with [Claude Code](https://claude.com/claude-code)