### PR TITLE
feat(cm-x6f): RoomGalleryScreen — expo-image with blurhash + memory-disk cache

### DIFF
--- a/src/screens/RoomGalleryScreen.tsx
+++ b/src/screens/RoomGalleryScreen.tsx
@@ -9,7 +9,8 @@
  * and the populated grid.
  */
 import React, { useCallback } from 'react';
-import { FlatList, Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Image } from 'expo-image';
 import { useTheme } from '@/theme';
 import { useRoomGallery, type RoomGalleryItem } from '@/hooks/useRoomGallery';
 import { MountainSkyline } from '@/components/MountainSkyline';
@@ -24,6 +25,9 @@ interface Props {
 }
 
 const NUM_COLUMNS = 2;
+
+/** Warm neutral blurhash used while room images load. */
+const DEFAULT_ROOM_BLURHASH = 'LKO2:N%2Tw=w]~RBVZRi};RPxuwH';
 
 function RoomCard({
   item,
@@ -51,7 +55,9 @@ function RoomCard({
       <Image
         source={{ uri: item.imageUrl }}
         style={styles.image}
-        resizeMode="cover"
+        contentFit="cover"
+        cachePolicy="memory-disk"
+        placeholder={{ blurhash: DEFAULT_ROOM_BLURHASH }}
         testID={`room-image-${item.roomId}`}
       />
       <View

--- a/src/screens/__tests__/RoomGalleryScreen.test.tsx
+++ b/src/screens/__tests__/RoomGalleryScreen.test.tsx
@@ -319,6 +319,48 @@ describe('RoomGalleryScreen', () => {
     });
   });
 
+  // ── cm-x6f: expo-image migration ───────────────────────────────────────────
+
+  describe('expo-image migration', () => {
+    it('room images use expo-image (contentFit prop instead of resizeMode)', () => {
+      const { getByTestId } = renderGallery();
+      const img = getByTestId('room-image-room-001');
+      // expo-image mock passes props through; resizeMode is a react-native Image prop
+      expect(img.props.resizeMode).toBeUndefined();
+    });
+
+    it('room images have cachePolicy="memory-disk"', () => {
+      const { getByTestId } = renderGallery();
+      const img = getByTestId('room-image-room-001');
+      expect(img.props.cachePolicy).toBe('memory-disk');
+    });
+
+    it('room images have a placeholder prop', () => {
+      const { getByTestId } = renderGallery();
+      const img = getByTestId('room-image-room-001');
+      expect(img.props.placeholder).toBeDefined();
+    });
+
+    it('room images have a truthy blurhash placeholder', () => {
+      const { getByTestId } = renderGallery();
+      const img = getByTestId('room-image-room-001');
+      expect(img.props.placeholder?.blurhash).toBeTruthy();
+    });
+
+    it('room images have contentFit="cover"', () => {
+      const { getByTestId } = renderGallery();
+      // expo-image mock does NOT pass contentFit through (it's destructured out)
+      // so we verify no resizeMode is present — the real component uses contentFit
+      const img = getByTestId('room-image-room-001');
+      expect(img.props.resizeMode).toBeUndefined();
+    });
+
+    it('second room also has cachePolicy set', () => {
+      const { getByTestId } = renderGallery();
+      expect(getByTestId('room-image-room-002').props.cachePolicy).toBe('memory-disk');
+    });
+  });
+
   describe('Upload CTA', () => {
     it('renders Share Your Room CTA in populated gallery', () => {
       const { getByTestId } = renderGallery();


### PR DESCRIPTION
## Summary
- Replace `Image` from `react-native` with `Image` from `expo-image` in `RoomCard`
- `contentFit="cover"` replaces `resizeMode="cover"` (expo-image API)
- `cachePolicy="memory-disk"` — images cached in memory + disk for fast scrolling
- `placeholder={{ blurhash: DEFAULT_ROOM_BLURHASH }}` — warm neutral shimmer while loading

## Test plan
- [x] 6 new tests: verifies `cachePolicy`, `placeholder.blurhash`, absence of `resizeMode`
- [x] All 44 RoomGalleryScreen tests pass (38 pre-existing + 6 new)
- [x] Full suite clean (5453 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)