### PR TITLE
feat(hq-g26rc): collapsible Resources section on ProductDetailScreen

### DIFF
--- a/src/components/ProductResourcesSection.tsx
+++ b/src/components/ProductResourcesSection.tsx
@@ -1,0 +1,131 @@
+/**
+ * @module ProductResourcesSection
+ *
+ * Collapsible "Resources" section for ProductDetailScreen.
+ * Renders tappable resource items (spec sheets, care guides, videos, etc.)
+ * sourced from useProductResources. Opens URLs via Linking.openURL.
+ *
+ * Hidden when: loading, error, or empty resources array.
+ * Starts expanded. Toggle collapses/expands the list.
+ *
+ * hq-g26rc / Phase 7 PDP
+ */
+
+import React, { useState, useCallback } from 'react';
+import { View, Text, TouchableOpacity, Linking, StyleSheet } from 'react-native';
+import { colors, spacing, typography, borderRadius } from '@/theme/tokens';
+import { type ProductResource } from '@/hooks/useProductResources';
+
+interface Props {
+  resources: ProductResource[];
+  loading: boolean;
+  error: Error | null;
+}
+
+export function ProductResourcesSection({ resources, loading, error }: Props) {
+  const [expanded, setExpanded] = useState(true);
+
+  const handleToggle = useCallback(() => setExpanded((v) => !v), []);
+
+  const handleOpen = useCallback((url: string) => {
+    Linking.openURL(url).catch(() => {
+      // URL open failure — platform may have no handler; fail silently
+    });
+  }, []);
+
+  if (loading || error || resources.length === 0) return null;
+
+  return (
+    <View testID="resources-section" style={styles.container}>
+      {/* Header row with toggle */}
+      <TouchableOpacity
+        testID="resources-toggle"
+        style={styles.header}
+        onPress={handleToggle}
+        accessibilityRole="button"
+        accessibilityLabel={expanded ? 'Collapse resources' : 'Expand resources'}
+      >
+        <Text style={styles.title}>Resources</Text>
+        <Text style={styles.chevron}>{expanded ? '▲' : '▼'}</Text>
+      </TouchableOpacity>
+
+      {/* Resource list */}
+      {expanded && (
+        <View testID="resources-list" style={styles.list}>
+          {resources.map((resource, index) => (
+            <TouchableOpacity
+              key={`${resource.resourceType}-${resource.sortOrder}`}
+              testID={`resource-item-${index}`}
+              style={styles.item}
+              onPress={() => handleOpen(resource.url)}
+              accessibilityRole="button"
+              accessibilityLabel={`Open ${resource.label}`}
+            >
+              <Text testID={`resource-icon-${index}`} style={styles.icon}>
+                {resource.icon}
+              </Text>
+              <Text style={styles.label} numberOfLines={1}>
+                {resource.label}
+              </Text>
+              <Text style={styles.arrow}>›</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+      )}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginHorizontal: spacing.lg,
+    marginTop: spacing.md,
+    marginBottom: spacing.sm,
+    borderRadius: borderRadius.md,
+    backgroundColor: colors.sandLight,
+    overflow: 'hidden',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+  },
+  title: {
+    fontFamily: typography.bodyFamilyBold,
+    fontSize: 15,
+    color: colors.espresso,
+  },
+  chevron: {
+    fontSize: 11,
+    color: colors.espressoLight,
+  },
+  list: {
+    borderTopWidth: StyleSheet.hairlineWidth,
+    borderTopColor: colors.sandDark,
+  },
+  item: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: spacing.md,
+    paddingVertical: spacing.sm,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+    borderBottomColor: colors.sandDark,
+  },
+  icon: {
+    fontSize: 16,
+    marginRight: spacing.sm,
+  },
+  label: {
+    flex: 1,
+    fontFamily: typography.bodyFamily,
+    fontSize: 14,
+    color: colors.espresso,
+  },
+  arrow: {
+    fontSize: 18,
+    color: colors.espressoLight,
+    marginLeft: spacing.xs,
+  },
+});

--- a/src/components/__tests__/ProductResourcesSection.test.tsx
+++ b/src/components/__tests__/ProductResourcesSection.test.tsx
@@ -1,0 +1,200 @@
+/**
+ * Tests for ProductResourcesSection — hq-g26rc
+ * TDD: tests written before implementation per Melania Directive.
+ *
+ * Collapsible section rendering tappable resource items that open URLs
+ * via Linking.openURL.
+ */
+
+import React from 'react';
+import { Linking } from 'react-native';
+import { render, fireEvent } from '@testing-library/react-native';
+import { ProductResourcesSection } from '../ProductResourcesSection';
+import { type ProductResource } from '@/hooks/useProductResources';
+
+const mockResources: ProductResource[] = [
+  {
+    productId: 'prod-1',
+    resourceType: 'SPEC_SHEET',
+    label: 'Product Spec Sheet',
+    url: 'https://example.com/spec.pdf',
+    sortOrder: 1,
+    icon: '📋',
+  },
+  {
+    productId: 'prod-1',
+    resourceType: 'CARE_GUIDE',
+    label: 'Care Guide',
+    url: 'https://example.com/care.pdf',
+    sortOrder: 2,
+    icon: '🧹',
+  },
+  {
+    productId: 'prod-1',
+    resourceType: 'VIDEO',
+    label: 'Assembly Video',
+    url: 'https://example.com/video',
+    sortOrder: 3,
+    icon: '🎬',
+  },
+];
+
+describe('ProductResourcesSection', () => {
+  beforeEach(() => {
+    jest.spyOn(Linking, 'openURL').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('empty / hidden states', () => {
+    it('renders nothing when resources array is empty', () => {
+      const { queryByTestId } = render(
+        <ProductResourcesSection resources={[]} loading={false} error={null} />,
+      );
+      expect(queryByTestId('resources-section')).toBeNull();
+    });
+
+    it('renders nothing while loading', () => {
+      const { queryByTestId } = render(
+        <ProductResourcesSection resources={[]} loading={true} error={null} />,
+      );
+      expect(queryByTestId('resources-section')).toBeNull();
+    });
+
+    it('renders nothing on error', () => {
+      const { queryByTestId } = render(
+        <ProductResourcesSection
+          resources={[]}
+          loading={false}
+          error={new Error('fetch failed')}
+        />,
+      );
+      expect(queryByTestId('resources-section')).toBeNull();
+    });
+  });
+
+  describe('section rendering', () => {
+    it('renders section when resources are present', () => {
+      const { getByTestId } = render(
+        <ProductResourcesSection resources={mockResources} loading={false} error={null} />,
+      );
+      expect(getByTestId('resources-section')).toBeTruthy();
+    });
+
+    it('renders "Resources" header text', () => {
+      const { getByText } = render(
+        <ProductResourcesSection resources={mockResources} loading={false} error={null} />,
+      );
+      expect(getByText('Resources')).toBeTruthy();
+    });
+
+    it('renders collapse toggle button', () => {
+      const { getByTestId } = render(
+        <ProductResourcesSection resources={mockResources} loading={false} error={null} />,
+      );
+      expect(getByTestId('resources-toggle')).toBeTruthy();
+    });
+  });
+
+  describe('collapsed / expanded behavior', () => {
+    it('starts expanded showing all resource items', () => {
+      const { getByTestId } = render(
+        <ProductResourcesSection resources={mockResources} loading={false} error={null} />,
+      );
+      expect(getByTestId('resources-list')).toBeTruthy();
+      expect(getByTestId('resource-item-0')).toBeTruthy();
+      expect(getByTestId('resource-item-1')).toBeTruthy();
+      expect(getByTestId('resource-item-2')).toBeTruthy();
+    });
+
+    it('hides resource list when toggle is pressed (collapse)', () => {
+      const { getByTestId, queryByTestId } = render(
+        <ProductResourcesSection resources={mockResources} loading={false} error={null} />,
+      );
+      fireEvent.press(getByTestId('resources-toggle'));
+      expect(queryByTestId('resources-list')).toBeNull();
+    });
+
+    it('shows resource list again when toggle pressed twice (expand)', () => {
+      const { getByTestId } = render(
+        <ProductResourcesSection resources={mockResources} loading={false} error={null} />,
+      );
+      fireEvent.press(getByTestId('resources-toggle'));
+      fireEvent.press(getByTestId('resources-toggle'));
+      expect(getByTestId('resources-list')).toBeTruthy();
+    });
+  });
+
+  describe('resource items', () => {
+    it('renders label for each resource', () => {
+      const { getByText } = render(
+        <ProductResourcesSection resources={mockResources} loading={false} error={null} />,
+      );
+      expect(getByText('Product Spec Sheet')).toBeTruthy();
+      expect(getByText('Care Guide')).toBeTruthy();
+      expect(getByText('Assembly Video')).toBeTruthy();
+    });
+
+    it('renders icon for each resource', () => {
+      const { getByTestId } = render(
+        <ProductResourcesSection resources={mockResources} loading={false} error={null} />,
+      );
+      expect(getByTestId('resource-icon-0')).toBeTruthy();
+      expect(getByTestId('resource-icon-1')).toBeTruthy();
+    });
+
+    it('tapping a resource calls Linking.openURL with its url', () => {
+      const { getByTestId } = render(
+        <ProductResourcesSection resources={mockResources} loading={false} error={null} />,
+      );
+      fireEvent.press(getByTestId('resource-item-0'));
+      expect(Linking.openURL).toHaveBeenCalledWith('https://example.com/spec.pdf');
+    });
+
+    it('tapping second resource opens its url', () => {
+      const { getByTestId } = render(
+        <ProductResourcesSection resources={mockResources} loading={false} error={null} />,
+      );
+      fireEvent.press(getByTestId('resource-item-1'));
+      expect(Linking.openURL).toHaveBeenCalledWith('https://example.com/care.pdf');
+    });
+
+    it('each resource item has correct accessibilityRole button', () => {
+      const { getByTestId } = render(
+        <ProductResourcesSection resources={mockResources} loading={false} error={null} />,
+      );
+      expect(getByTestId('resource-item-0').props.accessibilityRole).toBe('button');
+    });
+
+    it('each resource item has accessibilityLabel with its label', () => {
+      const { getByTestId } = render(
+        <ProductResourcesSection resources={mockResources} loading={false} error={null} />,
+      );
+      expect(getByTestId('resource-item-0').props.accessibilityLabel).toContain(
+        'Product Spec Sheet',
+      );
+    });
+  });
+
+  describe('single resource', () => {
+    it('renders correctly with one resource', () => {
+      const { getByTestId, getByText } = render(
+        <ProductResourcesSection resources={[mockResources[0]]} loading={false} error={null} />,
+      );
+      expect(getByTestId('resources-section')).toBeTruthy();
+      expect(getByText('Product Spec Sheet')).toBeTruthy();
+    });
+  });
+
+  describe('Linking error handling', () => {
+    it('does not throw when Linking.openURL rejects', async () => {
+      jest.spyOn(Linking, 'openURL').mockRejectedValueOnce(new Error('cannot open'));
+      const { getByTestId } = render(
+        <ProductResourcesSection resources={mockResources} loading={false} error={null} />,
+      );
+      expect(() => fireEvent.press(getByTestId('resource-item-0'))).not.toThrow();
+    });
+  });
+});

--- a/src/screens/ProductDetailScreen.tsx
+++ b/src/screens/ProductDetailScreen.tsx
@@ -92,6 +92,8 @@ import { FreightNoticeBanner } from '@/components/FreightNoticeBanner';
 import { useRecentlyViewedSlugs } from '@/hooks/useRecentlyViewedSlugs';
 import { RecentlyViewedRail } from '@/components/RecentlyViewedRail';
 import { PointsChip } from '@/components/PointsChip';
+import { useProductResources } from '@/hooks/useProductResources';
+import { ProductResourcesSection } from '@/components/ProductResourcesSection';
 
 const SCREEN_WIDTH = Dimensions.get('window').width;
 const GALLERY_HEIGHT = 400;
@@ -233,6 +235,11 @@ export function ProductDetailScreen({
 
   const { addViewed } = useRecentlyViewed();
   const { slugs: recentSlugs, addSlug } = useRecentlyViewedSlugs();
+  const {
+    resources,
+    loading: resourcesLoading,
+    error: resourcesError,
+  } = useProductResources(catalogProductId ?? model.id);
 
   // Track product view on mount
   useEffect(() => {
@@ -815,6 +822,13 @@ export function ProductDetailScreen({
             {isPremium && <PremiumBadge size="sm" testID="ar-premium-badge" />}
           </TouchableOpacity>
         </View>
+
+        {/* Resources — spec sheets, care guides, videos, assembly guides */}
+        <ProductResourcesSection
+          resources={resources}
+          loading={resourcesLoading}
+          error={resourcesError}
+        />
 
         {/* Fabric Selector */}
         <View style={[styles.section, { paddingHorizontal: spacing.lg }]}>


### PR DESCRIPTION
## Summary
- New `ProductResourcesSection` component: collapsible list of tappable resource items (spec sheets, care guides, videos, assembly guides)
- Wired into `ProductDetailScreen` below the AR CTA block, above Fabric Selector
- Consumes `useProductResources(catalogProductId ?? model.id)` (hook from PR #265)

## Behavior
- **Hidden** when `loading`, `error`, or `resources.length === 0`
- **Starts expanded** — toggle button collapses/expands the list
- Each item: icon + label + `›`, tappable via `Linking.openURL`
- Linking errors caught silently (no crash)
- Styled: `sandLight` background, `espresso` text, `sandDark` dividers

## testIDs
`resources-section`, `resources-toggle`, `resources-list`, `resource-item-{n}`, `resource-icon-{n}`

## Test plan
- [x] Hidden in all 3 empty states (loading / error / empty array)
- [x] Renders with 1 or 3 resources
- [x] Toggle collapses and re-expands
- [x] `Linking.openURL` called with correct URL per item
- [x] Accessibility: `role="button"` + `accessibilityLabel` on each item
- [x] Linking error handled without throw
- [x] 17 unit tests passing; 343 suites pass, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)