### PR TITLE
feat(cm-thv): CollectionsScreen — error state, skeleton loader, empty state

### DIFF
--- a/src/components/SkeletonCollectionCard.tsx
+++ b/src/components/SkeletonCollectionCard.tsx
@@ -1,0 +1,87 @@
+/**
+ * @module SkeletonCollectionCard
+ *
+ * Skeleton loading placeholder matching CollectionCard's 'featured' variant:
+ * full-bleed image with a gradient overlay, title, and subtitle shimmers.
+ * Used while the EditorialCollections list is loading.
+ *
+ * cm-thv: CollectionsScreen error state + skeleton loader
+ */
+import React, { memo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTheme } from '@/theme';
+import { Shimmer } from './Shimmer';
+
+const CARD_HEIGHT = 220;
+
+/** Skeleton placeholder matching a single CollectionCard in 'featured' variant. */
+export const SkeletonCollectionCard = memo(function SkeletonCollectionCard({
+  testID,
+}: {
+  testID?: string;
+}) {
+  const { borderRadius, spacing } = useTheme();
+
+  return (
+    <View
+      style={[styles.card, { borderRadius: borderRadius.card }]}
+      testID={testID ?? 'skeleton-collection-card'}
+      accessibilityLabel="Loading collection"
+    >
+      {/* Hero image shimmer */}
+      <Shimmer width="100%" height={CARD_HEIGHT} borderRadius={borderRadius.card} />
+
+      {/* Bottom overlay: mood tags + title + subtitle */}
+      <View style={[styles.overlay, { padding: spacing.md }]}>
+        {/* Mood tag */}
+        <Shimmer width={60} height={12} borderRadius={4} style={{ marginBottom: spacing.xs }} />
+        {/* Title */}
+        <Shimmer width="70%" height={18} borderRadius={4} style={{ marginBottom: spacing.xs }} />
+        {/* Subtitle */}
+        <Shimmer width="50%" height={13} borderRadius={4} />
+      </View>
+    </View>
+  );
+});
+
+/** Vertical list of skeleton collection cards matching CollectionsScreen layout. */
+export function SkeletonCollectionList({
+  count = 3,
+  testID,
+}: {
+  count?: number;
+  testID?: string;
+}) {
+  const { spacing } = useTheme();
+
+  return (
+    <View testID={testID ?? 'skeleton-collection-list'}>
+      {Array.from({ length: count }, (_, i) => (
+        <View
+          key={i}
+          style={[
+            styles.cardWrapper,
+            { paddingHorizontal: spacing.pagePadding, marginBottom: spacing.md },
+          ]}
+        >
+          <SkeletonCollectionCard testID={`skeleton-collection-${i}`} />
+        </View>
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  card: {
+    height: CARD_HEIGHT,
+    overflow: 'hidden',
+    position: 'relative',
+  },
+  overlay: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+  },
+  cardWrapper: {},
+});

--- a/src/screens/CollectionsScreen.tsx
+++ b/src/screens/CollectionsScreen.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useCallback } from 'react';
-import { Alert, FlatList, StyleSheet, Text, View } from 'react-native';
+import { Alert, FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -20,6 +20,7 @@ import { useMiniCartDrawer } from '@/hooks/useMiniCartDrawer';
 import { CollectionCard } from '@/components/CollectionCard';
 import { PremiumBadge } from '@/components/PremiumBadge';
 import { Header } from '@/components/Header';
+import { SkeletonCollectionList } from '@/components/SkeletonCollectionCard';
 import { useScrollPerformance } from '@/hooks/useScrollPerformance';
 import type { RootStackParamList } from '@/navigation/AppNavigator';
 import type { EditorialCollection } from '@/data/collections';
@@ -39,7 +40,7 @@ export function CollectionsScreen() {
   const { colors, spacing, typography } = useTheme();
   const navigation = useNavigation<NativeStackNavigationProp<RootStackParamList>>();
   const insets = useSafeAreaInsets();
-  const { collections } = useCollections();
+  const { collections, isLoading, error, refresh } = useCollections();
   const { isPremium } = usePremium();
   const { itemCount } = useCart();
   const { open: openCart } = useMiniCartDrawer();
@@ -115,6 +116,78 @@ export function CollectionsScreen() {
     [colors, spacing, typography],
   );
 
+  if (isLoading) {
+    return (
+      <View
+        style={[styles.container, { backgroundColor: colors.sandBase }]}
+        testID="collections-screen"
+      >
+        <Header
+          title="Curated Looks"
+          showBack
+          cartCount={itemCount}
+          onCartPress={openCart}
+          testID="collections-header"
+        />
+        <SkeletonCollectionList count={3} />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View
+        style={[styles.container, styles.centered, { backgroundColor: colors.sandBase }]}
+        testID="collections-screen"
+      >
+        <Header
+          title="Curated Looks"
+          showBack
+          cartCount={itemCount}
+          onCartPress={openCart}
+          testID="collections-header"
+        />
+        <Text
+          style={[styles.errorText, { color: colors.espresso }]}
+          testID="collections-error"
+        >
+          Couldn't load collections. Check your connection.
+        </Text>
+        <TouchableOpacity
+          style={[styles.retryButton, { backgroundColor: colors.sunsetCoral }]}
+          onPress={refresh}
+          testID="collections-retry"
+          accessibilityRole="button"
+        >
+          <Text style={[styles.retryButtonText, { color: colors.white }]}>Retry</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  if (collections.length === 0) {
+    return (
+      <View
+        style={[styles.container, styles.centered, { backgroundColor: colors.sandBase }]}
+        testID="collections-screen"
+      >
+        <Header
+          title="Curated Looks"
+          showBack
+          cartCount={itemCount}
+          onCartPress={openCart}
+          testID="collections-header"
+        />
+        <Text
+          style={[styles.emptyText, { color: colors.espressoLight }]}
+          testID="collections-empty"
+        >
+          No collections available yet. Check back soon!
+        </Text>
+      </View>
+    );
+  }
+
   return (
     <View
       style={[styles.container, { backgroundColor: colors.sandBase }]}
@@ -157,6 +230,30 @@ export function CollectionsScreen() {
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+  },
+  centered: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  errorText: {
+    fontSize: 15,
+    textAlign: 'center',
+    marginHorizontal: 32,
+    marginBottom: 20,
+  },
+  retryButton: {
+    paddingVertical: 12,
+    paddingHorizontal: 32,
+    borderRadius: 8,
+  },
+  retryButtonText: {
+    fontSize: 15,
+    fontWeight: '700',
+  },
+  emptyText: {
+    fontSize: 15,
+    textAlign: 'center',
+    marginHorizontal: 32,
   },
   earlyAccessOverlay: {
     flexDirection: 'row',

--- a/src/screens/__tests__/CollectionsScreen.test.tsx
+++ b/src/screens/__tests__/CollectionsScreen.test.tsx
@@ -3,6 +3,15 @@ import { render, fireEvent } from '@testing-library/react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { CollectionsScreen } from '../CollectionsScreen';
 import { ThemeProvider } from '@/theme/ThemeProvider';
+import { COLLECTIONS } from '@/data/collections';
+
+// Control useCollections state from tests
+const mockRefresh = jest.fn();
+const mockUseCollections = jest.fn();
+jest.mock('@/hooks/useCollections', () => ({
+  ...jest.requireActual('@/hooks/useCollections'),
+  useCollections: () => mockUseCollections(),
+}));
 
 const mockPremiumValue = {
   isPremium: false,
@@ -56,6 +65,16 @@ function renderCollectionsScreen() {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockPremiumValue.isPremium = false;
+  // Default: loaded, no error, full static collections
+  mockUseCollections.mockReturnValue({
+    collections: COLLECTIONS,
+    featured: COLLECTIONS.filter((c) => c.featured),
+    isLoading: false,
+    isStale: false,
+    error: null,
+    refresh: mockRefresh,
+  });
 });
 
 describe('CollectionsScreen', () => {
@@ -78,14 +97,92 @@ describe('CollectionsScreen', () => {
     mockPremiumValue.isPremium = false;
     const { getByTestId } = renderCollectionsScreen();
     expect(getByTestId('early-access-lock-spring-2026-preview')).toBeTruthy();
-    mockPremiumValue.isPremium = false;
   });
 
   it('hides early access lock for premium users', () => {
     mockPremiumValue.isPremium = true;
     const { queryByTestId } = renderCollectionsScreen();
     expect(queryByTestId('early-access-lock-spring-2026-preview')).toBeNull();
-    mockPremiumValue.isPremium = false;
+  });
+});
+
+describe('CollectionsScreen — loading state', () => {
+  beforeEach(() => {
+    mockUseCollections.mockReturnValue({
+      collections: [],
+      featured: [],
+      isLoading: true,
+      isStale: false,
+      error: null,
+      refresh: mockRefresh,
+    });
+  });
+
+  it('shows skeleton while loading', () => {
+    const { getByTestId } = renderCollectionsScreen();
+    expect(getByTestId('skeleton-collection-list')).toBeTruthy();
+  });
+
+  it('hides the collections list while loading', () => {
+    const { queryByTestId } = renderCollectionsScreen();
+    expect(queryByTestId('collections-list')).toBeNull();
+  });
+});
+
+describe('CollectionsScreen — error state', () => {
+  beforeEach(() => {
+    mockUseCollections.mockReturnValue({
+      collections: [],
+      featured: [],
+      isLoading: false,
+      isStale: false,
+      error: new Error('Network request failed'),
+      refresh: mockRefresh,
+    });
+  });
+
+  it('shows error message when fetch fails', () => {
+    const { getByTestId } = renderCollectionsScreen();
+    expect(getByTestId('collections-error')).toBeTruthy();
+  });
+
+  it('shows retry button on error', () => {
+    const { getByTestId } = renderCollectionsScreen();
+    expect(getByTestId('collections-retry')).toBeTruthy();
+  });
+
+  it('tapping retry calls refresh', () => {
+    const { getByTestId } = renderCollectionsScreen();
+    fireEvent.press(getByTestId('collections-retry'));
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('hides collections list on error', () => {
+    const { queryByTestId } = renderCollectionsScreen();
+    expect(queryByTestId('collections-list')).toBeNull();
+  });
+});
+
+describe('CollectionsScreen — empty state', () => {
+  beforeEach(() => {
+    mockUseCollections.mockReturnValue({
+      collections: [],
+      featured: [],
+      isLoading: false,
+      isStale: false,
+      error: null,
+      refresh: mockRefresh,
+    });
+  });
+
+  it('shows empty state when no collections returned', () => {
+    const { getByTestId } = renderCollectionsScreen();
+    expect(getByTestId('collections-empty')).toBeTruthy();
+  });
+
+  it('hides collections list when empty', () => {
+    const { queryByTestId } = renderCollectionsScreen();
+    expect(queryByTestId('collections-list')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary
- Add SkeletonCollectionCard + SkeletonCollectionList matching CollectionCard featured variant (220px hero + shimmer overlay labels)
- Wire isLoading / error / refresh from useCollections into CollectionsScreen
- Loading: 3-card skeleton, FlatList hidden
- Error: friendly message + Retry button (calls refresh)
- Empty: copy when collections array is empty

## Test plan
- [x] Tests written first (TDD)
- [x] 16 tests passing: skeleton, error, retry, empty, all existing happy-path cases
- [x] Self-review complete
- [x] No unchecked boxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)