### PR TITLE
feat(cm-7i1y0): streak multiplier display — match web Phase 2 tiers

### DIFF
--- a/src/components/StreakBadge.tsx
+++ b/src/components/StreakBadge.tsx
@@ -9,6 +9,7 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '@/theme';
+import { getStreakMultiplier } from '@/utils/streakMultiplier';
 
 interface Props {
   /** Number of consecutive days in the current streak. */
@@ -18,6 +19,8 @@ interface Props {
 
 export function StreakBadge({ streak, testID }: Props) {
   const { colors, borderRadius } = useTheme();
+  const multiplier = getStreakMultiplier(streak);
+  const showMultiplier = multiplier > 1;
 
   return (
     <View
@@ -30,12 +33,27 @@ export function StreakBadge({ streak, testID }: Props) {
         },
       ]}
       testID={testID ?? 'streak-badge'}
-      accessibilityLabel={`${streak} day streak`}
+      accessibilityLabel={`${streak} day streak${showMultiplier ? `, ${multiplier}× points` : ''}`}
       accessibilityRole="text"
     >
       <Text style={styles.fire}>🔥</Text>
       <Text style={[styles.count, { color: colors.sunsetCoral }]}>{streak}</Text>
       <Text style={[styles.label, { color: colors.sunsetCoral }]}>day streak</Text>
+      {showMultiplier && (
+        <Text
+          testID="streak-multiplier"
+          style={[
+            styles.multiplier,
+            {
+              color: colors.mountainBlue,
+              backgroundColor: colors.mountainBlue + '22',
+              borderRadius: borderRadius.sm,
+            },
+          ]}
+        >
+          {multiplier}×
+        </Text>
+      )}
     </View>
   );
 }
@@ -60,5 +78,12 @@ const styles = StyleSheet.create({
   label: {
     fontSize: 12,
     fontWeight: '600',
+  },
+  multiplier: {
+    fontSize: 11,
+    fontWeight: '700',
+    paddingHorizontal: 5,
+    paddingVertical: 1,
+    overflow: 'hidden',
   },
 });

--- a/src/components/__tests__/StreakBadge.test.tsx
+++ b/src/components/__tests__/StreakBadge.test.tsx
@@ -27,7 +27,7 @@ describe('StreakBadge', () => {
 
   it('shows the streak count', () => {
     const { getByText } = renderBadge(5);
-    expect(getByText(/5/)).toBeTruthy();
+    expect(getByText('5')).toBeTruthy();
   });
 
   it('shows "day streak" label for singular streak', () => {
@@ -70,5 +70,33 @@ describe('StreakBadge', () => {
   it('renders with large streak (365)', () => {
     const { getByText } = renderBadge(365);
     expect(getByText(/365/)).toBeTruthy();
+  });
+
+  // ── Streak Multiplier (cm-7i1y0) ───────────────────────────────
+
+  it('shows multiplier chip when streak >= 3 days', () => {
+    const { getByTestId } = renderBadge(3);
+    expect(getByTestId('streak-multiplier')).toBeTruthy();
+  });
+
+  it('shows "1.5×" multiplier for 3-day streak', () => {
+    const { getByText } = renderBadge(3);
+    expect(getByText(/1\.5×/)).toBeTruthy();
+  });
+
+  it('shows "2×" multiplier for 7-day streak', () => {
+    const { getByText } = renderBadge(7);
+    expect(getByText(/2×/)).toBeTruthy();
+  });
+
+  it('does NOT show multiplier chip when streak < 3 days', () => {
+    const { queryByTestId } = renderBadge(2);
+    expect(queryByTestId('streak-multiplier')).toBeNull();
+  });
+
+  it('includes multiplier in accessibility label when active', () => {
+    const { getByTestId } = renderBadge(7);
+    const badge = getByTestId('streak-badge');
+    expect(badge.props.accessibilityLabel).toMatch(/2×.*points/);
   });
 });

--- a/src/utils/__tests__/streakMultiplier.test.ts
+++ b/src/utils/__tests__/streakMultiplier.test.ts
@@ -1,0 +1,71 @@
+/**
+ * @module streakMultiplier.test
+ *
+ * Tests for getStreakMultiplier() utility matching web gamificationTokens.js
+ * STREAK_MULTIPLIER_TIERS (cf-7yu / cm-7i1y0).
+ *
+ * Tiers:
+ *   0–2 days → 1×
+ *   3–6 days → 1.5×
+ *   7+ days  → 2×
+ */
+
+import { getStreakMultiplier, STREAK_MULTIPLIER_TIERS } from '../streakMultiplier';
+
+describe('getStreakMultiplier', () => {
+  it('returns 1× for streak of 0 days', () => {
+    expect(getStreakMultiplier(0)).toBe(1);
+  });
+
+  it('returns 1× for streak of 1 day', () => {
+    expect(getStreakMultiplier(1)).toBe(1);
+  });
+
+  it('returns 1× for streak of 2 days', () => {
+    expect(getStreakMultiplier(2)).toBe(1);
+  });
+
+  it('returns 1.5× for streak of 3 days', () => {
+    expect(getStreakMultiplier(3)).toBe(1.5);
+  });
+
+  it('returns 1.5× for streak of 6 days', () => {
+    expect(getStreakMultiplier(6)).toBe(1.5);
+  });
+
+  it('returns 2× for streak of 7 days', () => {
+    expect(getStreakMultiplier(7)).toBe(2);
+  });
+
+  it('returns 2× for streak of 30 days', () => {
+    expect(getStreakMultiplier(30)).toBe(2);
+  });
+
+  it('returns 1× for negative values', () => {
+    expect(getStreakMultiplier(-1)).toBe(1);
+  });
+
+  it('returns 2× for very large streak', () => {
+    expect(getStreakMultiplier(365)).toBe(2);
+  });
+});
+
+describe('STREAK_MULTIPLIER_TIERS', () => {
+  it('has exactly 3 tiers', () => {
+    expect(STREAK_MULTIPLIER_TIERS).toHaveLength(3);
+  });
+
+  it('tiers are sorted by minDays descending (highest first)', () => {
+    for (let i = 1; i < STREAK_MULTIPLIER_TIERS.length; i++) {
+      expect(STREAK_MULTIPLIER_TIERS[i - 1].minDays).toBeGreaterThan(
+        STREAK_MULTIPLIER_TIERS[i].minDays,
+      );
+    }
+  });
+
+  it('all multipliers are >= 1', () => {
+    STREAK_MULTIPLIER_TIERS.forEach((tier) => {
+      expect(tier.multiplier).toBeGreaterThanOrEqual(1);
+    });
+  });
+});

--- a/src/utils/streakMultiplier.ts
+++ b/src/utils/streakMultiplier.ts
@@ -1,0 +1,33 @@
+/**
+ * @module streakMultiplier
+ *
+ * Streak-based points multiplier tiers — mirrors web gamificationTokens.js
+ * STREAK_MULTIPLIER_TIERS (cf-7yu).
+ *
+ * Tiers:
+ *   0–2 days → 1×  (base)
+ *   3–6 days → 1.5× (building momentum)
+ *   7+ days  → 2×  (max multiplier)
+ *
+ * cm-7i1y0
+ */
+
+export interface StreakMultiplierTier {
+  minDays: number;
+  multiplier: number;
+  label: string;
+}
+
+/** Sorted highest-first so getStreakMultiplier can short-circuit on first match. */
+export const STREAK_MULTIPLIER_TIERS: StreakMultiplierTier[] = [
+  { minDays: 7, multiplier: 2, label: '2× points' },
+  { minDays: 3, multiplier: 1.5, label: '1.5× points' },
+  { minDays: 0, multiplier: 1, label: 'Base points' },
+];
+
+/** Returns the points multiplier for a given streak length in days. */
+export function getStreakMultiplier(days: number): number {
+  const safeDays = Math.max(0, days);
+  const tier = STREAK_MULTIPLIER_TIERS.find((t) => safeDays >= t.minDays);
+  return tier?.multiplier ?? 1;
+}


### PR DESCRIPTION
## Summary
- Add `getStreakMultiplier()` utility mirroring web `gamificationTokens.js` `STREAK_MULTIPLIER_TIERS` (cf-7yu)
- Tiers: 1× (0-2 days), 1.5× (3-6 days), 2× (7+ days) — exact match with web implementation
- StreakBadge now shows Mountain Blue multiplier chip when streak >= 3 days
- Cross-rig homogenization: mobile multiplier logic is identical to web

## Test plan
- [x] 12 new utility tests for `getStreakMultiplier()` — boundary values, negative input, large values
- [x] 5 new StreakBadge tests — multiplier visibility, display values, a11y labels
- [x] All 14 StreakBadge tests pass
- [x] All 102 HomeScreen + AccountScreen tests pass (StreakBadge consumers)
- [x] Existing test fix: `getByText(/5/)` → `getByText('5')` to avoid collision with `1.5×`

🤖 Generated with [Claude Code](https://claude.com/claude-code)