### PR TITLE
feat: align gamified shipping tiers with Wix shippingIntelligence API (cm-z5f)

### DIFF
--- a/src/screens/CheckoutScreen.tsx
+++ b/src/screens/CheckoutScreen.tsx
@@ -49,6 +49,11 @@ import { initiateAffirmCheckout } from '@/services/affirmService';
 import { useOptionalWixClient } from '@/services/wix';
 import { useKlarnaCheckout } from '@/hooks/useKlarnaCheckout';
 import { getDeliveryEstimate } from '@/utils/deliveryEstimate';
+import {
+  fetchShippingOptions,
+  normalizeShippingOption,
+  type NormalizedShippingOption,
+} from '@/services/shippingIntelligenceService';
 
 const SHIPPING_THRESHOLD = 499;
 
@@ -195,69 +200,11 @@ const PAYMENT_OPTIONS: PaymentOption[] = [
   },
 ];
 
-// ── cm-m4w: gamified shipping badge layer ─────────────────────────────────────
-// PLACEHOLDER: Badge metadata is hardcoded here while Melania's shipping
-//   intelligence API is being built. Each option maps to a badge type and copy.
-// TODO(stilgar): Replace SHIPPING_DELIVERY_OPTIONS with real API response once
-//   Melania's shipping-intelligence service returns per-ZIP badge + upsell data.
-// SOURCE: Will come from shipping-intelligence service (tier/badge/upsell metadata
-//   keyed by ZIP prefix from cm-mk8 delivery window estimator).
-
-type DeliveryBadgeType = 'popular' | 'premium-experience' | 'local-love' | 'savings';
-
-interface DeliveryBadge {
-  type: DeliveryBadgeType;
-  label: string;
-}
-
-interface DeliveryOption {
-  id: string;
-  label: string;
-  /** 0 = FREE */
-  price: number;
-  badge: DeliveryBadge;
-}
-
-// PLACEHOLDER: Hardcoded 4 shipping tiers with mock badge types.
-// TODO(stilgar): Replace with real shipping-intelligence API response per ZIP.
-const SHIPPING_DELIVERY_OPTIONS: DeliveryOption[] = [
-  {
-    id: 'standard',
-    label: 'Standard Shipping',
-    price: 0,
-    // PLACEHOLDER: 'Popular' badge — most customers choose this; real data from analytics.
-    badge: { type: 'popular', label: 'Popular' },
-  },
-  {
-    id: 'white-glove',
-    label: 'White Glove Delivery',
-    price: 14900,
-    // PLACEHOLDER: 'Premium Experience' badge — concierge setup included.
-    badge: { type: 'premium-experience', label: 'Premium Experience' },
-  },
-  {
-    id: 'local',
-    label: 'Local Delivery',
-    price: 4900,
-    // PLACEHOLDER: 'Local Love' badge — shown for eligible ZIP tiers (NC).
-    badge: { type: 'local-love', label: 'Local Love' },
-  },
-  {
-    id: 'discounted',
-    label: 'Express (On Sale)',
-    price: 7900,
-    // PLACEHOLDER: 'You save X' badge — placeholder savings amount $50.
-    // TODO(stilgar): Wire real discount delta from shipping-intelligence API.
-    badge: { type: 'savings', label: 'You save $50' },
-  },
-];
-
-// Badge background colors keyed by type.
-// PLACEHOLDER: Colors are stand-in — replace with design tokens once finalized.
-const BADGE_COLORS: Record<DeliveryBadgeType, string> = {
-  popular: '#2E7D32',
-  'premium-experience': '#6A1B9A',
-  'local-love': '#E65100',
+/** Badge background colors keyed by badgeStyle from shippingIntelligence API (cm-z5f) */
+const BADGE_STYLE_COLORS: Record<string, string> = {
+  premium: '#6A1B9A',
+  freight: '#E65100',
+  local: '#2E7D32',
   savings: '#1565C0',
 };
 
@@ -347,10 +294,42 @@ export function CheckoutScreen({ onOrderComplete, onBack, testID }: Props) {
   const [shippingErrors, setShippingErrors] = useState<AddressErrors>({});
   const [billingErrors, setBillingErrors] = useState<AddressErrors>({});
 
-  // Delivery method selection — defaults to 'standard' (free shipping)
-  // PLACEHOLDER: Will be driven by ZIP-tier logic from cm-mk8 delivery window estimator.
-  // TODO(stilgar): Filter/rank options via shipping-intelligence API response.
-  const [selectedDelivery, setSelectedDelivery] = useState<string>('standard');
+  // Delivery method selection — driven by shippingIntelligence API (cm-z5f)
+  const [selectedDelivery, setSelectedDelivery] = useState<string | null>(null);
+  const [shippingOptions, setShippingOptions] = useState<NormalizedShippingOption[]>([]);
+  const [shippingOptionsLoading, setShippingOptionsLoading] = useState(false);
+
+  // Fetch shipping options when ZIP changes (cm-z5f)
+  useEffect(() => {
+    const zip = shippingAddress.zip;
+    if (!zip || !/^\d{5}(-\d{4})?$/.test(zip.trim())) return;
+
+    let cancelled = false;
+    setShippingOptionsLoading(true);
+
+    const cartItems = items.map((item: CartItem) => ({
+      productId: item.model.id,
+      quantity: item.quantity,
+      price: Math.round(item.unitPrice * 100),
+    }));
+
+    (async () => {
+      const result = wixClient
+        ? await fetchShippingOptions(wixClient, zip, cartItems)
+        : { success: false, options: [] };
+      if (cancelled) return;
+      if (result.success && result.options.length > 0) {
+        const normalized = result.options.map(normalizeShippingOption);
+        setShippingOptions(normalized);
+        setSelectedDelivery((prev) => prev ?? normalized[0].id);
+      }
+      setShippingOptionsLoading(false);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [shippingAddress.zip]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Card state
   const [cardComplete, setCardComplete] = useState(false);
@@ -848,84 +827,109 @@ export function CheckoutScreen({ onOrderComplete, onBack, testID }: Props) {
           {renderAddressForm(shippingAddress, shippingErrors, updateShippingField, 'shipping')}
         </View>
 
-        {/* Delivery Method — cm-m4w gamified shipping badge layer */}
-        {/* PLACEHOLDER: Options hardcoded; will be driven by shipping-intelligence API. */}
-        {/* TODO(stilgar): Wire to cm-mk8 ZIP tier + Melania's badge/upsell metadata. */}
-        <View
-          style={[styles.section, { paddingHorizontal: spacing.lg }]}
-          testID="delivery-method-section"
-        >
-          <Text
-            style={[
-              styles.sectionTitle,
-              { color: colors.espresso, fontFamily: typography.bodyFamilySemiBold },
-            ]}
-            testID="delivery-method-title"
-            accessibilityRole="header"
+        {/* Delivery Method — live from shippingIntelligence API (cm-z5f) */}
+        {shippingOptions.length > 0 && (
+          <View
+            style={[styles.section, { paddingHorizontal: spacing.lg }]}
+            testID="delivery-method-section"
           >
-            Delivery Method
-          </Text>
-          {SHIPPING_DELIVERY_OPTIONS.map((option) => {
-            const isSelected = selectedDelivery === option.id;
-            return (
-              <TouchableOpacity
-                key={option.id}
-                style={[
-                  styles.deliveryOption,
-                  {
-                    borderColor: isSelected ? colors.mountainBlue : colors.sandDark,
-                    borderRadius: borderRadius.card,
-                    backgroundColor: isSelected ? colors.sandLight : colors.sandBase,
-                  },
-                ]}
-                onPress={() => setSelectedDelivery(option.id)}
-                testID={`delivery-option-${option.id}`}
-                accessibilityRole="radio"
-                accessibilityState={{ selected: isSelected }}
-                accessibilityLabel={`${option.label}, ${option.price === 0 ? 'Free' : formatPrice(option.price)}, ${option.badge.label}`}
-              >
-                {/* Selection indicator */}
-                <View
-                  style={[
-                    styles.deliveryRadio,
-                    {
-                      borderColor: isSelected ? colors.mountainBlue : colors.sandDark,
-                      backgroundColor: isSelected ? colors.mountainBlue : 'transparent',
-                    },
-                  ]}
-                />
-                {/* Label + badge */}
-                <View style={styles.deliveryInfo}>
-                  <View style={styles.deliveryLabelRow}>
-                    <Text
-                      style={[styles.deliveryLabel, { color: colors.espresso }]}
-                      testID={`delivery-label-${option.id}`}
-                    >
-                      {option.label}
-                    </Text>
-                    {/* Gamified badge */}
+            <Text
+              style={[
+                styles.sectionTitle,
+                { color: colors.espresso, fontFamily: typography.bodyFamilySemiBold },
+              ]}
+              testID="delivery-method-title"
+              accessibilityRole="header"
+            >
+              Delivery Method
+            </Text>
+            {shippingOptionsLoading ? (
+              <BrandedSpinner testID="delivery-options-loading" />
+            ) : (
+              shippingOptions.map((option) => {
+                const isSelected = selectedDelivery === option.id;
+                const badgeColor = option.badgeStyle
+                  ? (BADGE_STYLE_COLORS[option.badgeStyle] ?? '#555')
+                  : null;
+                return (
+                  <TouchableOpacity
+                    key={option.id}
+                    style={[
+                      styles.deliveryOption,
+                      option.highlight && styles.deliveryOptionHighlight,
+                      {
+                        borderColor: isSelected ? colors.mountainBlue : colors.sandDark,
+                        borderRadius: borderRadius.card,
+                        backgroundColor: isSelected ? colors.sandLight : colors.sandBase,
+                      },
+                    ]}
+                    onPress={() => setSelectedDelivery(option.id)}
+                    testID={`delivery-option-${option.id}`}
+                    accessibilityRole="radio"
+                    accessibilityState={{ selected: isSelected }}
+                    accessibilityLabel={`${option.label}, ${option.priceCents === 0 ? 'Free' : formatPrice(option.priceCents)}`}
+                  >
+                    {/* Selection indicator */}
                     <View
                       style={[
-                        styles.deliveryBadge,
-                        { backgroundColor: BADGE_COLORS[option.badge.type] },
+                        styles.deliveryRadio,
+                        {
+                          borderColor: isSelected ? colors.mountainBlue : colors.sandDark,
+                          backgroundColor: isSelected ? colors.mountainBlue : 'transparent',
+                        },
                       ]}
-                    >
-                      <Text style={styles.deliveryBadgeText} testID={`delivery-badge-${option.id}`}>
-                        {option.badge.label}
+                    />
+                    {/* Label + badge + upsell */}
+                    <View style={styles.deliveryInfo}>
+                      <View style={styles.deliveryLabelRow}>
+                        <Text
+                          style={[styles.deliveryLabel, { color: colors.espresso }]}
+                          testID={`delivery-label-${option.id}`}
+                        >
+                          {option.icon} {option.label}
+                        </Text>
+                        {option.badge && badgeColor && (
+                          <View
+                            style={[styles.deliveryBadge, { backgroundColor: badgeColor }]}
+                          >
+                            <Text
+                              style={styles.deliveryBadgeText}
+                              testID={`delivery-badge-${option.id}`}
+                            >
+                              {option.badge}
+                            </Text>
+                          </View>
+                        )}
+                      </View>
+                      <Text
+                        style={[styles.deliveryPrice, { color: colors.espressoLight }]}
+                        testID={`delivery-price-${option.id}`}
+                      >
+                        {option.priceCents === 0 ? 'FREE' : formatPrice(option.priceCents)}
                       </Text>
+                      {option.upsellMessage && (
+                        <Text
+                          style={[styles.deliveryUpsell, { color: colors.mountainBlue }]}
+                          testID={`delivery-upsell-${option.id}`}
+                        >
+                          {option.upsellMessage}
+                        </Text>
+                      )}
+                      {option.terrainSurcharge !== undefined && option.terrainSurcharge > 0 && (
+                        <Text
+                          style={[styles.deliveryUpsell, { color: colors.espressoLight }]}
+                          testID={`delivery-terrain-${option.id}`}
+                        >
+                          +{formatPrice(option.terrainSurcharge * 100)} mountain surcharge
+                        </Text>
+                      )}
                     </View>
-                  </View>
-                  <Text
-                    style={[styles.deliveryPrice, { color: colors.espressoLight }]}
-                    testID={`delivery-price-${option.id}`}
-                  >
-                    {option.price === 0 ? 'FREE' : formatPrice(option.price)}
-                  </Text>
-                </View>
-              </TouchableOpacity>
-            );
-          })}
-        </View>
+                  </TouchableOpacity>
+                );
+              })
+            )}
+          </View>
+        )}
 
         {/* Billing / Shipping Toggle */}
         <View
@@ -1686,6 +1690,14 @@ const styles = StyleSheet.create({
   deliveryPrice: {
     fontSize: 12,
     marginTop: 2,
+  },
+  deliveryOptionHighlight: {
+    borderWidth: 2,
+  },
+  deliveryUpsell: {
+    fontSize: 11,
+    marginTop: 3,
+    fontStyle: 'italic' as const,
   },
   shippingNote: {
     fontSize: 12,

--- a/src/screens/__tests__/CheckoutScreen.test.tsx
+++ b/src/screens/__tests__/CheckoutScreen.test.tsx
@@ -132,7 +132,19 @@ jest.mock('@stripe/stripe-react-native', () => ({
 
 // Mock useWixClient
 jest.mock('@/services/wix', () => ({
-  useOptionalWixClient: () => ({ createPaymentIntent: jest.fn(), confirmOrder: jest.fn() }),
+  useOptionalWixClient: () => ({
+    createPaymentIntent: jest.fn(),
+    confirmOrder: jest.fn(),
+    callFunction: jest.fn(),
+  }),
+}));
+
+// Mock shippingIntelligenceService — default: no options (ZIP not yet entered)
+const mockFetchShippingOptions = jest.fn().mockResolvedValue({ success: false, options: [] });
+jest.mock('@/services/shippingIntelligenceService', () => ({
+  fetchShippingOptions: (...args: any[]) => mockFetchShippingOptions(...args),
+  normalizeShippingOption: jest.requireActual('@/services/shippingIntelligenceService')
+    .normalizeShippingOption,
 }));
 
 // Mock Affirm hooks/service so the full Affirm module tree doesn't load
@@ -979,135 +991,211 @@ describe('CheckoutScreen', () => {
     });
   });
 
-  // ── cm-m4w: gamified shipping badge layer ──────────────────────────────────
+  // ── cm-z5f: gamified delivery method section (aligned with Wix shippingIntelligence) ─
 
-  describe('Gamified shipping badges', () => {
+  const WIX_OPTIONS = [
+    {
+      code: 'local-delivery-asheville',
+      title: '🚚 Asheville Area Delivery',
+      price: '0.00',
+      currency: 'USD',
+      deliveryTime: '2–3 business days',
+      badge: 'Local Love',
+      badgeStyle: 'local',
+      upsellMessage: 'Free delivery in Asheville!',
+      highlight: true,
+      icon: '🚚',
+    },
+    {
+      code: 'white-glove-asheville',
+      title: '✨ White Glove Delivery',
+      price: '149.00',
+      currency: 'USD',
+      deliveryTime: '2–3 business days',
+      badge: 'Premium Experience',
+      badgeStyle: 'premium',
+      upsellMessage: null,
+      highlight: false,
+      icon: '✨',
+      terrainSurcharge: 25,
+    },
+    {
+      code: 'UPS_GROUND',
+      title: '📦 UPS Ground',
+      price: '49.00',
+      currency: 'USD',
+      deliveryTime: '5–7 business days',
+      badge: null,
+      badgeStyle: null,
+      upsellMessage: null,
+      highlight: false,
+      icon: '📦',
+    },
+  ];
+
+  describe('gamified delivery method section (cm-z5f)', () => {
     const seed = [{ model: asheville, fabric: naturalLinen, qty: 1 }];
 
-    it('renders the delivery method section', async () => {
+    beforeEach(() => {
+      mockFetchShippingOptions.mockResolvedValue({ success: true, options: WIX_OPTIONS });
+    });
+
+    afterEach(() => {
+      mockFetchShippingOptions.mockResolvedValue({ success: false, options: [] });
+    });
+
+    it('does not show delivery section before a valid ZIP is entered', async () => {
       const utils = renderCheckout({}, seed);
+      await act(async () => {});
+      expect(utils.queryByTestId('delivery-method-section')).toBeNull();
+    });
+
+    it('shows delivery section after valid ZIP is entered', async () => {
+      const utils = renderCheckout({}, seed);
+      await act(async () => {});
+      fireEvent.changeText(utils.getByTestId('shipping-zip'), '28801');
       await act(async () => {});
       expect(utils.getByTestId('delivery-method-section')).toBeTruthy();
     });
 
-    it('renders all four delivery option rows', async () => {
+    it('renders delivery method title', async () => {
       const utils = renderCheckout({}, seed);
       await act(async () => {});
-      expect(utils.getByTestId('delivery-option-standard')).toBeTruthy();
-      expect(utils.getByTestId('delivery-option-white-glove')).toBeTruthy();
-      expect(utils.getByTestId('delivery-option-local')).toBeTruthy();
-      expect(utils.getByTestId('delivery-option-discounted')).toBeTruthy();
+      fireEvent.changeText(utils.getByTestId('shipping-zip'), '28801');
+      await act(async () => {});
+      expect(utils.getByTestId('delivery-method-title')).toBeTruthy();
     });
 
-    it('shows Popular badge on standard shipping option', async () => {
+    it('renders all three options returned by the API', async () => {
       const utils = renderCheckout({}, seed);
       await act(async () => {});
-      expect(utils.getByTestId('delivery-badge-standard')).toBeTruthy();
-      expect(utils.getByTestId('delivery-badge-standard').props.children).toBe('Popular');
+      fireEvent.changeText(utils.getByTestId('shipping-zip'), '28801');
+      await act(async () => {});
+      expect(utils.getByTestId('delivery-option-local-delivery-asheville')).toBeTruthy();
+      expect(utils.getByTestId('delivery-option-white-glove-asheville')).toBeTruthy();
+      expect(utils.getByTestId('delivery-option-UPS_GROUND')).toBeTruthy();
+    });
+
+    it('auto-selects the first option on load', async () => {
+      const utils = renderCheckout({}, seed);
+      await act(async () => {});
+      fireEvent.changeText(utils.getByTestId('shipping-zip'), '28801');
+      await act(async () => {});
+      expect(
+        utils.getByTestId('delivery-option-local-delivery-asheville').props.accessibilityState
+          ?.selected,
+      ).toBe(true);
+    });
+
+    it('shows badge text for option with badge', async () => {
+      const utils = renderCheckout({}, seed);
+      await act(async () => {});
+      fireEvent.changeText(utils.getByTestId('shipping-zip'), '28801');
+      await act(async () => {});
+      expect(utils.getByTestId('delivery-badge-local-delivery-asheville')).toBeTruthy();
+      expect(utils.getByTestId('delivery-badge-local-delivery-asheville').props.children).toBe(
+        'Local Love',
+      );
     });
 
     it('shows Premium Experience badge on white glove option', async () => {
       const utils = renderCheckout({}, seed);
       await act(async () => {});
-      expect(utils.getByTestId('delivery-badge-white-glove')).toBeTruthy();
-      expect(utils.getByTestId('delivery-badge-white-glove').props.children).toBe(
+      fireEvent.changeText(utils.getByTestId('shipping-zip'), '28801');
+      await act(async () => {});
+      expect(utils.getByTestId('delivery-badge-white-glove-asheville').props.children).toBe(
         'Premium Experience',
       );
     });
 
-    it('shows Local Love badge on local delivery option', async () => {
+    it('does not show badge for option with null badge', async () => {
       const utils = renderCheckout({}, seed);
       await act(async () => {});
-      expect(utils.getByTestId('delivery-badge-local')).toBeTruthy();
-      expect(utils.getByTestId('delivery-badge-local').props.children).toBe('Local Love');
+      fireEvent.changeText(utils.getByTestId('shipping-zip'), '28801');
+      await act(async () => {});
+      expect(utils.queryByTestId('delivery-badge-UPS_GROUND')).toBeNull();
     });
 
-    it('shows You save X badge on discounted tier', async () => {
+    it('shows FREE price for zero-cost option', async () => {
       const utils = renderCheckout({}, seed);
       await act(async () => {});
-      expect(utils.getByTestId('delivery-badge-discounted')).toBeTruthy();
-      const badgeText = utils.getByTestId('delivery-badge-discounted').props.children;
-      expect(typeof badgeText).toBe('string');
-      expect(badgeText).toMatch(/you save/i);
-    });
-
-    it('standard option is selected by default', async () => {
-      const utils = renderCheckout({}, seed);
+      fireEvent.changeText(utils.getByTestId('shipping-zip'), '28801');
       await act(async () => {});
-      const option = utils.getByTestId('delivery-option-standard');
-      expect(option.props.accessibilityState?.selected).toBe(true);
-    });
-
-    it('selecting another option deselects standard', async () => {
-      const utils = renderCheckout({}, seed);
-      await act(async () => {});
-      fireEvent.press(utils.getByTestId('delivery-option-white-glove'));
-      await act(async () => {});
-      expect(utils.getByTestId('delivery-option-standard').props.accessibilityState?.selected).toBe(
-        false,
+      expect(utils.getByTestId('delivery-price-local-delivery-asheville').props.children).toBe(
+        'FREE',
       );
+    });
+
+    it('shows formatted price for paid option', async () => {
+      const utils = renderCheckout({}, seed);
+      await act(async () => {});
+      fireEvent.changeText(utils.getByTestId('shipping-zip'), '28801');
+      await act(async () => {});
+      const priceText = utils.getByTestId('delivery-price-UPS_GROUND').props.children;
+      expect(priceText).toMatch(/\$?49/);
+    });
+
+    it('shows upsell message for local option', async () => {
+      const utils = renderCheckout({}, seed);
+      await act(async () => {});
+      fireEvent.changeText(utils.getByTestId('shipping-zip'), '28801');
+      await act(async () => {});
+      expect(utils.getByTestId('delivery-upsell-local-delivery-asheville').props.children).toBe(
+        'Free delivery in Asheville!',
+      );
+    });
+
+    it('shows terrain surcharge for white glove option', async () => {
+      const utils = renderCheckout({}, seed);
+      await act(async () => {});
+      fireEvent.changeText(utils.getByTestId('shipping-zip'), '28801');
+      await act(async () => {});
+      expect(utils.getByTestId('delivery-terrain-white-glove-asheville')).toBeTruthy();
+    });
+
+    it('selecting another option deselects the current one', async () => {
+      const utils = renderCheckout({}, seed);
+      await act(async () => {});
+      fireEvent.changeText(utils.getByTestId('shipping-zip'), '28801');
+      await act(async () => {});
+      fireEvent.press(utils.getByTestId('delivery-option-white-glove-asheville'));
+      await act(async () => {});
       expect(
-        utils.getByTestId('delivery-option-white-glove').props.accessibilityState?.selected,
+        utils.getByTestId('delivery-option-local-delivery-asheville').props.accessibilityState
+          ?.selected,
+      ).toBe(false);
+      expect(
+        utils.getByTestId('delivery-option-white-glove-asheville').props.accessibilityState
+          ?.selected,
       ).toBe(true);
     });
 
-    it('each delivery option shows its label', async () => {
+    it('options have radio accessibility role', async () => {
       const utils = renderCheckout({}, seed);
       await act(async () => {});
-      expect(utils.getByTestId('delivery-label-standard')).toBeTruthy();
-      expect(utils.getByTestId('delivery-label-white-glove')).toBeTruthy();
-      expect(utils.getByTestId('delivery-label-local')).toBeTruthy();
-      expect(utils.getByTestId('delivery-label-discounted')).toBeTruthy();
+      fireEvent.changeText(utils.getByTestId('shipping-zip'), '28801');
+      await act(async () => {});
+      expect(
+        utils.getByTestId('delivery-option-local-delivery-asheville').props.accessibilityRole,
+      ).toBe('radio');
     });
 
-    it('each delivery option shows its price', async () => {
+    it('hides delivery section if API returns no options', async () => {
+      mockFetchShippingOptions.mockResolvedValueOnce({ success: false, options: [] });
       const utils = renderCheckout({}, seed);
       await act(async () => {});
-      expect(utils.getByTestId('delivery-price-standard')).toBeTruthy();
-      expect(utils.getByTestId('delivery-price-white-glove')).toBeTruthy();
-      expect(utils.getByTestId('delivery-price-local')).toBeTruthy();
-      expect(utils.getByTestId('delivery-price-discounted')).toBeTruthy();
+      fireEvent.changeText(utils.getByTestId('shipping-zip'), '28801');
+      await act(async () => {});
+      expect(utils.queryByTestId('delivery-method-section')).toBeNull();
     });
 
-    it('standard option shows FREE price', async () => {
+    it('does not call fetchShippingOptions for invalid ZIP', async () => {
+      mockFetchShippingOptions.mockClear();
       const utils = renderCheckout({}, seed);
       await act(async () => {});
-      expect(utils.getByTestId('delivery-price-standard').props.children).toBe('FREE');
-    });
-
-    it('delivery options have button accessibility role', async () => {
-      const utils = renderCheckout({}, seed);
+      fireEvent.changeText(utils.getByTestId('shipping-zip'), 'ABCDE');
       await act(async () => {});
-      expect(utils.getByTestId('delivery-option-standard').props.accessibilityRole).toBe('radio');
-    });
-
-    it('section has a section title', async () => {
-      const utils = renderCheckout({}, seed);
-      await act(async () => {});
-      expect(utils.getByTestId('delivery-method-title')).toBeTruthy();
-    });
-
-    it('badge colors differ by type (placeholder: badge has distinct testID per type)', async () => {
-      const utils = renderCheckout({}, seed);
-      await act(async () => {});
-      // All 4 badge testIDs must be unique and present
-      const ids = [
-        'delivery-badge-standard',
-        'delivery-badge-white-glove',
-        'delivery-badge-local',
-        'delivery-badge-discounted',
-      ];
-      for (const id of ids) {
-        expect(utils.getByTestId(id)).toBeTruthy();
-      }
-    });
-
-    it('does not show delivery section during loading/error', async () => {
-      // Loading state: no items → totals still render, delivery section should appear regardless
-      // (delivery section is always present when form loads)
-      const utils = renderCheckout({}, seed);
-      await act(async () => {});
-      expect(utils.getByTestId('delivery-method-section')).toBeTruthy();
+      expect(mockFetchShippingOptions).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/services/__tests__/shippingIntelligenceService.test.ts
+++ b/src/services/__tests__/shippingIntelligenceService.test.ts
@@ -1,0 +1,264 @@
+/**
+ * Tests for shippingIntelligenceService — cm-z5f
+ *
+ * Validates the service wrapper that calls the Wix shippingIntelligence
+ * webMethod and returns aligned option data.
+ */
+
+import { fetchShippingOptions, normalizeShippingOption } from '../shippingIntelligenceService';
+import { WixClient } from '@/services/wix/wixClient';
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const LOCAL_DELIVERY_OPTION = {
+  code: 'local-delivery-asheville',
+  title: '🚚 Asheville Area Delivery',
+  price: '0.00',
+  currency: 'USD',
+  deliveryTime: '2–3 business days',
+  badge: 'Local Love',
+  badgeStyle: 'local',
+  upsellMessage: 'Free delivery in Asheville!',
+  highlight: true,
+  icon: '🚚',
+};
+
+const WHITE_GLOVE_OPTION = {
+  code: 'white-glove-asheville',
+  title: '✨ White Glove Delivery',
+  price: '149.00',
+  currency: 'USD',
+  deliveryTime: '2–3 business days',
+  badge: 'Premium Experience',
+  badgeStyle: 'premium',
+  upsellMessage: 'We set it up for you!',
+  highlight: false,
+  icon: '✨',
+  terrainSurcharge: 25,
+};
+
+const UPS_GROUND_OPTION = {
+  code: 'UPS_GROUND',
+  title: '📦 UPS Ground',
+  price: '49.00',
+  currency: 'USD',
+  deliveryTime: '5–7 business days',
+  badge: null,
+  badgeStyle: null,
+  upsellMessage: null,
+  highlight: false,
+  icon: '📦',
+  isEstimate: true,
+};
+
+const LTL_FREIGHT_OPTION = {
+  code: 'WWEX_LTL_STANDARD',
+  title: '🚛 LTL Freight',
+  price: '299.00',
+  currency: 'USD',
+  deliveryTime: '7–10 business days',
+  badge: null,
+  badgeStyle: 'freight',
+  upsellMessage: null,
+  highlight: false,
+  icon: '🚛',
+  isLTL: true,
+  isEstimate: false,
+};
+
+const SUCCESS_RESULT = {
+  success: true,
+  options: [LOCAL_DELIVERY_OPTION, WHITE_GLOVE_OPTION, UPS_GROUND_OPTION],
+};
+
+const CART_ITEMS = [{ productId: 'prod-123', quantity: 1, price: 89900 }];
+
+// ── Mock WixClient ────────────────────────────────────────────────────────
+
+function makeMockClient(response: unknown) {
+  return {
+    callFunction: jest.fn().mockResolvedValue(response),
+  } as unknown as WixClient;
+}
+
+function makeFailingClient(error: Error) {
+  return {
+    callFunction: jest.fn().mockRejectedValue(error),
+  } as unknown as WixClient;
+}
+
+// ── fetchShippingOptions ──────────────────────────────────────────────────
+
+describe('fetchShippingOptions', () => {
+  it('returns options array on success', async () => {
+    const client = makeMockClient(SUCCESS_RESULT);
+    const result = await fetchShippingOptions(client, '28801', CART_ITEMS);
+    expect(result.success).toBe(true);
+    expect(result.options).toHaveLength(3);
+  });
+
+  it('calls the correct Wix function path', async () => {
+    const client = makeMockClient(SUCCESS_RESULT);
+    await fetchShippingOptions(client, '28801', CART_ITEMS);
+    expect(client.callFunction).toHaveBeenCalledWith(
+      '/_functions/shippingIntelligence/calculateBundleQuote',
+      'POST',
+      expect.objectContaining({ zip: '28801', items: CART_ITEMS }),
+    );
+  });
+
+  it('passes zip and items to the API', async () => {
+    const client = makeMockClient(SUCCESS_RESULT);
+    const items = [
+      { productId: 'a', quantity: 2, price: 50000 },
+      { productId: 'b', quantity: 1, price: 75000 },
+    ];
+    await fetchShippingOptions(client, '27703', items);
+    expect(client.callFunction).toHaveBeenCalledWith(
+      expect.any(String),
+      'POST',
+      expect.objectContaining({ zip: '27703', items }),
+    );
+  });
+
+  it('returns error result when API returns success:false', async () => {
+    const client = makeMockClient({ success: false, error: 'Invalid ZIP', options: [] });
+    const result = await fetchShippingOptions(client, '00000', CART_ITEMS);
+    expect(result.success).toBe(false);
+    expect(result.options).toEqual([]);
+    expect(result.error).toBe('Invalid ZIP');
+  });
+
+  it('returns error result on network failure', async () => {
+    const client = makeFailingClient(new Error('Network error'));
+    const result = await fetchShippingOptions(client, '28801', CART_ITEMS);
+    expect(result.success).toBe(false);
+    expect(result.options).toEqual([]);
+    expect(result.error).toMatch(/network|unavailable/i);
+  });
+
+  it('returns error result on timeout', async () => {
+    const client = makeFailingClient(
+      Object.assign(new Error('Request timeout after 10000ms'), { statusCode: undefined }),
+    );
+    const result = await fetchShippingOptions(client, '28801', CART_ITEMS);
+    expect(result.success).toBe(false);
+    expect(result.options).toEqual([]);
+  });
+
+  it('handles empty items array gracefully', async () => {
+    const client = makeMockClient(SUCCESS_RESULT);
+    const result = await fetchShippingOptions(client, '28801', []);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid ZIP (non-5-digit)', async () => {
+    const client = makeMockClient(SUCCESS_RESULT);
+    const result = await fetchShippingOptions(client, 'ABCDE', CART_ITEMS);
+    expect(result.success).toBe(false);
+    expect(client.callFunction).not.toHaveBeenCalled();
+  });
+
+  it('rejects empty ZIP', async () => {
+    const client = makeMockClient(SUCCESS_RESULT);
+    const result = await fetchShippingOptions(client, '', CART_ITEMS);
+    expect(result.success).toBe(false);
+    expect(client.callFunction).not.toHaveBeenCalled();
+  });
+
+  it('accepts ZIP+4 format', async () => {
+    const client = makeMockClient(SUCCESS_RESULT);
+    const result = await fetchShippingOptions(client, '28801-1234', CART_ITEMS);
+    expect(result.success).toBe(true);
+    expect(client.callFunction).toHaveBeenCalled();
+  });
+});
+
+// ── normalizeShippingOption ───────────────────────────────────────────────
+
+describe('normalizeShippingOption', () => {
+  it('maps code as the option id', () => {
+    const norm = normalizeShippingOption(LOCAL_DELIVERY_OPTION);
+    expect(norm.id).toBe('local-delivery-asheville');
+  });
+
+  it('maps title with icon', () => {
+    const norm = normalizeShippingOption(LOCAL_DELIVERY_OPTION);
+    expect(norm.label).toBe('🚚 Asheville Area Delivery');
+  });
+
+  it('maps price as cents (string "0.00" → 0)', () => {
+    const norm = normalizeShippingOption(LOCAL_DELIVERY_OPTION);
+    expect(norm.priceCents).toBe(0);
+  });
+
+  it('maps price "149.00" as cents → 14900', () => {
+    const norm = normalizeShippingOption(WHITE_GLOVE_OPTION);
+    expect(norm.priceCents).toBe(14900);
+  });
+
+  it('maps badge text', () => {
+    const norm = normalizeShippingOption(LOCAL_DELIVERY_OPTION);
+    expect(norm.badge).toBe('Local Love');
+  });
+
+  it('maps null badge', () => {
+    const norm = normalizeShippingOption(UPS_GROUND_OPTION);
+    expect(norm.badge).toBeNull();
+  });
+
+  it('maps badgeStyle', () => {
+    const norm = normalizeShippingOption(WHITE_GLOVE_OPTION);
+    expect(norm.badgeStyle).toBe('premium');
+  });
+
+  it('maps null badgeStyle', () => {
+    const norm = normalizeShippingOption(UPS_GROUND_OPTION);
+    expect(norm.badgeStyle).toBeNull();
+  });
+
+  it('maps upsellMessage', () => {
+    const norm = normalizeShippingOption(LOCAL_DELIVERY_OPTION);
+    expect(norm.upsellMessage).toBe('Free delivery in Asheville!');
+  });
+
+  it('maps null upsellMessage', () => {
+    const norm = normalizeShippingOption(UPS_GROUND_OPTION);
+    expect(norm.upsellMessage).toBeNull();
+  });
+
+  it('maps highlight flag', () => {
+    const norm = normalizeShippingOption(LOCAL_DELIVERY_OPTION);
+    expect(norm.highlight).toBe(true);
+  });
+
+  it('maps highlight false', () => {
+    const norm = normalizeShippingOption(UPS_GROUND_OPTION);
+    expect(norm.highlight).toBe(false);
+  });
+
+  it('maps terrainSurcharge when present', () => {
+    const norm = normalizeShippingOption(WHITE_GLOVE_OPTION);
+    expect(norm.terrainSurcharge).toBe(25);
+  });
+
+  it('maps terrainSurcharge undefined when absent', () => {
+    const norm = normalizeShippingOption(LOCAL_DELIVERY_OPTION);
+    expect(norm.terrainSurcharge).toBeUndefined();
+  });
+
+  it('maps isLTL flag', () => {
+    const norm = normalizeShippingOption(LTL_FREIGHT_OPTION);
+    expect(norm.isLTL).toBe(true);
+  });
+
+  it('maps deliveryTime', () => {
+    const norm = normalizeShippingOption(LOCAL_DELIVERY_OPTION);
+    expect(norm.deliveryTime).toBe('2–3 business days');
+  });
+
+  it('maps icon', () => {
+    const norm = normalizeShippingOption(UPS_GROUND_OPTION);
+    expect(norm.icon).toBe('📦');
+  });
+});

--- a/src/services/shippingIntelligenceService.ts
+++ b/src/services/shippingIntelligenceService.ts
@@ -1,0 +1,136 @@
+/**
+ * @module shippingIntelligenceService
+ *
+ * Calls the Wix shippingIntelligence.web.js backend webMethod and maps
+ * its response to the UI-ready shape used by CheckoutScreen.
+ *
+ * Aligns with the WixShippingOption shape from melania's PR #623:
+ *   code, title, price, badge, badgeStyle, upsellMessage, highlight,
+ *   icon, terrainSurcharge, isLTL, isEstimate
+ *
+ * cm-z5f
+ */
+
+import type { WixClient } from '@/services/wix/wixClient';
+
+const ZIP_RE = /^\d{5}(-\d{4})?$/;
+
+// ── Wix API types (mirrors shippingIntelligence.web.js JSDoc) ────────────────
+
+export interface WixShippingOption {
+  /** Unique method code (e.g. 'local-delivery-asheville', 'UPS_GROUND') */
+  code: string;
+  /** Display title with icon prefix (e.g. '📦 UPS Ground') */
+  title: string;
+  /** Formatted price string (e.g. '49.00') */
+  price: string;
+  currency: string;
+  /** Human-readable delivery window (e.g. '5–7 business days') */
+  deliveryTime: string;
+  /** Gamification badge text, or null */
+  badge: string | null;
+  /** Badge style key: 'premium' | 'freight' | 'local' | 'savings' | null */
+  badgeStyle: string | null;
+  /** Upsell copy shown below option label, or null */
+  upsellMessage: string | null;
+  /** Whether to show a highlighted border on this option row */
+  highlight: boolean;
+  /** Emoji icon for the option */
+  icon: string;
+  /** Additional terrain surcharge for white-glove in mountain zip codes */
+  terrainSurcharge?: number;
+  isLTL?: boolean;
+  isEstimate?: boolean;
+}
+
+export interface WixShippingIntelligenceResult {
+  success: boolean;
+  options: WixShippingOption[];
+  error?: string;
+}
+
+// ── Normalized (UI) shape ─────────────────────────────────────────────────────
+
+export interface NormalizedShippingOption {
+  /** Unique code from the API — used as selection key */
+  id: string;
+  label: string;
+  /** Price in cents (0 = FREE) */
+  priceCents: number;
+  badge: string | null;
+  badgeStyle: string | null;
+  upsellMessage: string | null;
+  highlight: boolean;
+  icon: string;
+  deliveryTime: string;
+  terrainSurcharge?: number;
+  isLTL?: boolean;
+}
+
+export type ShippingCartItem = {
+  productId: string;
+  quantity: number;
+  /** Price in cents */
+  price?: number;
+};
+
+// ── Service function ──────────────────────────────────────────────────────────
+
+/**
+ * Fetch shipping options from the Wix shippingIntelligence backend webMethod.
+ *
+ * @param client  WixClient instance (handles auth + retry)
+ * @param zip     5-digit US ZIP code (accepts ZIP+4 format)
+ * @param items   Cart items to quote. Pass empty array or omit for single-product estimate.
+ */
+export async function fetchShippingOptions(
+  client: WixClient,
+  zip: string,
+  items: ShippingCartItem[] = [],
+): Promise<WixShippingIntelligenceResult> {
+  if (!ZIP_RE.test(zip.trim())) {
+    return { success: false, options: [], error: 'Valid 5-digit ZIP required' };
+  }
+
+  try {
+    const result = await client.callFunction(
+      '/_functions/shippingIntelligence/calculateBundleQuote',
+      'POST',
+      { zip: zip.trim(), items },
+    );
+    return result as WixShippingIntelligenceResult;
+  } catch (err) {
+    return {
+      success: false,
+      options: [],
+      error: err instanceof Error ? err.message : 'Shipping options unavailable',
+    };
+  }
+}
+
+/**
+ * Normalize a raw WixShippingOption to the UI-ready NormalizedShippingOption shape.
+ * Converts price string to cents, maps code → id, etc.
+ */
+export function normalizeShippingOption(option: WixShippingOption): NormalizedShippingOption {
+  const priceCents = Math.round(parseFloat(option.price) * 100);
+
+  const normalized: NormalizedShippingOption = {
+    id: option.code,
+    label: option.title,
+    priceCents,
+    badge: option.badge,
+    badgeStyle: option.badgeStyle,
+    upsellMessage: option.upsellMessage,
+    highlight: option.highlight,
+    icon: option.icon,
+    deliveryTime: option.deliveryTime,
+    isLTL: option.isLTL,
+  };
+
+  if (option.terrainSurcharge !== undefined) {
+    normalized.terrainSurcharge = option.terrainSurcharge;
+  }
+
+  return normalized;
+}

--- a/src/services/wix/wixClient.ts
+++ b/src/services/wix/wixClient.ts
@@ -984,6 +984,22 @@ export class WixClient {
     });
   }
 
+  // ── Generic function caller (webMethods / /_functions/* ) ──────────────────
+
+  /**
+   * Call any Wix backend webMethod via /_functions/<module>/<method>.
+   *
+   * @param path   Full path including /_functions/ prefix
+   * @param method HTTP method (GET or POST)
+   * @param body   Request body for POST calls
+   */
+  async callFunction<T = unknown>(path: string, method: 'GET' | 'POST', body?: unknown): Promise<T> {
+    if (method === 'POST') {
+      return this.post<T>(path, body ?? {});
+    }
+    return this.get<T>(path);
+  }
+
   // ── HTTP helpers ───────────────────────────────────────────
 
   private headers(): Record<string, string> {


### PR DESCRIPTION
## Summary

- Adds `shippingIntelligenceService.ts` — typed wrapper around `shippingIntelligence.web.js` webMethod (`calculateBundleQuote`), with `fetchShippingOptions` and `normalizeShippingOption`
- Adds `callFunction` method to `WixClient` for generic `/_functions/` POST/GET calls
- Replaces hardcoded `SHIPPING_DELIVERY_OPTIONS` placeholder in `CheckoutScreen` with live API-driven options fetched on ZIP change
- Renders `badge`, `badgeStyle`, `upsellMessage`, `terrainSurcharge`, `icon`, `highlight` fields from API response shape

## Test plan

- [x] 27 unit tests for `shippingIntelligenceService` — fetchShippingOptions + normalizeShippingOption
- [x] 14 new CheckoutScreen tests for `gamified delivery method section (cm-z5f)` covering section visibility, option rendering, badge display, price formatting, upsell/terrain, selection behavior, and API error handling
- [x] All 156 CheckoutScreen tests pass

Closes cm-z5f

🤖 Generated with [Claude Code](https://claude.com/claude-code)