### PR TITLE
fix(hq-je5y0): tree fill color #5C4033 → #2E4A38 in MountainSkyline

### DIFF
--- a/src/components/MountainSkyline.tsx
+++ b/src/components/MountainSkyline.tsx
@@ -164,14 +164,14 @@ export function MountainSkyline({
               y={tree.trunk.y}
               width={tree.trunk.width}
               height={tree.trunk.height}
-              fill={colors.espresso}
+              fill={colors.treeDark}
               opacity={0.4}
             />
             {tree.canopyLayers.map((canopy, j) => (
               <Path
                 key={`canopy-${i}-${j}`}
                 d={canopy.path}
-                fill={colors.espresso}
+                fill={colors.treeDark}
                 opacity={canopy.opacity}
               />
             ))}

--- a/src/components/__tests__/MountainSkyline.test.tsx
+++ b/src/components/__tests__/MountainSkyline.test.tsx
@@ -48,6 +48,19 @@ describe('MountainSkyline', () => {
     expect(colors.espresso).toBe('#3A2518');
   });
 
+  it('treeDark token is forest dark green #2E4A38', () => {
+    expect(colors.treeDark).toBe('#2E4A38');
+  });
+
+  it('tree fill uses forest dark green (#2E4A38)', () => {
+    const { toJSON } = render(<MountainSkyline testID="skyline-tree-color" showDetails />, {
+      wrapper,
+    });
+    const json = JSON.stringify(toJSON());
+    // Trees (trunk Rect + canopy Path) should render with forest dark green
+    expect(json).toContain('"fill":"#2E4A38"');
+  });
+
   it('renders 7 mountain layers', () => {
     const { toJSON } = render(<MountainSkyline testID="skyline-layers" />, { wrapper });
     const json = JSON.stringify(toJSON());

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -61,6 +61,8 @@ export const colors = {
   // --- Decorative gradients ---
   skyGradientTop: '#B8D4E3',
   skyGradientBottom: '#F0C87A',
+  /** Forest dark green for pine tree illustration fills — matches web mountain-skyline-figma.svg */
+  treeDark: '#2E4A38',
 
   // --- Neutrals ---
   offWhite: '#FAF7F2',


### PR DESCRIPTION
## Summary

- Adds `treeDark: '#2E4A38'` token to `theme/tokens.ts` (forest dark green)
- Updates `MountainSkyline` pine tree trunk and canopy fills from `colors.espresso` to `colors.treeDark`
- Aligns mobile illustration with web `mountain-skyline-figma.svg` (cross-rig fix, hq-wisp-lsgs)

**Note:** `#5C4033` (`colors.espressoLight`) is still legitimately used for the atmospheric haze band — that is intentional and unchanged.

## Test plan

- [x] New test: `treeDark token is forest dark green #2E4A38` — verifies token value
- [x] New test: `tree fill uses forest dark green (#2E4A38)` — verifies rendered SVG contains correct fill
- [x] All 13 MountainSkyline tests pass
- [x] `eslint --fix` clean on all changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)