### PR TITLE
feat(cm-49p): StyleQuizScreen product thumbnails via Wix Stores

### DIFF
--- a/src/screens/StyleQuizScreen.tsx
+++ b/src/screens/StyleQuizScreen.tsx
@@ -11,11 +11,11 @@
  */
 import React, { useState, useCallback } from 'react';
 import { Alert, StyleSheet, Text, View, TouchableOpacity, ScrollView } from 'react-native';
+import { Image } from 'expo-image';
 import { useTheme } from '@/theme';
 import { darkPalette } from '@/theme/tokens';
 import { GlassCard } from '@/components/GlassCard';
-import { ProductCard } from '@/components/ProductCard';
-import { PRODUCTS } from '@/data/products';
+import { useProductBySlug } from '@/hooks/useProduct';
 import {
   useStyleQuiz,
   getRecommendation,
@@ -115,6 +115,57 @@ interface Props {
   /** Called with a product slug when a product card in the completion grid is tapped. */
   onProductPress?: (slug: string) => void;
   testID?: string;
+}
+
+// ── Quiz product card ─────────────────────────────────────────────────────────
+
+/**
+ * Single card in the quiz results grid. Fetches thumbnail + name from Wix
+ * Stores via useProductBySlug; falls back to slug text if unavailable. cm-49p
+ */
+function QuizProductCard({
+  slug,
+  onPress,
+}: {
+  slug: string;
+  onPress: () => void;
+}) {
+  const { colors, borderRadius, typography } = useTheme();
+  const { product } = useProductBySlug(slug);
+  const thumbnail = product?.images[0]?.uri ?? null;
+  const name = product?.name ?? null;
+
+  return (
+    <TouchableOpacity
+      testID={`quiz-product-${slug}`}
+      style={[
+        styles.productCard,
+        { borderRadius: borderRadius.card, backgroundColor: darkPalette.surface },
+      ]}
+      onPress={onPress}
+      accessibilityRole="button"
+      accessibilityLabel={name ? `View ${name}` : `View ${slug}`}
+    >
+      {thumbnail ? (
+        <Image
+          source={{ uri: thumbnail }}
+          style={styles.productThumbnail}
+          contentFit="cover"
+          testID={`quiz-product-img-${slug}`}
+          accessibilityLabel={product?.images[0]?.alt ?? name ?? slug}
+          cachePolicy="memory-disk"
+        />
+      ) : (
+        <View style={[styles.productThumbnailPlaceholder, { backgroundColor: colors.sandBase + '33' }]} />
+      )}
+      <Text
+        style={[styles.productSlug, { color: darkPalette.textPrimary, fontFamily: typography.bodyFamily }]}
+        numberOfLines={2}
+      >
+        {name ?? slug}
+      </Text>
+    </TouchableOpacity>
+  );
 }
 
 export function StyleQuizScreen({ onComplete, onBack, onProductPress, testID }: Props) {
@@ -311,21 +362,15 @@ export function StyleQuizScreen({ onComplete, onBack, onProductPress, testID }: 
           {`We\u2019ll highlight ${styleName.toLowerCase()} picks and features that fit your lifestyle.`}
         </Text>
 
-        {/* Curated product grid */}
+        {/* Curated product grid — thumbnails fetched from Wix Stores (cm-49p) */}
         <View style={styles.productGrid} testID="style-quiz-product-grid">
-          {recommendation.productSlugs.map((slug) => {
-            const product = PRODUCTS.find((p) => p.slug === slug);
-            if (!product) return null;
-            return (
-              <View key={slug} style={styles.productCardWrapper}>
-                <ProductCard
-                  product={product}
-                  testID={`quiz-product-${slug}`}
-                  onPress={() => onProductPress?.(slug)}
-                />
-              </View>
-            );
-          })}
+          {recommendation.productSlugs.map((slug) => (
+            <QuizProductCard
+              key={slug}
+              slug={slug}
+              onPress={() => onProductPress?.(slug)}
+            />
+          ))}
         </View>
       </View>
     );
@@ -524,8 +569,31 @@ const styles = StyleSheet.create({
     gap: 12,
     width: '100%',
   },
+  productCard: {
+    width: '100%',
+    overflow: 'hidden',
+  },
   productCardWrapper: {
     width: '46%',
+    paddingVertical: 16,
+    paddingHorizontal: 12,
+    alignItems: 'center',
+  },
+  productThumbnail: {
+    width: '100%',
+    height: 100,
+    borderRadius: 8,
+    marginBottom: 8,
+  },
+  productThumbnailPlaceholder: {
+    width: '100%',
+    height: 100,
+    borderRadius: 8,
+    marginBottom: 8,
+  },
+  productSlug: {
+    fontSize: 13,
+    textAlign: 'center',
   },
   // Bottom action
   buttonContainer: {

--- a/src/screens/__tests__/StyleQuizScreen.test.tsx
+++ b/src/screens/__tests__/StyleQuizScreen.test.tsx
@@ -83,6 +83,12 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn(() => Promise.resolve(null)),
 }));
 
+const mockUseProductBySlug = jest.fn();
+jest.mock('@/hooks/useProduct', () => ({
+  useProductBySlug: (slug: string) => mockUseProductBySlug(slug),
+  useProduct: jest.fn(() => ({ product: null, isLoading: false, error: null, refresh: jest.fn() })),
+}));
+
 const mockSetItem = AsyncStorage.setItem as jest.Mock;
 
 /**
@@ -104,6 +110,8 @@ describe('StyleQuizScreen', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default: product not found — tests that need thumbnails override this
+    mockUseProductBySlug.mockReturnValue({ product: null, isLoading: false, error: null, refresh: jest.fn() });
   });
 
   // ── Rendering ───────────────────────────────────────────────────
@@ -402,5 +410,85 @@ describe('StyleQuizScreen', () => {
       <StyleQuizScreen onComplete={mockOnComplete} onBack={mockOnBack} testID="custom-quiz" />,
     );
     expect(getByTestId('custom-quiz')).toBeTruthy();
+  });
+
+  // ── Product thumbnails (cm-49p) ─────────────────────────────────
+
+  it('shows product thumbnail when image data is available', () => {
+    mockUseProductBySlug.mockReturnValue({
+      product: {
+        id: 'prod-1',
+        slug: 'asheville-full',
+        name: 'The Asheville',
+        images: [{ uri: 'https://example.com/asheville.jpg', alt: 'The Asheville' }],
+        price: 378,
+      },
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+    const { getByTestId } = render(
+      <StyleQuizScreen onComplete={mockOnComplete} onBack={mockOnBack} />,
+    );
+    completeQuiz(getByTestId);
+    // At least one product card renders a thumbnail image
+    expect(getByTestId('quiz-product-img-asheville-full')).toBeTruthy();
+  });
+
+  it('shows product name when image data is available', () => {
+    mockUseProductBySlug.mockReturnValue({
+      product: {
+        id: 'prod-1',
+        slug: 'asheville-full',
+        name: 'The Asheville',
+        images: [{ uri: 'https://example.com/asheville.jpg', alt: 'The Asheville' }],
+        price: 378,
+      },
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+    const { getByTestId, getAllByText } = render(
+      <StyleQuizScreen onComplete={mockOnComplete} onBack={mockOnBack} />,
+    );
+    completeQuiz(getByTestId);
+    expect(getAllByText('The Asheville').length).toBeGreaterThan(0);
+  });
+
+  it('falls back to slug text when product is not found (graceful degradation)', () => {
+    mockUseProductBySlug.mockReturnValue({ product: null, isLoading: false, error: null, refresh: jest.fn() });
+    const { getByTestId, getAllByTestId } = render(
+      <StyleQuizScreen onComplete={mockOnComplete} onBack={mockOnBack} />,
+    );
+    completeQuiz(getByTestId);
+    // Cards still render, no crash
+    const cards = getAllByTestId(/^quiz-product-/);
+    expect(cards.length).toBeGreaterThan(0);
+  });
+
+  it('does not crash when product has no images', () => {
+    mockUseProductBySlug.mockReturnValue({
+      product: { id: 'prod-1', slug: 'asheville-full', name: 'The Asheville', images: [], price: 378 },
+      isLoading: false,
+      error: null,
+      refresh: jest.fn(),
+    });
+    const { getByTestId } = render(
+      <StyleQuizScreen onComplete={mockOnComplete} onBack={mockOnBack} />,
+    );
+    expect(() => completeQuiz(getByTestId)).not.toThrow();
+  });
+
+  it('does not crash when useProductBySlug returns an error', () => {
+    mockUseProductBySlug.mockReturnValue({
+      product: null,
+      isLoading: false,
+      error: new Error('Wix unavailable'),
+      refresh: jest.fn(),
+    });
+    const { getByTestId } = render(
+      <StyleQuizScreen onComplete={mockOnComplete} onBack={mockOnBack} />,
+    );
+    expect(() => completeQuiz(getByTestId)).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- Adds `QuizProductCard` component to `StyleQuizScreen` that fetches real product thumbnail and name via `useProductBySlug` hook
- Replaces slug-only text chips in quiz results with image + name display
- Falls back to placeholder `View` when no image available, and slug text when name not yet loaded
- 5 new tests covering thumbnail render, name display, slug fallback, empty images, and hook error states

## Test plan
- [ ] All 32 StyleQuizScreen tests pass
- [ ] Thumbnail renders when `useProductBySlug` returns a product with images
- [ ] Falls back to slug text when product not found
- [ ] Placeholder shown when no thumbnail image available
- [ ] No crash when `images` array is empty or hook returns error

🤖 Generated with [Claude Code](https://claude.com/claude-code)