### PR TITLE
feat(cm-k0396): persist shipping ZIP across PDP and checkout

### DIFF
--- a/docs/MASTER-HOOKUP.md
+++ b/docs/MASTER-HOOKUP.md
@@ -156,7 +156,9 @@ Next APK will contain all session-22 + session-23 work:
 - Recently Viewed rail on PDP — useRecentlyViewedSlugs hook (cm-pdp-recently-viewed) ✓ merged PR #233
 - Wishlist visual polish — item count, swipe actions, Add All to Cart (cm-l71) ✓ merged PR #239
 - A11y pass: shipping/share UI, ARIA labels, accessibilityHint, reduced-motion guards (cm-a11y-shipping) ✓ merged PR #234
-- Live points chip on PDP + CartPointsSummary earn estimate (cm-a02) — PR #238 in CI
+- Live points chip on PDP + CartPointsSummary earn estimate (cm-a02) ✓ merged PR #238
+- Loyalty screen reachable from AccountScreen (cm-1fh) ✓ merged PR #240
+- Search icon on HomeScreen navigates to SearchScreen (cm-we6) ✓ merged PR #241
 
 **EAS build blocker**: Free plan Android build quota exhausted. Resets 2026-04-01. To build before then, upgrade plan at https://expo.dev/accounts/halworker85/settings/billing or wait for reset.
 
@@ -258,12 +260,12 @@ When testing, verify each screen matches the Blue Ridge editorial feel:
 |--------|--------------------|-------------|
 | Home | Mountain skyline hero backdrop + GlassCard CTAs + mountain divider | — |
 | Shop | Dark editorial background, sand product cards, category pills | — |
-| Search | Search input with 300ms debounce + CMS trending chips (Wix) + results grid | 2026-03-22 cm-c00 + hq-jc723 |
+| Search | Search input with 300ms debounce + CMS trending chips (Wix) + results grid. Reachable via HomeScreen search icon (cm-we6) | 2026-03-22 cm-we6 |
 | Product Detail | Dark surfaces, editorial typography, warm shadows. Freight delivery banner (🚛) when requiresFreight=true with optional liftgate badge | 2026-03-22 cm-z9n |
 | Cart (empty) | Dark background, illustrated empty state (Blue Ridge SVG) | — |
 | Cart (items) | Dark editorial, product thumbnails, coral CTA | — |
 | Checkout | KeyboardAwareScrollView, saved address picker chips, address pre-fill. Loyalty tier banner near order summary when cart has items (hides on loading/error) | 2026-03-22 cm-ds5 |
-| Account | Dark editorial, Playfair Display heading, coral Sign In, saved addresses, privacy section (data export + account deletion) | — |
+| Account | Dark editorial, Playfair Display heading, coral Sign In, saved addresses, privacy section (data export + account deletion). Loyalty section tappable → LoyaltyScreen (cm-1fh) | 2026-03-22 cm-1fh |
 | Onboarding | Brand story slides + style quiz (dark editorial treatment). Quiz result shows Wix-fetched product thumbnails (expo-image) | 2026-03-22 cm-49p |
 | Login/SignUp | Dark editorial with GlassCard form container, KeyboardAwareScrollView | — |
 | OrderDetail | Order tracking with status timeline. Tracking number shows as tappable link only when URL present; plain text otherwise. recordDelivery fires exactly once | 2026-03-22 cm-tsh |
@@ -347,4 +349,7 @@ npm test
 | Challenges rail | **Live** | ChallengeCard with progress + countdown, ChallengesRail horizontal scroll |
 | Live points chip | **Live** | PointsChip on PDP, CartPointsSummary earn estimate (Mountain Blue) |
 | A11y shipping/share | **Live** | ARIA labels, accessibilityHint, reduced-motion guards on all shipping + share UI |
-| Test suite | **5679 tests passing** | 32 skipped, all green (session 23) |
+| Loyalty nav (cm-1fh) | **Live** | LoyaltyScreen reachable from AccountScreen tap |
+| Search nav (cm-we6) | **Live** | HomeScreen search icon → SearchScreen |
+| CollectionCard null safety | **Live** | heroImage/mood/productIds null guards (cm-crd) |
+| Test suite | **5761+ tests passing** | All green (session 24) |

--- a/src/screens/CheckoutScreen.tsx
+++ b/src/screens/CheckoutScreen.tsx
@@ -48,8 +48,12 @@ import { useAffirmPrequalification } from '@/hooks/useAffirmPrequalification';
 import { initiateAffirmCheckout } from '@/services/affirmService';
 import { useOptionalWixClient } from '@/services/wix';
 import { useKlarnaCheckout } from '@/hooks/useKlarnaCheckout';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { getDeliveryEstimate } from '@/utils/deliveryEstimate';
 import { useLoyalty } from '@/hooks/useLoyalty';
+
+const SHIPPING_ZIP_KEY = 'shipping_zip';
+const ZIP_RE = /^\d{5}(-\d{4})?$/;
 import { CheckoutLoyaltyBanner } from '@/components/CheckoutLoyaltyBanner';
 import {
   fetchShippingOptions,
@@ -289,7 +293,7 @@ export function CheckoutScreen({ onOrderComplete, onBack, testID }: Props) {
   // Address state — pre-fill from default saved address
   const [shippingAddress, setShippingAddress] = useState<Address>(EMPTY_ADDRESS);
 
-  // Pre-fill with default address on load
+  // Pre-fill with default address on load; fall back to persisted ZIP (cm-k0396)
   useEffect(() => {
     if (!addressBook.loading && addressBook.defaultAddress && !usingSavedAddress) {
       const da = addressBook.defaultAddress;
@@ -302,6 +306,17 @@ export function CheckoutScreen({ onOrderComplete, onBack, testID }: Props) {
         zip: da.zip,
       });
       setUsingSavedAddress(true);
+    } else if (!addressBook.loading && !addressBook.defaultAddress) {
+      // No saved address — pre-fill ZIP from shared shipping_zip key
+      AsyncStorage.getItem(SHIPPING_ZIP_KEY)
+        .then((stored) => {
+          if (stored) {
+            setShippingAddress((prev) => ({ ...prev, zip: stored }));
+          }
+        })
+        .catch(() => {
+          // Ignore storage errors — ZIP stays empty
+        });
     }
   }, [addressBook.loading, addressBook.defaultAddress]); // eslint-disable-line react-hooks/exhaustive-deps
   const [billingAddress, setBillingAddress] = useState<Address>(EMPTY_ADDRESS);
@@ -396,6 +411,10 @@ export function CheckoutScreen({ onOrderComplete, onBack, testID }: Props) {
       setShippingAddress((prev) => ({ ...prev, [field]: value }));
       if (shippingErrors[field as keyof AddressErrors]) {
         setShippingErrors((prev) => ({ ...prev, [field]: undefined }));
+      }
+      // Persist valid ZIP to shared storage for PDP/cart (cm-k0396)
+      if (field === 'zip' && ZIP_RE.test(value)) {
+        AsyncStorage.setItem(SHIPPING_ZIP_KEY, value).catch(() => {});
       }
     },
     [shippingErrors],

--- a/src/screens/__tests__/CheckoutScreen.test.tsx
+++ b/src/screens/__tests__/CheckoutScreen.test.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Platform } from 'react-native';
 import { render, fireEvent, waitFor, act } from '@testing-library/react-native';
+import AsyncStorage from '@react-native-async-storage/async-storage';
 import { CheckoutScreen } from '../CheckoutScreen';
 import { CartProvider, useCart } from '@/hooks/useCart';
 import { ConnectivityProvider } from '@/hooks/useConnectivity';
@@ -1524,6 +1525,108 @@ describe('CheckoutScreen', () => {
       fireEvent.changeText(utils.getByTestId('shipping-zip'), '28801');
       await act(async () => {});
       expect(utils.queryByTestId('shipping-options-error')).toBeNull();
+    });
+  });
+
+  describe('ZIP persistence (cm-k0396)', () => {
+    const SHIPPING_ZIP_KEY = 'shipping_zip';
+
+    beforeEach(() => {
+      (AsyncStorage.getItem as jest.Mock).mockResolvedValue(null);
+      (AsyncStorage.setItem as jest.Mock).mockResolvedValue(undefined);
+    });
+
+    it('pre-fills ZIP from AsyncStorage when no saved address exists', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+        key === SHIPPING_ZIP_KEY ? Promise.resolve('90210') : Promise.resolve(null),
+      );
+      const utils = renderCheckout({}, seed);
+      await act(async () => {});
+      const zipField = utils.getByTestId('shipping-zip');
+      expect(zipField.props.value).toBe('90210');
+    });
+
+    it('does NOT override saved address ZIP with persisted ZIP', async () => {
+      // Mock address book with a saved address
+      const useAddressBookModule = require('@/hooks/useAddressBook');
+      const original = useAddressBookModule.useAddressBook;
+      useAddressBookModule.useAddressBook = () => ({
+        addresses: [
+          {
+            id: '1',
+            fullName: 'Jane Doe',
+            line1: '456 Oak Ave',
+            line2: '',
+            city: 'Denver',
+            state: 'CO',
+            zip: '80202',
+            isDefault: true,
+          },
+        ],
+        defaultAddress: {
+          id: '1',
+          fullName: 'Jane Doe',
+          line1: '456 Oak Ave',
+          line2: '',
+          city: 'Denver',
+          state: 'CO',
+          zip: '80202',
+          isDefault: true,
+        },
+        loading: false,
+        addAddress: jest.fn(),
+        updateAddress: jest.fn(),
+        deleteAddress: jest.fn(),
+        setDefault: jest.fn(),
+        saveFromCheckout: jest.fn(),
+      });
+
+      (AsyncStorage.getItem as jest.Mock).mockImplementation((key: string) =>
+        key === SHIPPING_ZIP_KEY ? Promise.resolve('90210') : Promise.resolve(null),
+      );
+      const utils = renderCheckout({}, seed);
+      await act(async () => {});
+      const zipField = utils.getByTestId('shipping-zip');
+      // Saved address ZIP (80202) takes precedence over persisted ZIP (90210)
+      expect(zipField.props.value).toBe('80202');
+
+      // Restore original mock
+      useAddressBookModule.useAddressBook = original;
+    });
+
+    it('persists ZIP to AsyncStorage when user types in checkout', async () => {
+      const utils = renderCheckout({}, seed);
+      await act(async () => {});
+      fireEvent.changeText(utils.getByTestId('shipping-zip'), '10001');
+      await act(async () => {});
+      expect(AsyncStorage.setItem).toHaveBeenCalledWith(SHIPPING_ZIP_KEY, '10001');
+    });
+
+    it('handles AsyncStorage read failure gracefully — ZIP stays empty', async () => {
+      (AsyncStorage.getItem as jest.Mock).mockRejectedValue(new Error('storage error'));
+      const utils = renderCheckout({}, seed);
+      await act(async () => {});
+      const zipField = utils.getByTestId('shipping-zip');
+      expect(zipField.props.value).toBe('');
+    });
+
+    it('handles AsyncStorage write failure gracefully — no crash', async () => {
+      (AsyncStorage.setItem as jest.Mock).mockRejectedValue(new Error('write error'));
+      const utils = renderCheckout({}, seed);
+      await act(async () => {});
+      // Should not throw
+      fireEvent.changeText(utils.getByTestId('shipping-zip'), '28801');
+      await act(async () => {});
+      expect(utils.getByTestId('shipping-zip').props.value).toBe('28801');
+    });
+
+    it('does not persist empty or partial ZIP', async () => {
+      const utils = renderCheckout({}, seed);
+      await act(async () => {});
+      fireEvent.changeText(utils.getByTestId('shipping-zip'), '123');
+      await act(async () => {});
+      // Only valid 5-digit ZIPs should be persisted
+      expect(AsyncStorage.setItem).not.toHaveBeenCalledWith(SHIPPING_ZIP_KEY, '123');
     });
   });
 });


### PR DESCRIPTION
## Summary
- CheckoutScreen now reads the shared `shipping_zip` AsyncStorage key as a ZIP field fallback when no saved address exists
- Valid ZIPs entered in checkout are written back to `shipping_zip` so PDP ShippingEstimatePanel and CartItemDeliveryEstimate auto-fill on next visit
- Saved addresses still take priority — persisted ZIP is only used when no default address exists

## Test plan
- [x] 6 new tests added covering all paths:
  - Pre-fill from AsyncStorage when no saved address
  - Saved address ZIP takes priority over persisted ZIP
  - Persist valid ZIP on user input
  - AsyncStorage read failure handled gracefully
  - AsyncStorage write failure handled gracefully
  - Partial/invalid ZIPs not persisted
- [x] All 120 CheckoutScreen tests pass
- [x] All 58 shipping-related tests pass (useProductShippingEstimate, useCartItemDeliveryEstimate, ShippingEstimatePanel)
- [x] CI green on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)