### PR TITLE
feat(cm-z4amm): useProductResources hook — PDP resources from Wix CMS

### DIFF
--- a/src/hooks/__tests__/useProductResources.test.ts
+++ b/src/hooks/__tests__/useProductResources.test.ts
@@ -1,0 +1,126 @@
+/**
+ * @module useProductResources.test
+ *
+ * Tests for useProductResources hook — fetches product resources
+ * (spec sheets, care guides, videos, etc.) from getProductResources webMethod.
+ *
+ * cm-z4amm
+ */
+
+import { renderHook, waitFor } from '@testing-library/react-native';
+import { useProductResources } from '../useProductResources';
+
+const mockCallFunction = jest.fn();
+let mockWixClient: { callFunction: jest.Mock } | null = { callFunction: mockCallFunction };
+
+jest.mock('@/services/wix', () => ({
+  useOptionalWixClient: () => mockWixClient,
+}));
+
+const MOCK_RESOURCES = {
+  resources: [
+    {
+      productId: 'prod-asheville',
+      resourceType: 'SPEC_SHEET',
+      label: 'Asheville Specifications',
+      url: 'https://static.wixstatic.com/media/specs/asheville.pdf',
+      sortOrder: 1,
+    },
+    {
+      productId: 'prod-asheville',
+      resourceType: 'CARE_GUIDE',
+      label: 'Care Instructions',
+      url: 'https://static.wixstatic.com/media/care/futon-care.pdf',
+      sortOrder: 2,
+    },
+    {
+      productId: 'prod-asheville',
+      resourceType: 'VIDEO',
+      label: 'Assembly Video',
+      url: 'https://www.youtube.com/watch?v=abc123',
+      sortOrder: 3,
+    },
+  ],
+};
+
+describe('useProductResources', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockWixClient = { callFunction: mockCallFunction };
+    mockCallFunction.mockResolvedValue(MOCK_RESOURCES);
+  });
+
+  it('returns loading=true initially', () => {
+    const { result } = renderHook(() => useProductResources('prod-asheville'));
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('fetches resources and returns them sorted by sortOrder', async () => {
+    const { result } = renderHook(() => useProductResources('prod-asheville'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.resources).toHaveLength(3);
+    expect(result.current.resources[0].resourceType).toBe('SPEC_SHEET');
+    expect(result.current.resources[1].resourceType).toBe('CARE_GUIDE');
+    expect(result.current.resources[2].resourceType).toBe('VIDEO');
+  });
+
+  it('calls API with correct path and productId', async () => {
+    const { result } = renderHook(() => useProductResources('prod-asheville'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockCallFunction).toHaveBeenCalledWith('/_functions/getProductResources', 'POST', {
+      productId: 'prod-asheville',
+    });
+  });
+
+  it('returns empty array when API returns no resources', async () => {
+    mockCallFunction.mockResolvedValue({ resources: [] });
+    const { result } = renderHook(() => useProductResources('prod-asheville'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.resources).toEqual([]);
+  });
+
+  it('returns empty array and error on API failure', async () => {
+    mockCallFunction.mockRejectedValue(new Error('Network error'));
+    const { result } = renderHook(() => useProductResources('prod-asheville'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.resources).toEqual([]);
+    expect(result.current.error).toBeTruthy();
+  });
+
+  it('returns empty array when wix client is null', async () => {
+    mockWixClient = null;
+    const { result } = renderHook(() => useProductResources('prod-asheville'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.resources).toEqual([]);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('does not fetch when productId is empty', async () => {
+    const { result } = renderHook(() => useProductResources(''));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockCallFunction).not.toHaveBeenCalled();
+    expect(result.current.resources).toEqual([]);
+  });
+
+  it('handles malformed API response gracefully', async () => {
+    mockCallFunction.mockResolvedValue({ resources: null });
+    const { result } = renderHook(() => useProductResources('prod-asheville'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.resources).toEqual([]);
+  });
+
+  it('maps resource icon based on resourceType', async () => {
+    const { result } = renderHook(() => useProductResources('prod-asheville'));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.resources[0].icon).toBeDefined();
+    expect(result.current.resources[2].icon).toBeDefined(); // VIDEO
+  });
+});

--- a/src/hooks/useProductResources.ts
+++ b/src/hooks/useProductResources.ts
@@ -1,0 +1,118 @@
+/**
+ * @module useProductResources
+ *
+ * Fetches product resources (spec sheets, care guides, videos, assembly guides)
+ * from the Wix getProductResources webMethod.
+ *
+ * CMS collection: ProductResources (created by miquella, CF-wh4 PR #722)
+ * Fields: productId, resourceType, label, url, sortOrder
+ *
+ * cm-z4amm
+ */
+
+import { useState, useEffect } from 'react';
+import { useOptionalWixClient } from '@/services/wix';
+
+export type ResourceType =
+  | 'SPEC_SHEET'
+  | 'CARE_GUIDE'
+  | 'WARRANTY'
+  | 'VIDEO'
+  | 'POLICY_LINK'
+  | 'ASSEMBLY_GUIDE';
+
+const RESOURCE_ICONS: Record<ResourceType, string> = {
+  SPEC_SHEET: '📋',
+  CARE_GUIDE: '🧹',
+  WARRANTY: '🛡️',
+  VIDEO: '🎬',
+  POLICY_LINK: '📄',
+  ASSEMBLY_GUIDE: '🔧',
+};
+
+export interface ProductResource {
+  productId: string;
+  resourceType: ResourceType;
+  label: string;
+  url: string;
+  sortOrder: number;
+  icon: string;
+}
+
+interface ApiResource {
+  productId: string;
+  resourceType: string;
+  label: string;
+  url: string;
+  sortOrder: number;
+}
+
+export interface UseProductResourcesResult {
+  resources: ProductResource[];
+  loading: boolean;
+  error: Error | null;
+}
+
+function mapResource(api: ApiResource): ProductResource {
+  const type = api.resourceType as ResourceType;
+  return {
+    productId: api.productId,
+    resourceType: type,
+    label: api.label,
+    url: api.url,
+    sortOrder: api.sortOrder,
+    icon: RESOURCE_ICONS[type] ?? '📄',
+  };
+}
+
+export function useProductResources(productId: string): UseProductResourcesResult {
+  const wixClient = useOptionalWixClient();
+  const [resources, setResources] = useState<ProductResource[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    if (!productId) {
+      setResources([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    if (!wixClient) {
+      setResources([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    wixClient
+      .callFunction<{ resources: ApiResource[] | null }>(
+        '/_functions/getProductResources',
+        'POST',
+        { productId },
+      )
+      .then((res) => {
+        if (cancelled) return;
+        const items = Array.isArray(res?.resources) ? res.resources : [];
+        setResources(items.map(mapResource).sort((a, b) => a.sortOrder - b.sortOrder));
+        setLoading(false);
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        setError(err instanceof Error ? err : new Error('Failed to fetch resources'));
+        setResources([]);
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [wixClient, productId]);
+
+  return { resources, loading, error };
+}


### PR DESCRIPTION
## Summary
- New `useProductResources` hook fetching spec sheets, care guides, videos, assembly guides from Wix CMS
- Consumes `getProductResources(productId)` webMethod (live, created by miquella CF-wh4 PR #722)
- Maps resource types to emoji icons, sorts by sortOrder
- Graceful offline/error handling

## Test plan
- [x] 9 tests: loading, fetch + sort, API call, empty/error/null/malformed, icon mapping
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)