### PR TITLE
feat(cm-9yn): ShippingEstimatePanel — zip-driven parcel/freight estimate on PDP

### DIFF
--- a/src/components/ShippingEstimatePanel.tsx
+++ b/src/components/ShippingEstimatePanel.tsx
@@ -1,0 +1,157 @@
+/**
+ * @module ShippingEstimatePanel
+ *
+ * PDP shipping estimate section (cm-9yn).
+ * Renders a zip input; once a valid zip is entered it calls the
+ * getShippingEstimate backend webmethod and shows the parcel or freight rate.
+ * Displays an estimate disclaimer when the API marks the quote as provisional.
+ */
+
+import React, { memo } from 'react';
+import { StyleSheet, View, Text, TextInput, ActivityIndicator } from 'react-native';
+import { useTheme } from '@/theme';
+import {
+  useProductShippingEstimate,
+  type ProductDimensions,
+} from '@/hooks/useProductShippingEstimate';
+
+interface Props {
+  productId: string;
+  dimensions: ProductDimensions;
+  testID?: string;
+}
+
+export const ShippingEstimatePanel = memo(function ShippingEstimatePanel({
+  productId,
+  dimensions,
+  testID = 'shipping-panel',
+}: Props) {
+  const { colors, typography, borderRadius } = useTheme();
+  const { zip, setZip, rate, isLoading, error } = useProductShippingEstimate({
+    productId,
+    dimensions,
+  });
+
+  const hasZip = zip.length > 0;
+
+  return (
+    <View testID={testID} style={styles.container}>
+      {/* Section label */}
+      <Text style={[styles.label, { color: colors.espresso, fontFamily: typography.bodyFamilyBold }]}>
+        Shipping Estimate
+      </Text>
+
+      {/* Zip input */}
+      <TextInput
+        testID="shipping-zip-input"
+        style={[
+          styles.zipInput,
+          {
+            color: colors.espresso,
+            borderColor: colors.espressoLight,
+            borderRadius: borderRadius.sm,
+            fontFamily: typography.bodyFamily,
+          },
+        ]}
+        placeholder="Enter ZIP code"
+        placeholderTextColor={colors.espressoLight}
+        keyboardType="numeric"
+        maxLength={5}
+        value={zip}
+        onChangeText={setZip}
+        accessibilityLabel="ZIP code for shipping estimate"
+      />
+
+      {/* No-zip prompt */}
+      {!hasZip && (
+        <Text style={[styles.prompt, { color: colors.espressoLight }]}>
+          Enter zip for shipping estimate
+        </Text>
+      )}
+
+      {/* Loading */}
+      {hasZip && isLoading && (
+        <ActivityIndicator
+          testID="shipping-rate-loading"
+          size="small"
+          color={colors.mountainBlue}
+          style={styles.loader}
+        />
+      )}
+
+      {/* Error */}
+      {hasZip && !isLoading && error && (
+        <Text testID="shipping-rate-error" style={[styles.errorText, { color: colors.error }]}>
+          Unable to estimate shipping. Please verify your ZIP code.
+        </Text>
+      )}
+
+      {/* Rate result */}
+      {hasZip && !isLoading && !error && rate && (
+        <View testID="shipping-rate-result" style={styles.rateRow}>
+          <Text style={[styles.rateText, { color: colors.espresso, fontFamily: typography.bodyFamilyBold }]}>
+            ${rate.amount}
+          </Text>
+          <Text style={[styles.carrierText, { color: colors.espresso }]}>
+            {' · '}{rate.carrier}
+            {rate.isFreight ? ' · Freight (LTL)' : ''}
+          </Text>
+        </View>
+      )}
+
+      {/* isEstimate disclaimer */}
+      {hasZip && !isLoading && !error && rate?.isEstimate && (
+        <Text
+          testID="shipping-estimate-disclaimer"
+          style={[styles.disclaimer, { color: colors.espressoLight }]}
+        >
+          *Estimated rate — final shipping confirmed at checkout.
+        </Text>
+      )}
+    </View>
+  );
+});
+
+const styles = StyleSheet.create({
+  container: {
+    marginTop: 8,
+    marginBottom: 4,
+    gap: 6,
+  },
+  label: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+  zipInput: {
+    height: 40,
+    borderWidth: 1,
+    paddingHorizontal: 10,
+    fontSize: 15,
+  },
+  prompt: {
+    fontSize: 13,
+    fontStyle: 'italic',
+  },
+  loader: {
+    alignSelf: 'flex-start',
+    marginTop: 2,
+  },
+  rateRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    flexWrap: 'wrap',
+  },
+  rateText: {
+    fontSize: 15,
+  },
+  carrierText: {
+    fontSize: 14,
+  },
+  disclaimer: {
+    fontSize: 12,
+    fontStyle: 'italic',
+  },
+  errorText: {
+    fontSize: 13,
+  },
+});

--- a/src/components/__tests__/ShippingEstimatePanel.test.tsx
+++ b/src/components/__tests__/ShippingEstimatePanel.test.tsx
@@ -1,0 +1,175 @@
+/**
+ * Tests for ShippingEstimatePanel component — cm-9yn
+ * TDD: tests written before implementation.
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { ThemeProvider } from '@/theme/ThemeProvider';
+import { ShippingEstimatePanel } from '../ShippingEstimatePanel';
+
+// ── Mock the hook ─────────────────────────────────────────────────────────────
+
+const mockSetZip = jest.fn();
+let mockHookState = {
+  zip: '',
+  setZip: mockSetZip,
+  rate: null as null | {
+    amount: string;
+    carrier: string;
+    serviceLevel: string;
+    isEstimate: boolean;
+    isFreight: boolean;
+  },
+  isLoading: false,
+  error: null as Error | null,
+};
+
+jest.mock('@/hooks/useProductShippingEstimate', () => ({
+  useProductShippingEstimate: () => mockHookState,
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function renderPanel(overrides?: Partial<typeof mockHookState>) {
+  mockHookState = { zip: '', setZip: mockSetZip, rate: null, isLoading: false, error: null, ...overrides };
+  return render(
+    <ThemeProvider>
+      <ShippingEstimatePanel
+        productId="prod-001"
+        dimensions={{ width: 60, depth: 36, height: 35 }}
+        testID="shipping-panel"
+      />
+    </ThemeProvider>,
+  );
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ShippingEstimatePanel (cm-9yn)', () => {
+  beforeEach(() => jest.clearAllMocks());
+
+  // ── Render ─────────────────────────────────────────────────────────────────
+
+  it('renders with testID', () => {
+    const { getByTestId } = renderPanel();
+    expect(getByTestId('shipping-panel')).toBeTruthy();
+  });
+
+  it('renders zip input field', () => {
+    const { getByTestId } = renderPanel();
+    expect(getByTestId('shipping-zip-input')).toBeTruthy();
+  });
+
+  // ── No zip state ───────────────────────────────────────────────────────────
+
+  it('shows "Enter zip for shipping estimate" prompt when zip is empty', () => {
+    const { getByText } = renderPanel({ zip: '' });
+    expect(getByText('Enter zip for shipping estimate')).toBeTruthy();
+  });
+
+  it('does not show rate section when zip is empty', () => {
+    const { queryByTestId } = renderPanel({ zip: '' });
+    expect(queryByTestId('shipping-rate-result')).toBeNull();
+  });
+
+  // ── Zip input interaction ──────────────────────────────────────────────────
+
+  it('calls setZip when user types in zip input', () => {
+    const { getByTestId } = renderPanel();
+    fireEvent.changeText(getByTestId('shipping-zip-input'), '28801');
+    expect(mockSetZip).toHaveBeenCalledWith('28801');
+  });
+
+  // ── Loading state ──────────────────────────────────────────────────────────
+
+  it('shows loading indicator when isLoading=true', () => {
+    const { getByTestId } = renderPanel({ zip: '28801', isLoading: true });
+    expect(getByTestId('shipping-rate-loading')).toBeTruthy();
+  });
+
+  it('hides loading indicator when isLoading=false', () => {
+    const { queryByTestId } = renderPanel({ zip: '28801', isLoading: false });
+    expect(queryByTestId('shipping-rate-loading')).toBeNull();
+  });
+
+  // ── Rate display ───────────────────────────────────────────────────────────
+
+  it('shows parcel rate when API returns success', () => {
+    const { getByTestId, getByText } = renderPanel({
+      zip: '28801',
+      rate: {
+        amount: '49.00',
+        carrier: 'UPS',
+        serviceLevel: 'parcel',
+        isEstimate: false,
+        isFreight: false,
+      },
+    });
+    expect(getByTestId('shipping-rate-result')).toBeTruthy();
+    expect(getByText(/\$49\.00/)).toBeTruthy();
+    expect(getByText(/UPS/)).toBeTruthy();
+  });
+
+  it('shows freight label for LTL rate', () => {
+    const { getByText } = renderPanel({
+      zip: '28801',
+      rate: {
+        amount: '225.00',
+        carrier: 'R+L Carriers',
+        serviceLevel: 'freight',
+        isEstimate: true,
+        isFreight: true,
+      },
+    });
+    expect(getByText(/Freight/i)).toBeTruthy();
+  });
+
+  // ── isEstimate disclaimer ──────────────────────────────────────────────────
+
+  it('shows estimate disclaimer when isEstimate=true', () => {
+    const { getByTestId } = renderPanel({
+      zip: '28801',
+      rate: {
+        amount: '225.00',
+        carrier: 'R+L Carriers',
+        serviceLevel: 'freight',
+        isEstimate: true,
+        isFreight: true,
+      },
+    });
+    expect(getByTestId('shipping-estimate-disclaimer')).toBeTruthy();
+  });
+
+  it('does not show estimate disclaimer when isEstimate=false', () => {
+    const { queryByTestId } = renderPanel({
+      zip: '28801',
+      rate: {
+        amount: '49.00',
+        carrier: 'UPS',
+        serviceLevel: 'parcel',
+        isEstimate: false,
+        isFreight: false,
+      },
+    });
+    expect(queryByTestId('shipping-estimate-disclaimer')).toBeNull();
+  });
+
+  // ── Error state ────────────────────────────────────────────────────────────
+
+  it('shows error message when error is set', () => {
+    const { getByTestId } = renderPanel({
+      zip: '99999',
+      error: new Error('Invalid zip code'),
+    });
+    expect(getByTestId('shipping-rate-error')).toBeTruthy();
+  });
+
+  it('does not show rate result alongside error', () => {
+    const { queryByTestId } = renderPanel({
+      zip: '99999',
+      error: new Error('Service unavailable'),
+    });
+    expect(queryByTestId('shipping-rate-result')).toBeNull();
+  });
+});

--- a/src/hooks/__tests__/useProductShippingEstimate.test.ts
+++ b/src/hooks/__tests__/useProductShippingEstimate.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Tests for useProductShippingEstimate — cm-9yn
+ * TDD: tests written before implementation.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useProductShippingEstimate } from '../useProductShippingEstimate';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+jest.mock('@react-native-async-storage/async-storage', () =>
+  require('@react-native-async-storage/async-storage/jest/async-storage-mock'),
+);
+
+const mockGetShippingEstimate = jest.fn();
+
+jest.mock('@/services/wix/wixProvider', () => ({
+  useOptionalWixClient: () => ({
+    getShippingEstimate: mockGetShippingEstimate,
+  }),
+}));
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const DIMS = { width: 60, depth: 36, height: 35 };
+const PRODUCT_ID = 'prod-001';
+const ZIP = '28801';
+
+const PARCEL_RESPONSE = {
+  success: true,
+  rate: '49.00',
+  carrier: 'UPS',
+  serviceLevel: 'parcel',
+  isEstimate: false,
+  isFreight: false,
+};
+
+const FREIGHT_RESPONSE = {
+  success: true,
+  rate: '225.00',
+  carrier: 'R+L Carriers',
+  serviceLevel: 'freight',
+  isEstimate: true,
+  isFreight: true,
+};
+
+function renderEstimate(productId = PRODUCT_ID, dimensions = DIMS) {
+  return renderHook(() => useProductShippingEstimate({ productId, dimensions }));
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('useProductShippingEstimate (cm-9yn)', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    AsyncStorage.clear();
+  });
+
+  // ── Initial state ──────────────────────────────────────────────────────────
+
+  it('starts with empty zip, no rate, not loading', () => {
+    const { result } = renderEstimate();
+    expect(result.current.zip).toBe('');
+    expect(result.current.rate).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('does not call API when zip is empty', async () => {
+    renderEstimate();
+    await waitFor(() => {});
+    expect(mockGetShippingEstimate).not.toHaveBeenCalled();
+  });
+
+  // ── Zip persistence ────────────────────────────────────────────────────────
+
+  it('loads persisted zip from AsyncStorage on mount', async () => {
+    mockGetShippingEstimate.mockResolvedValue(PARCEL_RESPONSE);
+    await AsyncStorage.setItem('shipping_zip', ZIP);
+    const { result } = renderEstimate();
+    await waitFor(() => expect(result.current.zip).toBe(ZIP));
+  });
+
+  it('persists zip to AsyncStorage when setZip is called', async () => {
+    mockGetShippingEstimate.mockResolvedValue(PARCEL_RESPONSE);
+    const { result } = renderEstimate();
+    result.current.setZip(ZIP);
+    await waitFor(async () => {
+      const stored = await AsyncStorage.getItem('shipping_zip');
+      expect(stored).toBe(ZIP);
+    });
+  });
+
+  // ── API call ───────────────────────────────────────────────────────────────
+
+  it('calls getShippingEstimate with zip, productId and dims when zip is set', async () => {
+    mockGetShippingEstimate.mockResolvedValueOnce(PARCEL_RESPONSE);
+    const { result } = renderEstimate();
+    result.current.setZip(ZIP);
+
+    await waitFor(() => expect(mockGetShippingEstimate).toHaveBeenCalledTimes(1));
+    expect(mockGetShippingEstimate).toHaveBeenCalledWith({
+      zip: ZIP,
+      productId: PRODUCT_ID,
+      dimensions: DIMS,
+    });
+  });
+
+  it('sets rate from successful parcel API response', async () => {
+    mockGetShippingEstimate.mockResolvedValueOnce(PARCEL_RESPONSE);
+    const { result } = renderEstimate();
+    result.current.setZip(ZIP);
+
+    await waitFor(() => expect(result.current.rate).not.toBeNull());
+    expect(result.current.rate).toMatchObject({
+      amount: '49.00',
+      carrier: 'UPS',
+      serviceLevel: 'parcel',
+      isEstimate: false,
+      isFreight: false,
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('sets isEstimate=true and isFreight=true for freight response', async () => {
+    mockGetShippingEstimate.mockResolvedValueOnce(FREIGHT_RESPONSE);
+    const { result } = renderEstimate();
+    result.current.setZip(ZIP);
+
+    await waitFor(() => expect(result.current.rate).not.toBeNull());
+    expect(result.current.rate?.isEstimate).toBe(true);
+    expect(result.current.rate?.isFreight).toBe(true);
+    expect(result.current.rate?.amount).toBe('225.00');
+  });
+
+  // ── isLoading ──────────────────────────────────────────────────────────────
+
+  it('sets isLoading=true while API is in flight then false on resolve', async () => {
+    let resolve!: (v: unknown) => void;
+    mockGetShippingEstimate.mockReturnValueOnce(new Promise((r) => { resolve = r; }));
+
+    const { result } = renderEstimate();
+    result.current.setZip(ZIP);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+    resolve(PARCEL_RESPONSE);
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+  });
+
+  // ── Error handling ─────────────────────────────────────────────────────────
+
+  it('sets error when API throws, clears rate and isLoading', async () => {
+    mockGetShippingEstimate.mockRejectedValueOnce(new Error('network error'));
+    const { result } = renderEstimate();
+    result.current.setZip(ZIP);
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.error?.message).toBe('network error');
+    expect(result.current.rate).toBeNull();
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('sets error when API returns success=false', async () => {
+    mockGetShippingEstimate.mockResolvedValueOnce({ success: false, error: 'Invalid zip code' });
+    const { result } = renderEstimate();
+    result.current.setZip(ZIP);
+
+    await waitFor(() => expect(result.current.error).not.toBeNull());
+    expect(result.current.rate).toBeNull();
+  });
+
+  // ── Stale request cancellation ─────────────────────────────────────────────
+
+  it('ignores stale response when productId changes before resolution', async () => {
+    let resolveStale!: (v: unknown) => void;
+    mockGetShippingEstimate
+      .mockReturnValueOnce(new Promise((r) => { resolveStale = r; }))
+      .mockResolvedValueOnce({ ...PARCEL_RESPONSE, rate: '55.00', carrier: 'FedEx' });
+
+    const { result, rerender } = renderHook(
+      ({ productId }: { productId: string }) =>
+        useProductShippingEstimate({ productId, dimensions: DIMS }),
+      { initialProps: { productId: 'prod-001' } },
+    );
+
+    result.current.setZip(ZIP);
+    await waitFor(() => expect(result.current.isLoading).toBe(true));
+
+    // Swap product — triggers second call
+    rerender({ productId: 'prod-002' });
+
+    // Resolve stale first request
+    resolveStale(PARCEL_RESPONSE); // rate: 49.00 from old product
+
+    await waitFor(() => expect(result.current.rate?.amount).toBe('55.00'));
+    expect(result.current.rate?.amount).not.toBe('49.00');
+  });
+
+  // ── No wix client ──────────────────────────────────────────────────────────
+
+  it('handles sync throw from getShippingEstimate without crashing', async () => {
+    // Simulate client that throws synchronously
+    mockGetShippingEstimate.mockImplementationOnce(() => {
+      throw new Error('getShippingEstimate not available');
+    });
+
+    const { result } = renderEstimate();
+    result.current.setZip(ZIP);
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    // Error is set, rate stays null — screen does not crash
+    expect(result.current.rate).toBeNull();
+    expect(result.current.error?.message).toBe('getShippingEstimate not available');
+  });
+
+  // ── Zip validation ─────────────────────────────────────────────────────────
+
+  it('does not call API for zip shorter than 5 digits', async () => {
+    const { result } = renderEstimate();
+    result.current.setZip('123');
+    await waitFor(() => {});
+    expect(mockGetShippingEstimate).not.toHaveBeenCalled();
+  });
+
+  it('calls API for a valid 5-digit zip', async () => {
+    mockGetShippingEstimate.mockResolvedValueOnce(PARCEL_RESPONSE);
+    const { result } = renderEstimate();
+    result.current.setZip('90210');
+    await waitFor(() => expect(mockGetShippingEstimate).toHaveBeenCalledTimes(1));
+  });
+});

--- a/src/hooks/useProductShippingEstimate.ts
+++ b/src/hooks/useProductShippingEstimate.ts
@@ -1,0 +1,160 @@
+/**
+ * @module useProductShippingEstimate
+ *
+ * Provides a zip-code-driven shipping estimate for a single product on the PDP.
+ * User enters their zip; it's persisted to AsyncStorage and used to call the
+ * /_functions/getShippingEstimate backend webmethod.
+ *
+ * cm-9yn
+ */
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+import { useOptionalWixClient } from '@/services/wix/wixProvider';
+
+const STORAGE_KEY = 'shipping_zip';
+const ZIP_RE = /^\d{5}(-\d{4})?$/;
+
+export interface ProductDimensions {
+  width: number;
+  depth: number;
+  height: number;
+}
+
+export interface ShippingRate {
+  amount: string;
+  carrier: string;
+  serviceLevel: string;
+  isEstimate: boolean;
+  isFreight: boolean;
+}
+
+export interface UseProductShippingEstimateResult {
+  zip: string;
+  setZip: (zip: string) => void;
+  rate: ShippingRate | null;
+  isLoading: boolean;
+  error: Error | null;
+}
+
+interface Props {
+  productId: string;
+  dimensions: ProductDimensions;
+}
+
+export function useProductShippingEstimate({
+  productId,
+  dimensions,
+}: Props): UseProductShippingEstimateResult {
+  const wixClient = useOptionalWixClient();
+
+  const [zip, setZipState] = useState('');
+  const [rate, setRate] = useState<ShippingRate | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Track active fetch so stale responses are discarded
+  const fetchIdRef = useRef(0);
+  // Stable ref to avoid wixClient object identity triggering re-runs
+  const wixClientRef = useRef(wixClient);
+  wixClientRef.current = wixClient;
+
+  // Load persisted zip on mount
+  useEffect(() => {
+    AsyncStorage.getItem(STORAGE_KEY)
+      .then((stored) => {
+        if (stored) setZipState(stored);
+      })
+      .catch(() => {
+        // Ignore storage errors — zip stays empty
+      });
+  }, []);
+
+  const setZip = useCallback((newZip: string) => {
+    setZipState(newZip);
+    AsyncStorage.setItem(STORAGE_KEY, newZip).catch(() => {});
+  }, []);
+
+  // Stabilize dimensions — only re-run when values actually change
+  const dimW = dimensions.width;
+  const dimD = dimensions.depth;
+  const dimH = dimensions.height;
+
+  // Fetch estimate whenever zip, productId, or dimensions values change
+  useEffect(() => {
+    if (!ZIP_RE.test(zip)) {
+      // Not a valid zip yet — clear results without error
+      setRate(null);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    const client = wixClientRef.current;
+    if (!client) {
+      // No client available — silent, no rate
+      setRate(null);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    const fetchId = ++fetchIdRef.current;
+    let cancelled = false;
+
+    setIsLoading(true);
+    setError(null);
+    setRate(null);
+
+    let promise: Promise<unknown>;
+    try {
+      promise = client.getShippingEstimate({
+        zip,
+        productId,
+        dimensions: { width: dimW, depth: dimD, height: dimH },
+      });
+    } catch (syncErr) {
+      if (!cancelled && fetchIdRef.current === fetchId) {
+        setError(syncErr instanceof Error ? syncErr : new Error('Shipping estimate failed'));
+        setRate(null);
+        setIsLoading(false);
+      }
+      return;
+    }
+
+    promise
+      .then((res: unknown) => {
+        if (cancelled || fetchIdRef.current !== fetchId) return;
+        const r = res as { success: boolean; rate?: string; carrier?: string; serviceLevel?: string; isEstimate?: boolean; isFreight?: boolean; error?: string };
+        if (!r.success) {
+          setError(new Error(r.error ?? 'Shipping estimate unavailable'));
+          setRate(null);
+        } else {
+          setRate({
+            amount: r.rate ?? '0',
+            carrier: r.carrier ?? '',
+            serviceLevel: r.serviceLevel ?? 'parcel',
+            isEstimate: r.isEstimate ?? false,
+            isFreight: r.isFreight ?? false,
+          });
+          setError(null);
+        }
+        setIsLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled || fetchIdRef.current !== fetchId) return;
+        setError(err instanceof Error ? err : new Error('Shipping estimate failed'));
+        setRate(null);
+        setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  // wixClient intentionally omitted — accessed via wixClientRef to avoid
+  // new object identity on every render causing infinite effect re-runs
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [zip, productId, dimW, dimD, dimH]);
+
+  return { zip, setZip, rate, isLoading, error };
+}

--- a/src/screens/ProductDetailScreen.tsx
+++ b/src/screens/ProductDetailScreen.tsx
@@ -67,6 +67,7 @@ import { useBundleDeals } from '@/hooks/useBundleDeals';
 import { ShippingEstimateBadge } from '@/components/ShippingEstimateBadge';
 import { DeliveryEstimateWidget } from '@/components/DeliveryEstimateWidget';
 import { useShippingEstimate } from '@/hooks/useShippingEstimate';
+import { ShippingEstimatePanel } from '@/components/ShippingEstimatePanel';
 import { AnimatedPressable } from '@/components/AnimatedPressable';
 import { ImageGalleryModal } from '@/components/ImageGalleryModal';
 import { useRecentlyViewed } from '@/hooks/useRecentlyViewed';
@@ -761,6 +762,13 @@ export function ProductDetailScreen({
           <DeliveryEstimateWidget
             productIds={catalogProductId ? [catalogProductId] : []}
             testID="delivery-estimate-widget"
+          />
+
+          {/* Shipping Estimate Panel — cm-9yn: zip-driven parcel/freight rate */}
+          <ShippingEstimatePanel
+            productId={catalogProductId ?? model.id}
+            dimensions={model.dimensions}
+            testID="shipping-estimate-panel"
           />
 
           {/* Try in AR — primary CTA near price, Wayfair/IKEA pattern for conversion */}

--- a/src/services/wix/wixClient.ts
+++ b/src/services/wix/wixClient.ts
@@ -582,6 +582,27 @@ export class WixClient {
   }
 
   /**
+   * Fetch a single-product shipping estimate from the getShippingEstimate
+   * Wix backend webmethod (cm-9yn). Returns parcel or freight rate for a
+   * specific product based on its dimensions.
+   */
+  async getShippingEstimate(params: {
+    zip: string;
+    productId: string;
+    dimensions: { width: number; depth: number; height: number };
+  }): Promise<{
+    success: boolean;
+    rate?: string;
+    carrier?: string;
+    serviceLevel?: string;
+    isEstimate?: boolean;
+    isFreight?: boolean;
+    error?: string;
+  }> {
+    return this.post('/_functions/getShippingEstimate', params);
+  }
+
+  /**
    * Call godfrey's getDeliveryEstimate webMethod (cm-uyd).
    * Returns a delivery window or fallback "2-5 business days" copy.
    */


### PR DESCRIPTION
## Summary

- **useProductShippingEstimate hook**: user-entered zip persisted to AsyncStorage, calls `/_functions/getShippingEstimate` with productId + dims, returns rate/isEstimate/isFreight; stale requests cancelled on productId change; 5-digit zip validation before API call
- **ShippingEstimatePanel component**: zip TextInput, 'Enter zip for shipping estimate' prompt when empty, loading indicator, rate display (amount + carrier + Freight/LTL label), isEstimate disclaimer (*estimated rate copy), error state
- **WixClient.getShippingEstimate()**: new method wired to `/_functions/getShippingEstimate`
- **ProductDetailScreen**: ShippingEstimatePanel wired below DeliveryEstimateWidget in price section

## Test coverage (27 tests — TDD)

Hook (15):
- Initial state: empty zip, null rate, not loading
- Does not call API when zip is empty or <5 digits
- Loads persisted zip from AsyncStorage on mount
- Persists zip to AsyncStorage on setZip
- Calls API with correct params (zip, productId, dims)
- Parcel and freight rate mapping (amount, carrier, serviceLevel, isEstimate, isFreight)
- isLoading true during flight, false on resolve
- Error on API throw; error on success=false
- Stale request ignored when productId changes before resolution
- Sync throw from getShippingEstimate caught gracefully

Component (12):
- Renders with testID, zip input visible
- 'Enter zip for shipping estimate' prompt when no zip
- No rate section when zip empty
- setZip called on input change
- Loading indicator when isLoading=true
- Rate result with amount + carrier shown
- Freight label for LTL rate
- isEstimate disclaimer shown/hidden
- Error message shown, rate section hidden

## Checklist

- [x] TDD — tests committed with implementation
- [x] All ACs: zip input, AsyncStorage persist, parcel+freight rates, isEstimate disclaimer, no-zip + error states
- [x] try/catch on all async ops including sync throws
- [x] Stale request cancellation
- [x] Input validation (5-digit zip)
- [x] Self-review complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)