### PR TITLE
feat(hq-qrjk2): wire ChallengeCompletedToast at App root

### DIFF
--- a/src/contexts/TriggerMomentsContext.tsx
+++ b/src/contexts/TriggerMomentsContext.tsx
@@ -1,0 +1,81 @@
+/**
+ * @module TriggerMomentsContext
+ *
+ * React context + provider that hosts useTriggerMoments at the App root
+ * and renders ChallengeCompletedToast as a global floating overlay.
+ *
+ * Mount TriggerMomentsProvider inside AppNavigator so the toast floats
+ * above all navigation layers. Consumers call useTriggerMomentsContext()
+ * to read triggers, dismiss, and reportChallengesCompleted.
+ *
+ * hq-qrjk2
+ */
+import React, { createContext, useContext, useEffect } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { ChallengeCompletedToast } from '@/components/ChallengeCompletedToast';
+import {
+  useTriggerMoments,
+  type TriggerMoments,
+  type UseTriggerMomentsResult,
+} from '@/hooks/useTriggerMoments';
+
+/** Duration of the full toast animation sequence (fade-in + hold + fade-out). */
+const TOAST_ANIMATION_DURATION_MS = 1900;
+
+interface TriggerMomentsContextValue {
+  triggers: TriggerMoments;
+  dismiss: UseTriggerMomentsResult['dismiss'];
+  reportChallengesCompleted: UseTriggerMomentsResult['reportChallengesCompleted'];
+}
+
+const TriggerMomentsContext = createContext<TriggerMomentsContextValue | null>(null);
+
+/** Hosts useTriggerMoments once at the App root and renders the global ChallengeCompletedToast overlay. */
+export function TriggerMomentsProvider({ children }: { children: React.ReactNode }) {
+  const { triggers, dismiss, reportChallengesCompleted } = useTriggerMoments();
+
+  // Auto-dismiss after the toast animation completes so the next queue item can show.
+  // Keyed on challengeId so the timer re-arms for each new queue item rather than on
+  // every reference change of the challengeCompleted object.
+  useEffect(() => {
+    if (!triggers.challengeCompleted) return;
+    const timer = setTimeout(() => {
+      dismiss('challengeCompleted');
+    }, TOAST_ANIMATION_DURATION_MS);
+    return () => clearTimeout(timer);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [triggers.challengeCompleted?.challengeId, dismiss]);
+
+  return (
+    <TriggerMomentsContext.Provider value={{ triggers, dismiss, reportChallengesCompleted }}>
+      <View style={styles.container}>
+        {children}
+        <ChallengeCompletedToast
+          key={triggers.challengeCompleted?.challengeId ?? 'none'}
+          title={triggers.challengeCompleted?.title ?? ''}
+          rewardPoints={triggers.challengeCompleted?.rewardPoints ?? 0}
+          visible={triggers.challengeCompleted !== null}
+          testID="challenge-completed-toast"
+        />
+      </View>
+    </TriggerMomentsContext.Provider>
+  );
+}
+
+/**
+ * Returns triggers, dismiss, and reportChallengesCompleted from the nearest
+ * TriggerMomentsProvider. Throws if used outside one.
+ */
+export function useTriggerMomentsContext(): TriggerMomentsContextValue {
+  const ctx = useContext(TriggerMomentsContext);
+  if (!ctx) {
+    throw new Error('useTriggerMomentsContext must be used within a TriggerMomentsProvider');
+  }
+  return ctx;
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/src/contexts/__tests__/TriggerMomentsContext.test.tsx
+++ b/src/contexts/__tests__/TriggerMomentsContext.test.tsx
@@ -1,0 +1,243 @@
+/**
+ * TriggerMomentsContext tests — hq-qrjk2
+ *
+ * TDD spec for the global TriggerMomentsProvider that hosts useTriggerMoments
+ * at the App root and renders ChallengeCompletedToast as a floating overlay.
+ */
+import React from 'react';
+import { render, act, fireEvent } from '@testing-library/react-native';
+import { Text, TouchableOpacity } from 'react-native';
+import { TriggerMomentsProvider, useTriggerMomentsContext } from '../TriggerMomentsContext';
+import { ThemeProvider } from '@/theme/ThemeProvider';
+import type { ChallengeCompletedItem } from '@/hooks/useTriggerMoments';
+
+// Mock reanimated — animation mechanics not under test
+jest.mock('react-native-reanimated', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: {
+      View,
+      createAnimatedComponent: (c: React.ComponentType) => c,
+    },
+    useSharedValue: (init: number) => ({ value: init }),
+    useAnimatedStyle: (fn: () => object) => fn(),
+    withTiming: (val: number) => val,
+    withSequence: (...vals: number[]) => vals[vals.length - 1],
+    withDelay: (_delay: number, val: number) => val,
+    runOnJS: (fn: (...args: unknown[]) => void) => fn,
+  };
+});
+
+// Controllable mock for the underlying hook
+const mockDismiss = jest.fn();
+const mockReportChallengesCompleted = jest.fn();
+let mockTriggers = {
+  tierChanged: null as null,
+  streakDanger: false,
+  challengeCompleted: null as ChallengeCompletedItem | null,
+};
+
+jest.mock('@/hooks/useTriggerMoments', () => ({
+  useTriggerMoments: () => ({
+    triggers: mockTriggers,
+    dismiss: mockDismiss,
+    reportChallengesCompleted: mockReportChallengesCompleted,
+  }),
+}));
+
+jest.useFakeTimers();
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return (
+    <ThemeProvider>
+      <TriggerMomentsProvider>{children}</TriggerMomentsProvider>
+    </ThemeProvider>
+  );
+}
+
+/** Consumer that reads triggers from context */
+function TriggersDisplay() {
+  const { triggers } = useTriggerMomentsContext();
+  return <Text testID="triggers-display">{JSON.stringify(triggers)}</Text>;
+}
+
+/** Consumer that calls dismiss */
+function DismissButton() {
+  const { dismiss } = useTriggerMomentsContext();
+  return (
+    <TouchableOpacity onPress={() => dismiss('challengeCompleted')} testID="dismiss-btn">
+      <Text>Dismiss</Text>
+    </TouchableOpacity>
+  );
+}
+
+/** Consumer that calls reportChallengesCompleted */
+function ReportButton({ items }: { items: ChallengeCompletedItem[] }) {
+  const { reportChallengesCompleted } = useTriggerMomentsContext();
+  return (
+    <TouchableOpacity onPress={() => reportChallengesCompleted(items)} testID="report-btn">
+      <Text>Report</Text>
+    </TouchableOpacity>
+  );
+}
+
+describe('TriggerMomentsContext', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockTriggers = { tierChanged: null, streakDanger: false, challengeCompleted: null };
+  });
+
+  // ── Provider renders ──────────────────────────────────────────────────────
+
+  it('renders children without crashing', () => {
+    const { getByText } = render(
+      <Wrapper>
+        <Text>hello</Text>
+      </Wrapper>,
+    );
+    expect(getByText('hello')).toBeTruthy();
+  });
+
+  it('renders the challenge toast overlay (initially hidden) inside the provider', () => {
+    const { getByTestId } = render(
+      <Wrapper>
+        <Text>child</Text>
+      </Wrapper>,
+    );
+    expect(getByTestId('challenge-completed-toast', { includeHiddenElements: true })).toBeTruthy();
+  });
+
+  // ── Context values ─────────────────────────────────────────────────────────
+
+  it('exposes triggers from useTriggerMoments', () => {
+    const { getByTestId } = render(
+      <Wrapper>
+        <TriggersDisplay />
+      </Wrapper>,
+    );
+    const text = getByTestId('triggers-display').props.children;
+    expect(text).toContain('"streakDanger":false');
+    expect(text).toContain('"tierChanged":null');
+  });
+
+  it('exposes dismiss from useTriggerMoments', () => {
+    const { getByTestId } = render(
+      <Wrapper>
+        <DismissButton />
+      </Wrapper>,
+    );
+    fireEvent.press(getByTestId('dismiss-btn'));
+    expect(mockDismiss).toHaveBeenCalledWith('challengeCompleted');
+  });
+
+  it('exposes reportChallengesCompleted from useTriggerMoments', () => {
+    const items: ChallengeCompletedItem[] = [
+      { challengeId: 'c1', title: 'Spring Refresh', rewardPoints: 500 },
+    ];
+    const { getByTestId } = render(
+      <Wrapper>
+        <ReportButton items={items} />
+      </Wrapper>,
+    );
+    fireEvent.press(getByTestId('report-btn'));
+    expect(mockReportChallengesCompleted).toHaveBeenCalledWith(items);
+  });
+
+  // ── Toast visibility ───────────────────────────────────────────────────────
+
+  it('toast is hidden (accessibilityElementsHidden=true) when no challenge completed', () => {
+    const { getByTestId } = render(
+      <Wrapper>
+        <Text>child</Text>
+      </Wrapper>,
+    );
+    const toast = getByTestId('challenge-completed-toast', { includeHiddenElements: true });
+    expect(toast.props.accessibilityElementsHidden).toBe(true);
+  });
+
+  it('toast is visible when challengeCompleted is non-null', () => {
+    mockTriggers = {
+      tierChanged: null,
+      streakDanger: false,
+      challengeCompleted: { challengeId: 'c1', title: 'Spring Refresh', rewardPoints: 500 },
+    };
+    const { getByTestId } = render(
+      <Wrapper>
+        <Text>child</Text>
+      </Wrapper>,
+    );
+    const toast = getByTestId('challenge-completed-toast');
+    expect(toast.props.accessibilityElementsHidden).toBe(false);
+  });
+
+  it('toast displays the challenge title when visible', () => {
+    mockTriggers = {
+      tierChanged: null,
+      streakDanger: false,
+      challengeCompleted: { challengeId: 'c1', title: 'Trail Blazer', rewardPoints: 250 },
+    };
+    const { getByText } = render(
+      <Wrapper>
+        <Text>child</Text>
+      </Wrapper>,
+    );
+    expect(getByText(/Trail Blazer/)).toBeTruthy();
+  });
+
+  it('toast displays rewardPoints when visible', () => {
+    mockTriggers = {
+      tierChanged: null,
+      streakDanger: false,
+      challengeCompleted: { challengeId: 'c1', title: 'Explorer', rewardPoints: 1000 },
+    };
+    const { getByText } = render(
+      <Wrapper>
+        <Text>child</Text>
+      </Wrapper>,
+    );
+    expect(getByText(/\+1000/)).toBeTruthy();
+  });
+
+  // ── Auto-dismiss ───────────────────────────────────────────────────────────
+
+  it('calls dismiss after animation completes (1900ms)', () => {
+    mockTriggers = {
+      tierChanged: null,
+      streakDanger: false,
+      challengeCompleted: { challengeId: 'c1', title: 'Spring Refresh', rewardPoints: 500 },
+    };
+    render(
+      <Wrapper>
+        <Text>child</Text>
+      </Wrapper>,
+    );
+    expect(mockDismiss).not.toHaveBeenCalled();
+    act(() => {
+      jest.advanceTimersByTime(1900);
+    });
+    expect(mockDismiss).toHaveBeenCalledWith('challengeCompleted');
+  });
+
+  it('does not call dismiss when challengeCompleted is null', () => {
+    render(
+      <Wrapper>
+        <Text>child</Text>
+      </Wrapper>,
+    );
+    act(() => {
+      jest.advanceTimersByTime(2000);
+    });
+    expect(mockDismiss).not.toHaveBeenCalled();
+  });
+
+  // ── Error boundary ─────────────────────────────────────────────────────────
+
+  it('useTriggerMomentsContext throws when used outside provider', () => {
+    const Bad = () => {
+      useTriggerMomentsContext();
+      return null;
+    };
+    expect(() => render(<Bad />)).toThrow(/TriggerMomentsProvider/);
+  });
+});

--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -20,6 +20,7 @@ import type { ARWebScreenParams } from '@/screens/ARWebScreen';
 import type { OrderConfirmation } from '@/services/payment';
 import { useOnboarding } from '@/hooks/useOnboarding';
 import { BadgeToastProvider } from '@/contexts/BadgeToastContext';
+import { TriggerMomentsProvider } from '@/contexts/TriggerMomentsContext';
 
 const OnboardingScreenWithBoundary = withScreenErrorBoundary(OnboardingScreen, 'Onboarding');
 
@@ -246,226 +247,235 @@ export function AppNavigator() {
 
   return (
     <BadgeToastProvider>
-      <Suspense fallback={<LazyFallback />}>
-        <Stack.Navigator
-          screenOptions={{ headerShown: false }}
-          initialRouteName={hasSeenOnboarding ? 'Tabs' : 'Onboarding'}
-        >
-          <Stack.Screen name="Onboarding">
-            {({ navigation: nav }) => (
-              <OnboardingScreenWithBoundary
-                onComplete={() => {
-                  handleOnboardingComplete();
-                  nav.dispatch(CommonActions.reset({ index: 0, routes: [{ name: 'Tabs' }] }));
-                }}
-              />
-            )}
-          </Stack.Screen>
-          <Stack.Screen name="Tabs" component={TabNavigator} />
-          <Stack.Screen
-            name="AR"
-            component={ARScreen}
-            options={{ presentation: 'fullScreenModal', animation: 'fade' }}
-          />
-          <Stack.Screen
-            name="ProductDetail"
-            component={ProductDetailScreen}
-            options={fadeTransition}
-          />
-          <Stack.Screen name="Category" component={CategoryScreen} options={fadeTransition} />
-          <Stack.Screen name="Checkout">
-            {({ navigation: nav }) => (
-              <CheckoutScreen
-                onOrderComplete={(order) => {
-                  nav.dispatch(
-                    CommonActions.reset({
-                      index: 0,
-                      routes: [
-                        { name: 'Tabs' },
-                        { name: 'PaymentConfirmation', params: { order } },
-                      ],
-                    }),
-                  );
-                }}
-                onBack={() => nav.goBack()}
-              />
-            )}
-          </Stack.Screen>
-          <Stack.Screen name="PaymentConfirmation">
-            {({ route, navigation: nav }) => {
-              // Guard against malformed deep-links or push notification payloads
-              // that arrive without the required params — crash-safe fallback.
-              if (!route.params?.order) {
-                nav.goBack();
-                return null;
-              }
-              const { order } = route.params as { order: OrderConfirmation };
-              return (
-                <Suspense fallback={<LazyFallback />}>
-                  <PaymentConfirmationScreen
-                    order={order}
-                    onSuccess={() =>
-                      nav.replace('OrderSuccess', {
-                        orderId: order.orderId,
-                        orderNumber: order.orderNumber,
-                      })
-                    }
-                    onRetry={() => nav.goBack()}
-                  />
-                </Suspense>
-              );
-            }}
-          </Stack.Screen>
-          <Stack.Screen name="OrderSuccess">
-            {({ route, navigation: nav }) => {
-              // Guard against malformed deep-links or push notification payloads.
-              if (!route.params?.orderNumber) {
-                nav.goBack();
-                return null;
-              }
-              const { orderNumber } = route.params as {
-                orderNumber: string;
-              };
-              return (
-                <Suspense fallback={<LazyFallback />}>
-                  <OrderSuccessScreen
-                    orderNumber={orderNumber}
-                    onContinueShopping={() =>
-                      nav.dispatch(CommonActions.reset({ index: 0, routes: [{ name: 'Tabs' }] }))
-                    }
-                    onViewOrders={() =>
-                      nav.dispatch(
-                        CommonActions.reset({
-                          index: 1,
-                          routes: [{ name: 'Tabs' }, { name: 'OrderHistory' }],
-                        }),
-                      )
-                    }
-                  />
-                </Suspense>
-              );
-            }}
-          </Stack.Screen>
-          <Stack.Screen name="OrderConfirmation">
-            {({ route, navigation: nav }) => (
-              <OrderConfirmationScreen
-                order={(route.params as { order: OrderConfirmation }).order}
-                onContinueShopping={() => {
-                  nav.dispatch(CommonActions.reset({ index: 0, routes: [{ name: 'Tabs' }] }));
-                }}
-                onViewOrders={() => {
-                  nav.dispatch(
-                    CommonActions.reset({
-                      index: 1,
-                      routes: [{ name: 'Tabs' }, { name: 'OrderHistory' }],
-                    }),
-                  );
-                }}
-              />
-            )}
-          </Stack.Screen>
-          <Stack.Screen name="OrderHistory">
-            {({ navigation: nav }) => (
-              <OrderHistoryScreen
-                onSelectOrder={(orderId) => nav.navigate('OrderDetail', { orderId })}
-                onStartShopping={() => {
-                  nav.dispatch(CommonActions.reset({ index: 0, routes: [{ name: 'Tabs' }] }));
-                }}
-              />
-            )}
-          </Stack.Screen>
-          <Stack.Screen name="OrderDetail">
-            {({ route, navigation: nav }) => (
-              <OrderDetailScreen
-                orderId={(route.params as { orderId: string }).orderId}
-                onBack={() => nav.goBack()}
-                onReorderSuccess={() => {
-                  nav.dispatch(
-                    CommonActions.reset({
-                      index: 0,
-                      routes: [{ name: 'Tabs', state: { index: 2 } } as any],
-                    }),
-                  );
-                }}
-              />
-            )}
-          </Stack.Screen>
-          <Stack.Screen name="Login" component={LoginScreen} options={modalTransition} />
-          <Stack.Screen name="SignUp" component={SignUpScreen} options={modalTransition} />
-          <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} />
-          <Stack.Screen name="NotificationPreferences" component={NotificationPreferencesScreen} />
-          <Stack.Screen name="Wishlist" component={WishlistScreen} />
-          <Stack.Screen name="StoreLocator" component={StoreLocatorScreen} />
-          <Stack.Screen name="StoreDetail" component={StoreDetailScreen} />
-          <Stack.Screen
-            name="ARWeb"
-            component={ARWebScreen}
-            options={{ presentation: 'fullScreenModal', animation: 'fade' }}
-          />
-          <Stack.Screen name="Collections" component={CollectionsScreen} options={fadeTransition} />
-          <Stack.Screen
-            name="CollectionDetail"
-            component={CollectionDetailScreen}
-            options={fadeTransition}
-          />
-          <Stack.Screen name="Premium">
-            {({ navigation: nav }) => <PremiumScreen onBack={() => nav.goBack()} />}
-          </Stack.Screen>
-          <Stack.Screen name="StyleQuiz">
-            {({ navigation: nav }) => (
-              <StyleQuizScreen
-                onComplete={() => nav.goBack()}
-                onBack={() => nav.goBack()}
-                onProductPress={(slug) =>
-                  nav.navigate('ProductDetail', { productId: slug, source: 'quiz' })
-                }
-              />
-            )}
-          </Stack.Screen>
-          <Stack.Screen name="Search" component={SearchScreen} options={fadeTransition} />
-          <Stack.Screen name="Compare" options={fadeTransition}>
-            {({ navigation: nav, route }) => {
-              const { PRODUCTS } = require('@/data/products');
-              const products = (route.params?.productSlugs ?? [])
-                .map((slug: string) => PRODUCTS.find((p: { slug: string }) => p.slug === slug))
-                .filter(Boolean);
-              return (
-                <CompareScreen
-                  products={products}
-                  onRemove={(id: string) => {
-                    const remaining = products.filter((p: { id: string }) => p.id !== id);
-                    if (remaining.length === 0) {
-                      nav.goBack();
-                    } else {
-                      nav.setParams({
-                        productSlugs: remaining.map((p: { slug: string }) => p.slug),
-                      });
-                    }
+      <TriggerMomentsProvider>
+        <Suspense fallback={<LazyFallback />}>
+          <Stack.Navigator
+            screenOptions={{ headerShown: false }}
+            initialRouteName={hasSeenOnboarding ? 'Tabs' : 'Onboarding'}
+          >
+            <Stack.Screen name="Onboarding">
+              {({ navigation: nav }) => (
+                <OnboardingScreenWithBoundary
+                  onComplete={() => {
+                    handleOnboardingComplete();
+                    nav.dispatch(CommonActions.reset({ index: 0, routes: [{ name: 'Tabs' }] }));
                   }}
-                  onProductPress={(p: { slug: string }) =>
-                    nav.navigate('ProductDetail', { slug: p.slug })
-                  }
+                />
+              )}
+            </Stack.Screen>
+            <Stack.Screen name="Tabs" component={TabNavigator} />
+            <Stack.Screen
+              name="AR"
+              component={ARScreen}
+              options={{ presentation: 'fullScreenModal', animation: 'fade' }}
+            />
+            <Stack.Screen
+              name="ProductDetail"
+              component={ProductDetailScreen}
+              options={fadeTransition}
+            />
+            <Stack.Screen name="Category" component={CategoryScreen} options={fadeTransition} />
+            <Stack.Screen name="Checkout">
+              {({ navigation: nav }) => (
+                <CheckoutScreen
+                  onOrderComplete={(order) => {
+                    nav.dispatch(
+                      CommonActions.reset({
+                        index: 0,
+                        routes: [
+                          { name: 'Tabs' },
+                          { name: 'PaymentConfirmation', params: { order } },
+                        ],
+                      }),
+                    );
+                  }}
                   onBack={() => nav.goBack()}
                 />
-              );
-            }}
-          </Stack.Screen>
-          <Stack.Screen name="PrivacyPolicy">
-            {({ navigation: nav }) => <PrivacyPolicyScreen onBack={() => nav.goBack()} />}
-          </Stack.Screen>
-          <Stack.Screen name="RoomGallery" options={fadeTransition}>
-            {({ navigation: nav }) => (
-              <RoomGalleryScreen
-                onProductPress={(productId) => nav.navigate('ProductDetail', { slug: productId })}
-              />
-            )}
-          </Stack.Screen>
-          <Stack.Screen name="Loyalty" options={modalTransition}>
-            {({ navigation: nav }) => <LoyaltyScreen onClose={() => nav.goBack()} />}
-          </Stack.Screen>
-          <Stack.Screen name="ReferralLanding" component={ReferralLandingScreen} />
-        </Stack.Navigator>
-      </Suspense>
+              )}
+            </Stack.Screen>
+            <Stack.Screen name="PaymentConfirmation">
+              {({ route, navigation: nav }) => {
+                // Guard against malformed deep-links or push notification payloads
+                // that arrive without the required params — crash-safe fallback.
+                if (!route.params?.order) {
+                  nav.goBack();
+                  return null;
+                }
+                const { order } = route.params as { order: OrderConfirmation };
+                return (
+                  <Suspense fallback={<LazyFallback />}>
+                    <PaymentConfirmationScreen
+                      order={order}
+                      onSuccess={() =>
+                        nav.replace('OrderSuccess', {
+                          orderId: order.orderId,
+                          orderNumber: order.orderNumber,
+                        })
+                      }
+                      onRetry={() => nav.goBack()}
+                    />
+                  </Suspense>
+                );
+              }}
+            </Stack.Screen>
+            <Stack.Screen name="OrderSuccess">
+              {({ route, navigation: nav }) => {
+                // Guard against malformed deep-links or push notification payloads.
+                if (!route.params?.orderNumber) {
+                  nav.goBack();
+                  return null;
+                }
+                const { orderNumber } = route.params as {
+                  orderNumber: string;
+                };
+                return (
+                  <Suspense fallback={<LazyFallback />}>
+                    <OrderSuccessScreen
+                      orderNumber={orderNumber}
+                      onContinueShopping={() =>
+                        nav.dispatch(CommonActions.reset({ index: 0, routes: [{ name: 'Tabs' }] }))
+                      }
+                      onViewOrders={() =>
+                        nav.dispatch(
+                          CommonActions.reset({
+                            index: 1,
+                            routes: [{ name: 'Tabs' }, { name: 'OrderHistory' }],
+                          }),
+                        )
+                      }
+                    />
+                  </Suspense>
+                );
+              }}
+            </Stack.Screen>
+            <Stack.Screen name="OrderConfirmation">
+              {({ route, navigation: nav }) => (
+                <OrderConfirmationScreen
+                  order={(route.params as { order: OrderConfirmation }).order}
+                  onContinueShopping={() => {
+                    nav.dispatch(CommonActions.reset({ index: 0, routes: [{ name: 'Tabs' }] }));
+                  }}
+                  onViewOrders={() => {
+                    nav.dispatch(
+                      CommonActions.reset({
+                        index: 1,
+                        routes: [{ name: 'Tabs' }, { name: 'OrderHistory' }],
+                      }),
+                    );
+                  }}
+                />
+              )}
+            </Stack.Screen>
+            <Stack.Screen name="OrderHistory">
+              {({ navigation: nav }) => (
+                <OrderHistoryScreen
+                  onSelectOrder={(orderId) => nav.navigate('OrderDetail', { orderId })}
+                  onStartShopping={() => {
+                    nav.dispatch(CommonActions.reset({ index: 0, routes: [{ name: 'Tabs' }] }));
+                  }}
+                />
+              )}
+            </Stack.Screen>
+            <Stack.Screen name="OrderDetail">
+              {({ route, navigation: nav }) => (
+                <OrderDetailScreen
+                  orderId={(route.params as { orderId: string }).orderId}
+                  onBack={() => nav.goBack()}
+                  onReorderSuccess={() => {
+                    nav.dispatch(
+                      CommonActions.reset({
+                        index: 0,
+                        routes: [{ name: 'Tabs', state: { index: 2 } } as any],
+                      }),
+                    );
+                  }}
+                />
+              )}
+            </Stack.Screen>
+            <Stack.Screen name="Login" component={LoginScreen} options={modalTransition} />
+            <Stack.Screen name="SignUp" component={SignUpScreen} options={modalTransition} />
+            <Stack.Screen name="ForgotPassword" component={ForgotPasswordScreen} />
+            <Stack.Screen
+              name="NotificationPreferences"
+              component={NotificationPreferencesScreen}
+            />
+            <Stack.Screen name="Wishlist" component={WishlistScreen} />
+            <Stack.Screen name="StoreLocator" component={StoreLocatorScreen} />
+            <Stack.Screen name="StoreDetail" component={StoreDetailScreen} />
+            <Stack.Screen
+              name="ARWeb"
+              component={ARWebScreen}
+              options={{ presentation: 'fullScreenModal', animation: 'fade' }}
+            />
+            <Stack.Screen
+              name="Collections"
+              component={CollectionsScreen}
+              options={fadeTransition}
+            />
+            <Stack.Screen
+              name="CollectionDetail"
+              component={CollectionDetailScreen}
+              options={fadeTransition}
+            />
+            <Stack.Screen name="Premium">
+              {({ navigation: nav }) => <PremiumScreen onBack={() => nav.goBack()} />}
+            </Stack.Screen>
+            <Stack.Screen name="StyleQuiz">
+              {({ navigation: nav }) => (
+                <StyleQuizScreen
+                  onComplete={() => nav.goBack()}
+                  onBack={() => nav.goBack()}
+                  onProductPress={(slug) =>
+                    nav.navigate('ProductDetail', { productId: slug, source: 'quiz' })
+                  }
+                />
+              )}
+            </Stack.Screen>
+            <Stack.Screen name="Search" component={SearchScreen} options={fadeTransition} />
+            <Stack.Screen name="Compare" options={fadeTransition}>
+              {({ navigation: nav, route }) => {
+                const { PRODUCTS } = require('@/data/products');
+                const products = (route.params?.productSlugs ?? [])
+                  .map((slug: string) => PRODUCTS.find((p: { slug: string }) => p.slug === slug))
+                  .filter(Boolean);
+                return (
+                  <CompareScreen
+                    products={products}
+                    onRemove={(id: string) => {
+                      const remaining = products.filter((p: { id: string }) => p.id !== id);
+                      if (remaining.length === 0) {
+                        nav.goBack();
+                      } else {
+                        nav.setParams({
+                          productSlugs: remaining.map((p: { slug: string }) => p.slug),
+                        });
+                      }
+                    }}
+                    onProductPress={(p: { slug: string }) =>
+                      nav.navigate('ProductDetail', { slug: p.slug })
+                    }
+                    onBack={() => nav.goBack()}
+                  />
+                );
+              }}
+            </Stack.Screen>
+            <Stack.Screen name="PrivacyPolicy">
+              {({ navigation: nav }) => <PrivacyPolicyScreen onBack={() => nav.goBack()} />}
+            </Stack.Screen>
+            <Stack.Screen name="RoomGallery" options={fadeTransition}>
+              {({ navigation: nav }) => (
+                <RoomGalleryScreen
+                  onProductPress={(productId) => nav.navigate('ProductDetail', { slug: productId })}
+                />
+              )}
+            </Stack.Screen>
+            <Stack.Screen name="Loyalty" options={modalTransition}>
+              {({ navigation: nav }) => <LoyaltyScreen onClose={() => nav.goBack()} />}
+            </Stack.Screen>
+            <Stack.Screen name="ReferralLanding" component={ReferralLandingScreen} />
+          </Stack.Navigator>
+        </Suspense>
+      </TriggerMomentsProvider>
     </BadgeToastProvider>
   );
 }

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -34,9 +34,8 @@ import { RecommendationCarousel } from '@/components/RecommendationCarousel';
 import { ChallengesRail } from '@/components/ChallengesRail';
 import { useActiveChallenges } from '@/hooks/useActiveChallenges';
 import { StreakDangerBanner } from '@/components/StreakDangerBanner';
-import { ChallengeCompletedToast } from '@/components/ChallengeCompletedToast';
 import { TierUpgradeToast } from '@/components/TierUpgradeToast';
-import { useTriggerMoments } from '@/hooks/useTriggerMoments';
+import { useTriggerMomentsContext } from '@/contexts/TriggerMomentsContext';
 import { ProductCard } from '@/components/ProductCard';
 import type { EditorialCollection } from '@/data/collections';
 import type { Product } from '@/data/products';
@@ -75,7 +74,7 @@ export function HomeScreen({ onOpenAR, onOpenShop, onCollectionPress }: Props) {
     quizTaken,
   } = useQuizRecommendations();
   const { challenges } = useActiveChallenges();
-  const { triggers, dismiss } = useTriggerMoments();
+  const { triggers, dismiss } = useTriggerMomentsContext();
   const skyState = useLivingSky();
 
   const handleOpenAR = useCallback(() => {
@@ -451,16 +450,7 @@ export function HomeScreen({ onOpenAR, onOpenShop, onCollectionPress }: Props) {
         </View>
       </ScrollView>
 
-      {/* Gamification toasts — cfutons_mobile-0lt */}
-      {triggers.challengeCompleted && (
-        <ChallengeCompletedToast
-          title={triggers.challengeCompleted.title}
-          rewardPoints={triggers.challengeCompleted.rewardPoints}
-          visible={true}
-          testID="home-challenge-toast"
-          onDismiss={() => dismiss('challengeCompleted')}
-        />
-      )}
+      {/* ChallengeCompletedToast is rendered globally by TriggerMomentsContext — hq-qrjk2 */}
       {triggers.tierChanged && (
         <TierUpgradeToast
           tier={triggers.tierChanged}

--- a/src/screens/__tests__/HomeScreen.test.tsx
+++ b/src/screens/__tests__/HomeScreen.test.tsx
@@ -45,9 +45,9 @@ jest.mock('@/hooks/useActiveChallenges', () => ({
   useActiveChallenges: () => ({ challenges: [], loading: false, error: null, refresh: jest.fn() }),
 }));
 
-const mockUseTriggerMoments = jest.fn();
-jest.mock('@/hooks/useTriggerMoments', () => ({
-  useTriggerMoments: () => mockUseTriggerMoments(),
+const mockUseTriggerMomentsContext = jest.fn();
+jest.mock('@/contexts/TriggerMomentsContext', () => ({
+  useTriggerMomentsContext: () => mockUseTriggerMomentsContext(),
 }));
 
 jest.mock('@react-native-async-storage/async-storage', () => ({
@@ -75,9 +75,10 @@ describe('HomeScreen', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     // Default: no active triggers
-    mockUseTriggerMoments.mockReturnValue({
-      triggers: { tierChanged: null, streakDanger: false },
+    mockUseTriggerMomentsContext.mockReturnValue({
+      triggers: { tierChanged: null, streakDanger: false, challengeCompleted: null },
       dismiss: jest.fn(),
+      reportChallengesCompleted: jest.fn(),
     });
     // Default: collections load with realistic featured data matching static COLLECTIONS
     mockUseCollections.mockReturnValue({
@@ -264,18 +265,20 @@ describe('HomeScreen', () => {
   // Streak danger banner (cm-a7bqj)
   describe('StreakDangerBanner integration', () => {
     it('does not show streak danger banner when streakDanger is false', () => {
-      mockUseTriggerMoments.mockReturnValue({
-        triggers: { tierChanged: null, streakDanger: false },
+      mockUseTriggerMomentsContext.mockReturnValue({
+        triggers: { tierChanged: null, streakDanger: false, challengeCompleted: null },
         dismiss: jest.fn(),
+        reportChallengesCompleted: jest.fn(),
       });
       const { queryByTestId } = renderHomeScreen();
       expect(queryByTestId('streak-danger-banner')).toBeNull();
     });
 
     it('shows streak danger banner when streakDanger is true', () => {
-      mockUseTriggerMoments.mockReturnValue({
-        triggers: { tierChanged: null, streakDanger: true },
+      mockUseTriggerMomentsContext.mockReturnValue({
+        triggers: { tierChanged: null, streakDanger: true, challengeCompleted: null },
         dismiss: jest.fn(),
+        reportChallengesCompleted: jest.fn(),
       });
       const { getByTestId } = renderHomeScreen();
       expect(getByTestId('streak-danger-banner')).toBeTruthy();
@@ -283,9 +286,10 @@ describe('HomeScreen', () => {
 
     it('pressing dismiss calls dismiss("streakDanger")', () => {
       const mockDismiss = jest.fn();
-      mockUseTriggerMoments.mockReturnValue({
-        triggers: { tierChanged: null, streakDanger: true },
+      mockUseTriggerMomentsContext.mockReturnValue({
+        triggers: { tierChanged: null, streakDanger: true, challengeCompleted: null },
         dismiss: mockDismiss,
+        reportChallengesCompleted: jest.fn(),
       });
       const { getByTestId } = renderHomeScreen();
       fireEvent.press(getByTestId('streak-danger-dismiss'));
@@ -355,52 +359,12 @@ describe('HomeScreen', () => {
     });
   });
 
-  // cfutons_mobile-0lt — gamification trigger toasts
-  describe('ChallengeCompletedToast integration', () => {
-    it('does not show challenge toast when challengeCompleted is null', () => {
-      mockUseTriggerMoments.mockReturnValue({
-        triggers: { tierChanged: null, streakDanger: false, challengeCompleted: null },
-        dismiss: jest.fn(),
-        reportChallengesCompleted: jest.fn(),
-      });
-      const { queryByTestId } = renderHomeScreen();
-      expect(queryByTestId('home-challenge-toast')).toBeNull();
-    });
-
-    it('shows challenge toast when challengeCompleted is set', () => {
-      mockUseTriggerMoments.mockReturnValue({
-        triggers: {
-          tierChanged: null,
-          streakDanger: false,
-          challengeCompleted: { challengeId: 'c1', title: 'Spring Refresh', rewardPoints: 200 },
-        },
-        dismiss: jest.fn(),
-        reportChallengesCompleted: jest.fn(),
-      });
-      const { getByTestId } = renderHomeScreen();
-      expect(getByTestId('home-challenge-toast')).toBeTruthy();
-    });
-
-    it('dismisses challenge toast on animation end by calling dismiss("challengeCompleted")', () => {
-      const mockDismiss = jest.fn();
-      mockUseTriggerMoments.mockReturnValue({
-        triggers: {
-          tierChanged: null,
-          streakDanger: false,
-          challengeCompleted: { challengeId: 'c1', title: 'Spring Refresh', rewardPoints: 200 },
-        },
-        dismiss: mockDismiss,
-        reportChallengesCompleted: jest.fn(),
-      });
-      const { getByTestId } = renderHomeScreen();
-      fireEvent(getByTestId('home-challenge-toast'), 'onDismiss');
-      expect(mockDismiss).toHaveBeenCalledWith('challengeCompleted');
-    });
-  });
+  // cfutons_mobile-0lt — ChallengeCompletedToast is rendered globally by TriggerMomentsContext
+  // (hq-qrjk2). Tests for its visibility live in TriggerMomentsContext.test.tsx.
 
   describe('TierUpgradeToast integration', () => {
     it('does not show tier upgrade toast when tierChanged is null', () => {
-      mockUseTriggerMoments.mockReturnValue({
+      mockUseTriggerMomentsContext.mockReturnValue({
         triggers: { tierChanged: null, streakDanger: false, challengeCompleted: null },
         dismiss: jest.fn(),
         reportChallengesCompleted: jest.fn(),
@@ -410,7 +374,7 @@ describe('HomeScreen', () => {
     });
 
     it('shows tier upgrade toast when tierChanged is set', () => {
-      mockUseTriggerMoments.mockReturnValue({
+      mockUseTriggerMomentsContext.mockReturnValue({
         triggers: { tierChanged: 'silver', streakDanger: false, challengeCompleted: null },
         dismiss: jest.fn(),
         reportChallengesCompleted: jest.fn(),
@@ -421,7 +385,7 @@ describe('HomeScreen', () => {
 
     it('dismisses tier toast on animation end by calling dismiss("tierChanged")', () => {
       const mockDismiss = jest.fn();
-      mockUseTriggerMoments.mockReturnValue({
+      mockUseTriggerMomentsContext.mockReturnValue({
         triggers: { tierChanged: 'gold', streakDanger: false, challengeCompleted: null },
         dismiss: mockDismiss,
         reportChallengesCompleted: jest.fn(),


### PR DESCRIPTION
## Summary

- Creates `TriggerMomentsContext` — a React context + provider that calls `useTriggerMoments` once at the App root and renders `ChallengeCompletedToast` as a global floating overlay
- Mounts `TriggerMomentsProvider` inside `AppNavigator` (inside `BadgeToastProvider`), so the toast floats above all navigation layers
- Auto-dismisses after the 1900ms animation sequence (`300ms fade-in + 1200ms hold + 400ms fade-out`), re-arming per `challengeId` so queued challenges show one at a time
- `HomeScreen` updated to call `useTriggerMomentsContext()` instead of the raw hook — eliminates a second hook instance that would have had independent state

## Files

- `src/contexts/TriggerMomentsContext.tsx` — new provider + `useTriggerMomentsContext` hook
- `src/contexts/__tests__/TriggerMomentsContext.test.tsx` — 12 specs (TDD: written first)
- `src/navigation/AppNavigator.tsx` — mounts `TriggerMomentsProvider`
- `src/screens/HomeScreen.tsx` — calls `useTriggerMomentsContext()` instead of `useTriggerMoments()`
- `src/screens/__tests__/HomeScreen.test.tsx` — mocks context instead of hook

## Test plan

- [x] `TriggerMomentsContext.test.tsx` — 12 specs pass (renders, context values, toast visibility, auto-dismiss timer, error boundary)
- [x] `HomeScreen.test.tsx` — 24 specs pass (unchanged behavior, updated mock)
- [x] `useTriggerMoments.test.ts` — 43 specs pass (unchanged)
- [x] `ChallengeCompletedToast.test.tsx` — 14 specs pass (unchanged)
- [x] `eslint --fix` clean on all changed files

Closes hq-qrjk2

🤖 Generated with [Claude Code](https://claude.com/claude-code)