### PR TITLE
fix(cm-crd): null-safe CollectionCard for Wix optional fields

### DIFF
--- a/src/components/CollectionCard.tsx
+++ b/src/components/CollectionCard.tsx
@@ -52,7 +52,7 @@ export const CollectionCard = memo(function CollectionCard({
       accessibilityLabel={`${collection.title}: ${collection.subtitle}`}
       accessibilityRole="button"
     >
-      {imageError ? (
+      {imageError || !collection.heroImage ? (
         <View style={[styles.image, styles.imagePlaceholder, { backgroundColor: colors.sandDark }]}>
           <Text style={styles.placeholderEmoji}>🏡</Text>
         </View>
@@ -71,7 +71,7 @@ export const CollectionCard = memo(function CollectionCard({
       )}
       <View style={[styles.overlay, { backgroundColor: colors.overlay, padding: spacing.md }]}>
         <View style={styles.moodRow}>
-          {collection.mood.slice(0, 3).map((tag) => (
+          {(collection.mood ?? []).slice(0, 3).map((tag) => (
             <View
               key={tag}
               style={[
@@ -118,7 +118,7 @@ export const CollectionCard = memo(function CollectionCard({
             },
           ]}
         >
-          {collection.productIds.length} items
+          {(collection.productIds ?? []).length} items
         </Text>
       </View>
     </TouchableOpacity>

--- a/src/components/__tests__/CollectionCard.test.tsx
+++ b/src/components/__tests__/CollectionCard.test.tsx
@@ -60,4 +60,22 @@ describe('CollectionCard', () => {
       'Test Collection: A test subtitle',
     );
   });
+
+  it('renders placeholder emoji when heroImage is undefined', () => {
+    const collectionNoImage = { ...mockCollection, heroImage: undefined as unknown as EditorialCollection['heroImage'] };
+    const { getByText } = renderCard({ collection: collectionNoImage });
+    expect(getByText('🏡')).toBeTruthy();
+  });
+
+  it('renders without crashing when mood is undefined', () => {
+    const collectionNoMood = { ...mockCollection, mood: undefined as unknown as string[] };
+    const { getByText } = renderCard({ collection: collectionNoMood });
+    expect(getByText('Test Collection')).toBeTruthy();
+  });
+
+  it('renders 0 items when productIds is undefined', () => {
+    const collectionNoProducts = { ...mockCollection, productIds: undefined as unknown as string[] };
+    const { getByText } = renderCard({ collection: collectionNoProducts });
+    expect(getByText('0 items')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- heroImage can be undefined from Wix — guard image render, show placeholder instead of crash
- mood can be undefined — use (collection.mood ?? []).slice(0,3)
- productIds can be undefined — use (collection.productIds ?? []).length

Discovered during live Android emulator testing against real Wix data.

## Test plan
- 3 new test cases covering all three undefined field paths
- All 10 CollectionCard tests pass

🤖 Generated with Claude Code