### PR TITLE
feat(cm-x6f): RoomGalleryScreen — migrate Image to expo-image with blurhash + disk cache

### DIFF
--- a/src/screens/RoomGalleryScreen.tsx
+++ b/src/screens/RoomGalleryScreen.tsx
@@ -8,8 +8,9 @@
  * States handled: loading skeleton, empty gallery, API error with retry,
  * and the populated grid.
  */
-import React, { useCallback } from 'react';
-import { FlatList, Image, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import React, { useCallback, useState } from 'react';
+import { FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Image } from 'expo-image';
 import { useTheme } from '@/theme';
 import { useRoomGallery, type RoomGalleryItem } from '@/hooks/useRoomGallery';
 import { MountainSkyline } from '@/components/MountainSkyline';
@@ -25,6 +26,9 @@ interface Props {
 
 const NUM_COLUMNS = 2;
 
+/** Neutral warm fallback blurhash while room images are loading. */
+const DEFAULT_ROOM_BLURHASH = 'LKO2:N%2Tw=w]~RBVZRi};RPxuwH';
+
 function RoomCard({
   item,
   onProductPress,
@@ -33,6 +37,7 @@ function RoomCard({
   onProductPress?: (productId: string) => void;
 }) {
   const { colors, spacing, borderRadius, typography } = useTheme();
+  const [imageError, setImageError] = useState(false);
 
   const handlePress = useCallback(() => {
     if (item.productIds.length > 0) {
@@ -48,12 +53,22 @@ function RoomCard({
       accessibilityLabel={`${item.roomStyle} room, ${item.productIds.length} ${item.productIds.length === 1 ? 'product' : 'products'}`}
       accessibilityRole="button"
     >
-      <Image
-        source={{ uri: item.imageUrl }}
-        style={styles.image}
-        resizeMode="cover"
-        testID={`room-image-${item.roomId}`}
-      />
+      {imageError ? (
+        <View
+          style={[styles.image, styles.imageFallback, { backgroundColor: colors.sandDark }]}
+          testID={`room-image-fallback-${item.roomId}`}
+        />
+      ) : (
+        <Image
+          source={{ uri: item.imageUrl }}
+          style={styles.image}
+          contentFit="cover"
+          placeholder={DEFAULT_ROOM_BLURHASH}
+          cachePolicy="memory-disk"
+          onError={() => setImageError(true)}
+          testID={`room-image-${item.roomId}`}
+        />
+      )}
       <View
         style={[
           styles.overlay,
@@ -259,6 +274,7 @@ const styles = StyleSheet.create({
     width: '100%',
     height: '100%',
   },
+  imageFallback: {},
   overlay: {
     position: 'absolute',
     bottom: 0,

--- a/src/screens/__tests__/RoomGalleryScreen.test.tsx
+++ b/src/screens/__tests__/RoomGalleryScreen.test.tsx
@@ -376,4 +376,46 @@ describe('RoomGalleryScreen', () => {
       expect(getByTestId('room-gallery-share-cta').props.accessibilityRole).toBe('button');
     });
   });
+
+  // ── cm-x6f: expo-image migration ──────────────────────────────────────────
+
+  describe('expo-image migration', () => {
+    it('renders room images with cachePolicy memory-disk', () => {
+      const { getByTestId } = renderGallery();
+      const img = getByTestId('room-image-room-001');
+      expect(img.props.cachePolicy).toBe('memory-disk');
+    });
+
+    it('passes blurhash placeholder to room images', () => {
+      const { getByTestId } = renderGallery();
+      const img = getByTestId('room-image-room-001');
+      expect(img.props.placeholder).toBeDefined();
+    });
+
+    it('renders image source with correct uri', () => {
+      const { getByTestId } = renderGallery();
+      const img = getByTestId('room-image-room-001');
+      expect(img.props.source).toEqual({
+        uri: 'https://static.wixstatic.com/media/e04e89_abc123',
+      });
+    });
+
+    it('handles image load error without crashing', () => {
+      const { getByTestId } = renderGallery();
+      // Trigger onError on the image — should not throw
+      expect(() => {
+        const img = getByTestId('room-image-room-001');
+        img.props.onError?.({ nativeEvent: { error: 'load failed' } });
+      }).not.toThrow();
+    });
+
+    it('shows fallback when image fails to load', () => {
+      const { getByTestId } = renderGallery();
+      const img = getByTestId('room-image-room-001');
+      // Fire onError to trigger fallback state
+      img.props.onError?.({ nativeEvent: { error: 'load failed' } });
+      // Room card remains visible (no crash, card still rendered)
+      expect(getByTestId('room-card-room-001')).toBeTruthy();
+    });
+  });
 });


### PR DESCRIPTION
## Summary
- Replace react-native `Image` with `expo-image` `Image` in `RoomCard`
- Add `DEFAULT_ROOM_BLURHASH` placeholder shown while images load
- Add `cachePolicy="memory-disk"` for persistent cross-session image caching
- Add `onError` handler: falls back to `sandDark` fill on load failure
- Add `useState(imageError)` for in-card fallback rendering

## Test plan
- [x] Tests written first (TDD)
- [x] 43 tests passing: all existing + 5 new expo-image tests (cachePolicy, placeholder, source, onError no-crash, fallback card visible)
- [x] Self-review complete
- [x] No unchecked boxes

🤖 Generated with [Claude Code](https://claude.com/claude-code)