### PR TITLE
fix(cm-tsh): OrderDetailScreen — useRef guard for recordDelivery + tracking.url null-check

### DIFF
--- a/src/screens/OrderDetailScreen.tsx
+++ b/src/screens/OrderDetailScreen.tsx
@@ -7,7 +7,7 @@
  * back to the cart for easy repeat purchases.
  */
 
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import {
   StyleSheet,
   Text,
@@ -218,12 +218,19 @@ export function OrderDetailScreen({
   const { getModel, getFabric } = useFutonModels();
   const { recordDelivery } = useRatingPrompt();
   const [refreshing, setRefreshing] = useState(false);
+  // cm-tsh: guard prevents recordDelivery firing on every re-render
+  const deliveryRecordedRef = useRef(false);
 
   const order = ordersProp ? ordersProp.find((o) => o.id === orderId) : getOrder(orderId);
 
   useEffect(() => {
-    if (order?.status === 'delivered') {
-      recordDelivery();
+    if (order?.status === 'delivered' && !deliveryRecordedRef.current) {
+      deliveryRecordedRef.current = true;
+      try {
+        recordDelivery();
+      } catch {
+        // Rating service failure must not crash the order detail screen
+      }
     }
   }, [order?.status, recordDelivery]);
 
@@ -375,16 +382,26 @@ export function OrderDetailScreen({
             <Text style={[styles.trackingLabel, { color: colors.mountainBlueDark }]}>
               {order.tracking.carrier} Tracking
             </Text>
-            <TouchableOpacity
-              onPress={handleTrackingPress}
-              testID="tracking-link"
-              accessibilityLabel={`Track package with ${order.tracking.carrier}, tracking number ${order.tracking.trackingNumber}`}
-              accessibilityRole="link"
-            >
-              <Text style={[styles.trackingNumber, { color: colors.mountainBlueDark }]}>
+            {/* cm-tsh: only render as tappable link when a URL is available */}
+            {order.tracking.url ? (
+              <TouchableOpacity
+                onPress={handleTrackingPress}
+                testID="tracking-link"
+                accessibilityLabel={`Track package with ${order.tracking.carrier}, tracking number ${order.tracking.trackingNumber}`}
+                accessibilityRole="link"
+              >
+                <Text style={[styles.trackingNumber, { color: colors.mountainBlueDark }]}>
+                  {order.tracking.trackingNumber}
+                </Text>
+              </TouchableOpacity>
+            ) : (
+              <Text
+                style={[styles.trackingNumber, { color: colors.mountainBlueDark }]}
+                testID="tracking-number-text"
+              >
                 {order.tracking.trackingNumber}
               </Text>
-            </TouchableOpacity>
+            )}
             {order.tracking.estimatedDelivery && (
               <Text
                 style={[styles.trackingEta, { color: colors.espressoLight }]}

--- a/src/screens/__tests__/OrderDetailScreen.test.tsx
+++ b/src/screens/__tests__/OrderDetailScreen.test.tsx
@@ -337,5 +337,68 @@ describe('OrderDetailScreen', () => {
         expect(mockRecordDelivery).not.toHaveBeenCalled();
       });
     });
+
+    // cm-tsh: useRef guard — must fire exactly once, not on every render
+    it('calls recordDelivery exactly once even when component re-renders', async () => {
+      const { rerender } = renderOrderDetail({ orderId: 'ord-001' });
+      await waitFor(() => {
+        expect(mockRecordDelivery).toHaveBeenCalledTimes(1);
+      });
+      // Trigger a re-render (e.g. new props ref)
+      rerender(
+        <ConnectivityProvider>
+          <ThemeProvider>
+            <CartProvider>
+              <OrderDetailScreen orderId="ord-001" />
+            </CartProvider>
+          </ThemeProvider>
+        </ConnectivityProvider>,
+      );
+      await waitFor(() => {
+        // Must still be exactly 1, not 2
+        expect(mockRecordDelivery).toHaveBeenCalledTimes(1);
+      });
+    });
+
+    // cm-tsh: try/catch — recordDelivery throwing must not crash the screen
+    it('does not crash when recordDelivery throws', async () => {
+      mockRecordDelivery.mockImplementationOnce(() => {
+        throw new Error('Rating service unavailable');
+      });
+      expect(() => renderOrderDetail({ orderId: 'ord-001' })).not.toThrow();
+    });
+  });
+
+  describe('Tracking link null URL guard (cm-tsh)', () => {
+    it('does not render tracking link when tracking.url is null', () => {
+      const orderWithNullUrl = {
+        ...MOCK_ORDERS[0],
+        tracking: { ...MOCK_ORDERS[0].tracking!, url: null as unknown as string },
+      };
+      const { queryByTestId } = renderOrderDetail({
+        orderId: 'ord-001',
+        orders: [orderWithNullUrl],
+      });
+      expect(queryByTestId('tracking-link')).toBeNull();
+    });
+
+    it('renders tracking number as plain text when tracking.url is null', () => {
+      const orderWithNullUrl = {
+        ...MOCK_ORDERS[0],
+        tracking: { ...MOCK_ORDERS[0].tracking!, url: null as unknown as string },
+      };
+      const { getByTestId } = renderOrderDetail({
+        orderId: 'ord-001',
+        orders: [orderWithNullUrl],
+      });
+      // Tracking card still renders (carrier + number), just not as a link
+      expect(getByTestId('order-tracking-card')).toBeTruthy();
+      expect(getByTestId('tracking-number-text')).toBeTruthy();
+    });
+
+    it('still renders tracking link when tracking.url is present', () => {
+      const { getByTestId } = renderOrderDetail({ orderId: 'ord-001' });
+      expect(getByTestId('tracking-link')).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
Fixes cm-tsh: useRef guard, null tracking.url check, try/catch on recordDelivery. Tests cover: fires-once-on-rerender, null-url-no-link, service-throw-no-crash, non-delivered-no-call.