### PR TITLE
feat(cm-f3872): useActiveChallenges hook — Phase 4 API integration

### DIFF
--- a/src/hooks/__tests__/useActiveChallenges.test.ts
+++ b/src/hooks/__tests__/useActiveChallenges.test.ts
@@ -152,10 +152,6 @@ describe('useActiveChallenges', () => {
     const { result } = renderHook(() => useActiveChallenges());
     await waitFor(() => expect(result.current.loading).toBe(false));
 
-    expect(mockCallFunction).toHaveBeenCalledWith(
-      '/_functions/getActiveChallenges',
-      'POST',
-      {},
-    );
+    expect(mockCallFunction).toHaveBeenCalledWith('/_functions/getActiveChallenges', 'POST', {});
   });
 });

--- a/src/hooks/useActiveChallenges.ts
+++ b/src/hooks/useActiveChallenges.ts
@@ -47,8 +47,7 @@ export interface UseActiveChallengesResult {
 }
 
 function mapApiChallenge(api: ApiChallenge): Challenge {
-  const rawProgress =
-    api.targetCount > 0 ? api.progress.progressValue / api.targetCount : 0;
+  const rawProgress = api.targetCount > 0 ? api.progress.progressValue / api.targetCount : 0;
 
   return {
     id: api.challengeId,


### PR DESCRIPTION
## Summary
- New `useActiveChallenges` hook fetching from Wix `getActiveChallenges` webMethod
- Maps API response to existing `Challenge` type (progress ratio, expiry timestamp)
- Falls back to static mock challenges when offline/no Wix client
- Cross-rig Phase 4 counterpart — API contract confirmed by melania (hq-wisp-rxmt)
- Ready to wire into existing `ChallengesRail` component on HomeScreen

## Test plan
- [x] 11 tests covering: loading state, API mapping, progress computation, error handling, offline fallback, malformed response, progress clamping, reward formatting, API call verification
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)