### PR TITLE
fix(hq-w7m3n): OrderConfirmation status bar — dark espresso

### DIFF
--- a/src/screens/OrderConfirmationScreen.tsx
+++ b/src/screens/OrderConfirmationScreen.tsx
@@ -7,7 +7,15 @@
  * shopping or view order history.
  */
 import React, { useCallback, useEffect, useState } from 'react';
-import { Share, StyleSheet, Text, View, ScrollView, TouchableOpacity } from 'react-native';
+import {
+  Share,
+  StatusBar,
+  StyleSheet,
+  Text,
+  View,
+  ScrollView,
+  TouchableOpacity,
+} from 'react-native';
 import { PointsToast } from '@/components/PointsToast';
 import { useTheme } from '@/theme';
 import { formatPrice } from '@/utils';
@@ -65,6 +73,7 @@ export function OrderConfirmationScreen({
       style={[styles.root, { backgroundColor: colors.sandBase }]}
       testID={testID ?? 'order-confirmation-screen'}
     >
+      <StatusBar barStyle="dark-content" />
       {pointsEarned != null && (
         <PointsToast points={pointsEarned} visible={toastVisible} testID="order-points-toast" />
       )}

--- a/src/screens/__tests__/OrderConfirmationScreen.test.tsx
+++ b/src/screens/__tests__/OrderConfirmationScreen.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { render, fireEvent, waitFor } from '@testing-library/react-native';
+import { StatusBar } from 'react-native';
 import { OrderConfirmationScreen } from '../OrderConfirmationScreen';
 import { ThemeProvider } from '@/theme/ThemeProvider';
 import type { OrderConfirmation } from '@/services/payment';
@@ -74,6 +75,12 @@ describe('OrderConfirmationScreen', () => {
     it('displays "Order Confirmed!" heading', () => {
       const { getByText } = renderConfirmation();
       expect(getByText('Order Confirmed!')).toBeTruthy();
+    });
+
+    it('renders StatusBar with dark-content barStyle (hq-w7m3n)', () => {
+      const { UNSAFE_getByType } = renderConfirmation();
+      const statusBar = UNSAFE_getByType(StatusBar);
+      expect(statusBar.props.barStyle).toBe('dark-content');
     });
   });
 


### PR DESCRIPTION
## Summary
- Fix OrderConfirmation screen status bar showing bright blue instead of dark espresso
- Matches all other screens' dark theme treatment

## Test plan
- [x] 25 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)