### PR TITLE
feat(cm-thv): CollectionsScreen error state + skeleton loader

### DIFF
--- a/src/components/SkeletonCollectionCard.tsx
+++ b/src/components/SkeletonCollectionCard.tsx
@@ -1,0 +1,75 @@
+/**
+ * @module SkeletonCollectionCard
+ *
+ * Skeleton loading placeholder matching CollectionCard dimensions:
+ * large hero image with title, subtitle, and mood tags below.
+ * Used while editorial collections are loading.
+ *
+ * cm-thv: CollectionsScreen skeleton / error / empty states
+ */
+import React, { memo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTheme } from '@/theme';
+import { Shimmer, ShimmerLines } from './Shimmer';
+
+const HERO_HEIGHT = 220;
+
+/** Skeleton placeholder matching a single featured CollectionCard. */
+export const SkeletonCollectionCard = memo(function SkeletonCollectionCard({
+  testID,
+}: {
+  testID?: string;
+}) {
+  const { colors, borderRadius, shadows, spacing } = useTheme();
+
+  return (
+    <View
+      style={[
+        styles.card,
+        shadows.card,
+        { backgroundColor: colors.white, borderRadius: borderRadius.card },
+      ]}
+      testID={testID ?? 'skeleton-collection-card'}
+      accessibilityLabel="Loading collection"
+    >
+      {/* Hero image placeholder */}
+      <Shimmer
+        height={HERO_HEIGHT}
+        borderRadius={0}
+        style={{
+          width: '100%',
+          borderTopLeftRadius: borderRadius.card,
+          borderTopRightRadius: borderRadius.card,
+        }}
+      />
+
+      {/* Info area */}
+      <View style={[styles.info, { padding: spacing.md }]}>
+        {/* Title */}
+        <ShimmerLines lines={1} lineHeight={18} gap={0} lastLineWidth="80%" />
+        {/* Subtitle */}
+        <Shimmer width="60%" height={13} style={{ marginTop: 6 }} />
+        {/* Mood tags */}
+        <View style={styles.tagsRow}>
+          <Shimmer width={60} height={22} borderRadius={11} />
+          <Shimmer width={50} height={22} borderRadius={11} />
+        </View>
+      </View>
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  card: {
+    overflow: 'hidden',
+    marginBottom: 12,
+  },
+  info: {
+    gap: 4,
+  },
+  tagsRow: {
+    flexDirection: 'row',
+    gap: 8,
+    marginTop: 8,
+  },
+});

--- a/src/screens/CollectionsScreen.tsx
+++ b/src/screens/CollectionsScreen.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useCallback } from 'react';
-import { Alert, FlatList, StyleSheet, Text, View } from 'react-native';
+import { Alert, FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -20,6 +20,7 @@ import { useMiniCartDrawer } from '@/hooks/useMiniCartDrawer';
 import { CollectionCard } from '@/components/CollectionCard';
 import { PremiumBadge } from '@/components/PremiumBadge';
 import { Header } from '@/components/Header';
+import { SkeletonCollectionCard } from '@/components/SkeletonCollectionCard';
 import { useScrollPerformance } from '@/hooks/useScrollPerformance';
 import type { RootStackParamList } from '@/navigation/AppNavigator';
 import type { EditorialCollection } from '@/data/collections';
@@ -39,7 +40,7 @@ export function CollectionsScreen() {
   const { colors, spacing, typography } = useTheme();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const insets = useSafeAreaInsets();
-  const { collections } = useCollections();
+  const { collections, isLoading, error, refresh } = useCollections();
   const { isPremium } = usePremium();
   const { itemCount } = useCart();
   const { open: openCart } = useMiniCartDrawer();
@@ -115,18 +116,56 @@ export function CollectionsScreen() {
     [colors, spacing, typography],
   );
 
-  return (
-    <View
-      style={[styles.container, { backgroundColor: colors.sandBase }]}
-      testID="collections-screen"
-    >
-      <Header
-        title="Curated Looks"
-        showBack
-        cartCount={itemCount}
-        onCartPress={openCart}
-        testID="collections-header"
-      />
+  const renderContent = () => {
+    if (isLoading) {
+      return (
+        <View
+          testID="collections-skeleton"
+          style={{ paddingHorizontal: spacing.pagePadding, paddingTop: spacing.lg }}
+        >
+          {[0, 1, 2, 3].map((i) => (
+            <SkeletonCollectionCard key={i} testID={`skeleton-collection-card-${i}`} />
+          ))}
+        </View>
+      );
+    }
+
+    if (error) {
+      return (
+        <View testID="collections-error" style={styles.centerContent}>
+          <Text
+            testID="collections-error-message"
+            style={[typography.body, { color: colors.espressoLight, textAlign: 'center' }]}
+          >
+            Something went wrong loading collections.
+          </Text>
+          <TouchableOpacity
+            testID="collections-retry-btn"
+            onPress={refresh}
+            style={[styles.retryBtn, { backgroundColor: colors.espresso }]}
+          >
+            <Text style={[typography.body, { color: colors.white, fontWeight: '600' }]}>
+              Try Again
+            </Text>
+          </TouchableOpacity>
+        </View>
+      );
+    }
+
+    if (collections.length === 0) {
+      return (
+        <View testID="collections-empty" style={styles.centerContent}>
+          <Text
+            testID="collections-empty-message"
+            style={[typography.body, { color: colors.espressoLight, textAlign: 'center' }]}
+          >
+            No collections available right now.
+          </Text>
+        </View>
+      );
+    }
+
+    return (
       <FlatList
         testID="collections-list"
         data={collections}
@@ -150,6 +189,22 @@ export function CollectionsScreen() {
         onScrollBeginDrag={scrollPerf.onScrollBeginDrag}
         onScrollEndDrag={scrollPerf.onScrollEndDrag}
       />
+    );
+  };
+
+  return (
+    <View
+      style={[styles.container, { backgroundColor: colors.sandBase }]}
+      testID="collections-screen"
+    >
+      <Header
+        title="Curated Looks"
+        showBack
+        cartCount={itemCount}
+        onCartPress={openCart}
+        testID="collections-header"
+      />
+      {renderContent()}
     </View>
   );
 }
@@ -157,6 +212,19 @@ export function CollectionsScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  centerContent: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: 32,
+    gap: 16,
+  },
+  retryBtn: {
+    paddingHorizontal: 24,
+    paddingVertical: 10,
+    borderRadius: 8,
+    marginTop: 8,
   },
   earlyAccessOverlay: {
     flexDirection: 'row',

--- a/src/screens/__tests__/CollectionsScreen.test.tsx
+++ b/src/screens/__tests__/CollectionsScreen.test.tsx
@@ -33,6 +33,11 @@ jest.mock('@/hooks/usePremium', () => ({
   usePremium: () => mockPremiumValue,
 }));
 
+const mockUseCollections = jest.fn();
+jest.mock('@/hooks/useCollections', () => ({
+  useCollections: () => mockUseCollections(),
+}));
+
 jest.mock('@/services/wix', () => ({
   useOptionalWixClient: () => ({
     queryData: jest.fn().mockResolvedValue({ items: [], totalResults: 0 }),
@@ -43,6 +48,27 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn().mockResolvedValue(null),
   setItem: jest.fn().mockResolvedValue(undefined),
 }));
+
+const COLLECTIONS_LOADED = {
+  collections: [
+    {
+      id: 'col-1',
+      slug: 'mountain-lodge-living',
+      title: 'Mountain Lodge Living',
+      subtitle: 'Cozy warmth',
+      description: 'Test',
+      heroImage: { uri: 'https://example.com/img.jpg', alt: 'Lodge' },
+      mood: [],
+      featured: true,
+      productIds: [],
+    },
+  ],
+  featured: [],
+  isLoading: false,
+  isStale: false,
+  error: null,
+  refresh: jest.fn(),
+};
 
 function renderCollectionsScreen() {
   return render(
@@ -56,6 +82,7 @@ function renderCollectionsScreen() {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockUseCollections.mockReturnValue(COLLECTIONS_LOADED);
 });
 
 describe('CollectionsScreen', () => {
@@ -75,6 +102,16 @@ describe('CollectionsScreen', () => {
   });
 
   it('shows early access lock on gated collection for non-premium users', () => {
+    mockUseCollections.mockReturnValue({
+      ...COLLECTIONS_LOADED,
+      collections: [
+        {
+          ...COLLECTIONS_LOADED.collections[0],
+          slug: 'spring-2026-preview',
+          earlyAccess: true,
+        },
+      ],
+    });
     mockPremiumValue.isPremium = false;
     const { getByTestId } = renderCollectionsScreen();
     expect(getByTestId('early-access-lock-spring-2026-preview')).toBeTruthy();
@@ -82,10 +119,165 @@ describe('CollectionsScreen', () => {
   });
 
   it('hides early access lock for premium users', () => {
+    mockUseCollections.mockReturnValue({
+      ...COLLECTIONS_LOADED,
+      collections: [
+        {
+          ...COLLECTIONS_LOADED.collections[0],
+          slug: 'spring-2026-preview',
+          earlyAccess: true,
+        },
+      ],
+    });
     mockPremiumValue.isPremium = true;
     const { queryByTestId } = renderCollectionsScreen();
     expect(queryByTestId('early-access-lock-spring-2026-preview')).toBeNull();
     mockPremiumValue.isPremium = false;
+  });
+});
+
+// ── Skeleton loading state ─────────────────────────────────────────────────────
+
+describe('CollectionsScreen — skeleton loading', () => {
+  it('shows skeleton placeholders while loading', () => {
+    mockUseCollections.mockReturnValue({
+      ...COLLECTIONS_LOADED,
+      collections: [],
+      isLoading: true,
+    });
+    const { getByTestId } = renderCollectionsScreen();
+    expect(getByTestId('collections-skeleton')).toBeTruthy();
+  });
+
+  it('renders 4 skeleton cards while loading', () => {
+    mockUseCollections.mockReturnValue({
+      ...COLLECTIONS_LOADED,
+      collections: [],
+      isLoading: true,
+    });
+    const { getAllByTestId } = renderCollectionsScreen();
+    expect(getAllByTestId(/^skeleton-collection-card-/).length).toBe(4);
+  });
+
+  it('does not show error state while loading', () => {
+    mockUseCollections.mockReturnValue({
+      ...COLLECTIONS_LOADED,
+      collections: [],
+      isLoading: true,
+    });
+    const { queryByTestId } = renderCollectionsScreen();
+    expect(queryByTestId('collections-error')).toBeNull();
+  });
+
+  it('does not show empty state while loading', () => {
+    mockUseCollections.mockReturnValue({
+      ...COLLECTIONS_LOADED,
+      collections: [],
+      isLoading: true,
+    });
+    const { queryByTestId } = renderCollectionsScreen();
+    expect(queryByTestId('collections-empty')).toBeNull();
+  });
+});
+
+// ── Error state ───────────────────────────────────────────────────────────────
+
+describe('CollectionsScreen — error state', () => {
+  it('shows error state when fetch fails', () => {
+    mockUseCollections.mockReturnValue({
+      ...COLLECTIONS_LOADED,
+      collections: [],
+      isLoading: false,
+      error: new Error('Network error'),
+    });
+    const { getByTestId } = renderCollectionsScreen();
+    expect(getByTestId('collections-error')).toBeTruthy();
+  });
+
+  it('shows error message text', () => {
+    mockUseCollections.mockReturnValue({
+      ...COLLECTIONS_LOADED,
+      collections: [],
+      isLoading: false,
+      error: new Error('Network error'),
+    });
+    const { getByTestId } = renderCollectionsScreen();
+    expect(getByTestId('collections-error-message')).toBeTruthy();
+  });
+
+  it('shows retry button on error', () => {
+    mockUseCollections.mockReturnValue({
+      ...COLLECTIONS_LOADED,
+      collections: [],
+      isLoading: false,
+      error: new Error('Network error'),
+    });
+    const { getByTestId } = renderCollectionsScreen();
+    expect(getByTestId('collections-retry-btn')).toBeTruthy();
+  });
+
+  it('calls refresh when retry button is pressed', () => {
+    const mockRefresh = jest.fn();
+    mockUseCollections.mockReturnValue({
+      ...COLLECTIONS_LOADED,
+      collections: [],
+      isLoading: false,
+      error: new Error('Network error'),
+      refresh: mockRefresh,
+    });
+    const { getByTestId } = renderCollectionsScreen();
+    fireEvent.press(getByTestId('collections-retry-btn'));
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not show skeleton or list when error', () => {
+    mockUseCollections.mockReturnValue({
+      ...COLLECTIONS_LOADED,
+      collections: [],
+      isLoading: false,
+      error: new Error('Network error'),
+    });
+    const { queryByTestId } = renderCollectionsScreen();
+    expect(queryByTestId('collections-skeleton')).toBeNull();
+    expect(queryByTestId('collections-list')).toBeNull();
+  });
+});
+
+// ── Empty state ───────────────────────────────────────────────────────────────
+
+describe('CollectionsScreen — empty state', () => {
+  it('shows empty state when collections array is empty', () => {
+    mockUseCollections.mockReturnValue({
+      ...COLLECTIONS_LOADED,
+      collections: [],
+      isLoading: false,
+      error: null,
+    });
+    const { getByTestId } = renderCollectionsScreen();
+    expect(getByTestId('collections-empty')).toBeTruthy();
+  });
+
+  it('shows empty state message text', () => {
+    mockUseCollections.mockReturnValue({
+      ...COLLECTIONS_LOADED,
+      collections: [],
+      isLoading: false,
+      error: null,
+    });
+    const { getByTestId } = renderCollectionsScreen();
+    expect(getByTestId('collections-empty-message')).toBeTruthy();
+  });
+
+  it('does not show skeleton or error in empty state', () => {
+    mockUseCollections.mockReturnValue({
+      ...COLLECTIONS_LOADED,
+      collections: [],
+      isLoading: false,
+      error: null,
+    });
+    const { queryByTestId } = renderCollectionsScreen();
+    expect(queryByTestId('collections-skeleton')).toBeNull();
+    expect(queryByTestId('collections-error')).toBeNull();
   });
 });
 

--- a/src/screens/__tests__/ListVirtualization.test.tsx
+++ b/src/screens/__tests__/ListVirtualization.test.tsx
@@ -40,6 +40,29 @@ jest.mock('@/services/wix', () => ({
   }),
 }));
 
+jest.mock('@/hooks/useCollections', () => ({
+  useCollections: () => ({
+    collections: [
+      {
+        id: 'col-1',
+        slug: 'mountain-lodge-living',
+        title: 'Mountain Lodge Living',
+        subtitle: 'Cozy warmth',
+        description: 'Test',
+        heroImage: { uri: 'https://example.com/img.jpg', alt: 'Lodge' },
+        mood: [],
+        featured: true,
+        productIds: [],
+      },
+    ],
+    featured: [],
+    isLoading: false,
+    isStale: false,
+    error: null,
+    refresh: jest.fn(),
+  }),
+}));
+
 jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn().mockResolvedValue(null),
   setItem: jest.fn().mockResolvedValue(undefined),


### PR DESCRIPTION
## Summary
- **Skeleton loader**: 4 shimmer `SkeletonCollectionCard` placeholders display while `isLoading=true` (`testID="collections-skeleton"`, cards `skeleton-collection-card-0..3`)
- **Error state**: Full-screen error message + retry button when `error` is set; pressing retry calls `refresh()` (`testID="collections-error"`, `collections-retry-btn`)
- **Empty state**: Friendly message when `collections.length === 0` and no error (`testID="collections-empty"`)
- **New component**: `SkeletonCollectionCard` — shimmer hero image + title/subtitle/tags matching CollectionCard proportions

## Test plan
- [x] 9 new tests: 4 skeleton, 5 error/empty covering all branches
- [x] Existing 11 CollectionsScreen tests still pass (20 total)
- [x] `ListVirtualization.test.tsx` updated with `useCollections` mock to prevent loading guard from hiding FlatList
- [x] Full suite clean (sentry flaky pre-exists on main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)