### PR TITLE
fix(cm-cii): Wix network error state — retry screen instead of $0.00 fallback

### DIFF
--- a/src/screens/ProductDetailScreen.tsx
+++ b/src/screens/ProductDetailScreen.tsx
@@ -12,6 +12,7 @@ import {
   StyleSheet,
   Text,
   View,
+  Pressable,
   TouchableOpacity,
   FlatList,
   Dimensions,
@@ -126,9 +127,12 @@ export function ProductDetailScreen({
 
   // When Wix is configured and no local model matches, fetch from Wix API
   const isWixProduct = !localModel && isWixConfigured();
-  const { product: wixProduct, isLoading: isWixLoading } = useProductBySlug(
-    isWixProduct ? resolvedId : '',
-  );
+  const {
+    product: wixProduct,
+    isLoading: isWixLoading,
+    error: wixError,
+    refresh: refreshWixProduct,
+  } = useProductBySlug(isWixProduct ? resolvedId : '');
 
   const catalogProductId = resolvedId ? `prod-${resolvedId}` : '';
   const { product: catalogProduct, isLoading: isProductLoading } = useProduct(catalogProductId);
@@ -497,7 +501,31 @@ export function ProductDetailScreen({
     if (wixProduct) {
       return <WixProductDetail product={wixProduct} onBack={onBack} testID={testID} />;
     }
-    // Wix fetch failed or product not found — fall through to local model
+    if (wixError) {
+      return (
+        <View
+          style={[styles.wixErrorContainer, { backgroundColor: colors.sandBase }]}
+          testID="wix-network-error"
+        >
+          <Text style={[styles.wixErrorTitle, { color: colors.espresso }]}>
+            Couldn't load product
+          </Text>
+          <Text style={[styles.wixErrorMessage, { color: colors.espressoLight }]}>
+            Check your connection and try again.
+          </Text>
+          <Pressable
+            style={[styles.wixErrorRetryButton, { backgroundColor: colors.sunsetCoral }]}
+            onPress={refreshWixProduct}
+            testID="wix-network-error-retry"
+            accessibilityRole="button"
+            accessibilityLabel="Retry loading product"
+          >
+            <Text style={[styles.wixErrorRetryText, { color: colors.sandBase }]}>Try Again</Text>
+          </Pressable>
+        </View>
+      );
+    }
+    // Wix product not found — fall through to local model
   }
 
   if (isProductLoading) {
@@ -2131,6 +2159,32 @@ const styles = StyleSheet.create({
   qaSubmitBtnText: {
     color: '#FFFFFF',
     fontSize: 14,
+    fontWeight: '600',
+  },
+  wixErrorContainer: {
+    flex: 1,
+    justifyContent: 'center' as const,
+    alignItems: 'center' as const,
+    padding: 32,
+  },
+  wixErrorTitle: {
+    fontSize: 20,
+    fontWeight: '700',
+    marginBottom: 8,
+    textAlign: 'center' as const,
+  },
+  wixErrorMessage: {
+    fontSize: 15,
+    textAlign: 'center' as const,
+    marginBottom: 24,
+  },
+  wixErrorRetryButton: {
+    paddingHorizontal: 24,
+    paddingVertical: 12,
+    borderRadius: 8,
+  },
+  wixErrorRetryText: {
+    fontSize: 16,
     fontWeight: '600',
   },
 });

--- a/src/screens/__tests__/ProductDetailScreen.test.tsx
+++ b/src/screens/__tests__/ProductDetailScreen.test.tsx
@@ -1582,4 +1582,44 @@ describe('ProductDetailScreen', () => {
       expect(queryByTestId('bnpl-continue-btn')).toBeNull();
     });
   });
+
+  describe('Wix network error state (cm-cii)', () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('shows network error banner when Wix fetch fails', () => {
+      jest.spyOn(require('@/services/wix/config'), 'isWixConfigured').mockReturnValue(true);
+      jest.spyOn(require('@/hooks/useProduct'), 'useProductBySlug').mockReturnValue({
+        product: null,
+        isLoading: false,
+        error: new Error('Network request failed'),
+        refresh: jest.fn(),
+      });
+
+      const { getByTestId } = renderDetail({ productId: 'wix-mesa-5000' });
+      expect(getByTestId('wix-network-error')).toBeTruthy();
+    });
+
+    it('shows retry button on Wix network error and calls refresh', () => {
+      const mockRefresh = jest.fn();
+      jest.spyOn(require('@/services/wix/config'), 'isWixConfigured').mockReturnValue(true);
+      jest.spyOn(require('@/hooks/useProduct'), 'useProductBySlug').mockReturnValue({
+        product: null,
+        isLoading: false,
+        error: new Error('Network request failed'),
+        refresh: mockRefresh,
+      });
+
+      const { getByTestId } = renderDetail({ productId: 'wix-mesa-5000' });
+      fireEvent.press(getByTestId('wix-network-error-retry'));
+      expect(mockRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not show network error when Wix product loads successfully', () => {
+      // Default: isWixConfigured returns false (no env vars in test), local models render fine
+      const { queryByTestId } = renderDetail({ productId: 'asheville-full' });
+      expect(queryByTestId('wix-network-error')).toBeNull();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- When Wix API is unreachable (emulator NAT, no network), `ProductDetailScreen` was silently falling through to static data with `$0.00` price — confusing and misleading
- Now shows a branded error screen with "Couldn't load product" + "Try Again" retry button
- Retry calls `refreshWixProduct` from `useProductBySlug`

## Changes
- `ProductDetailScreen.tsx`: destructure `error` + `refresh` from `useProductBySlug`; render `wix-network-error` view when Wix fetch fails
- `ProductDetailScreen.test.tsx`: 3 new edge-case tests — error banner renders, retry button calls refresh, success path has no error banner

## Test plan
- [ ] All 183 ProductDetailScreen tests pass
- [ ] `wix-network-error` testID visible when Wix unreachable
- [ ] `wix-network-error-retry` press triggers refresh
- [ ] Normal local product renders without error banner

Closes cm-cii

🤖 Generated with [Claude Code](https://claude.com/claude-code)