### PR TITLE
feat(hq-94ado): gamification offline queue with eventId idempotency

### DIFF
--- a/src/hooks/__tests__/useGamificationOfflineSync.test.tsx
+++ b/src/hooks/__tests__/useGamificationOfflineSync.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * useGamificationOfflineSync TDD tests — hq-94ado
+ *
+ * Tests written BEFORE implementation per CLAUDE.md mandate.
+ * Hook: auto-flush on reconnect + emitOrQueue for call sites.
+ */
+
+import React from 'react';
+import { Text, TouchableOpacity, View } from 'react-native';
+import { render, fireEvent, act, waitFor } from '@testing-library/react-native';
+import { ConnectivityProvider, useConnectivity } from '../useConnectivity';
+import { useGamificationOfflineSync } from '../useGamificationOfflineSync';
+import { _resetForTesting, getQueue } from '@/services/offlineQueue';
+import { trackEvent } from '@/services/analytics';
+
+// ── Mock analytics ────────────────────────────────────────────────────────────
+jest.mock('@/services/analytics', () => ({
+  trackEvent: jest.fn(),
+  getEventBuffer: jest.fn(() => []),
+  clearEventBuffer: jest.fn(),
+}));
+
+// ── Mock wixClientSingleton ───────────────────────────────────────────────────
+const mockCallFunction = jest.fn().mockResolvedValue({ ok: true });
+jest.mock('@/services/wix/wixClientSingleton', () => ({
+  getWixClientSingleton: () => ({
+    callFunction: mockCallFunction,
+  }),
+}));
+
+// ── Test harness ──────────────────────────────────────────────────────────────
+function Harness() {
+  const { emitOrQueue, pendingCount, isSyncing } = useGamificationOfflineSync();
+  const { isOnline, setOnline } = useConnectivity();
+
+  return (
+    <View>
+      <Text testID="pending">{pendingCount}</Text>
+      <Text testID="syncing">{String(isSyncing)}</Text>
+      <Text testID="online">{String(isOnline)}</Text>
+      <TouchableOpacity
+        testID="emit-add-to-cart"
+        onPress={() => emitOrQueue('gamification_add_to_cart', { product_id: 'p1', price: 99 })}
+      />
+      <TouchableOpacity
+        testID="emit-ar-used"
+        onPress={() => emitOrQueue('gamification_ar_used', { product_id: 'p2' })}
+      />
+      <TouchableOpacity testID="go-offline" onPress={() => setOnline(false)} />
+      <TouchableOpacity testID="go-online" onPress={() => setOnline(true)} />
+    </View>
+  );
+}
+
+function renderHarness(initialOnline = true) {
+  return render(
+    <ConnectivityProvider initialOnline={initialOnline} skipNetInfo>
+      <Harness />
+    </ConnectivityProvider>,
+  );
+}
+
+// ── Setup ─────────────────────────────────────────────────────────────────────
+beforeEach(() => {
+  _resetForTesting();
+  jest.clearAllMocks();
+});
+
+// ── emitOrQueue ───────────────────────────────────────────────────────────────
+describe('emitOrQueue', () => {
+  it('calls trackEvent when online', async () => {
+    const { getByTestId } = renderHarness(true);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('emit-add-to-cart'));
+    });
+
+    expect(trackEvent).toHaveBeenCalledWith(
+      'gamification_add_to_cart',
+      expect.objectContaining({ product_id: 'p1', price: 99 }),
+    );
+  });
+
+  it('does not queue event when online', async () => {
+    const { getByTestId } = renderHarness(true);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('emit-add-to-cart'));
+    });
+
+    expect(getQueue('gamification')).toHaveLength(0);
+  });
+
+  it('queues event when offline instead of calling trackEvent', async () => {
+    const { getByTestId } = renderHarness(false);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('emit-add-to-cart'));
+    });
+
+    expect(trackEvent).not.toHaveBeenCalled();
+    expect(getQueue('gamification')).toHaveLength(1);
+    expect(getQueue('gamification')[0].action).toBe('gamification_add_to_cart');
+  });
+
+  it('pendingCount reflects number of queued events', async () => {
+    const { getByTestId } = renderHarness(false);
+
+    expect(getByTestId('pending').props.children).toBe(0);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('emit-add-to-cart'));
+    });
+    expect(getByTestId('pending').props.children).toBe(1);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('emit-ar-used'));
+    });
+    expect(getByTestId('pending').props.children).toBe(2);
+  });
+});
+
+// ── auto-flush on reconnect ───────────────────────────────────────────────────
+describe('auto-flush on reconnect', () => {
+  it('flushes queued events when transitioning from offline to online', async () => {
+    const { getByTestId } = renderHarness(false);
+
+    // Queue two events while offline
+    await act(async () => {
+      fireEvent.press(getByTestId('emit-add-to-cart'));
+      fireEvent.press(getByTestId('emit-ar-used'));
+    });
+
+    expect(getQueue('gamification')).toHaveLength(2);
+
+    // Come back online
+    await act(async () => {
+      fireEvent.press(getByTestId('go-online'));
+    });
+
+    await waitFor(() => {
+      expect(mockCallFunction).toHaveBeenCalledTimes(2);
+    });
+
+    expect(getQueue('gamification')).toHaveLength(0);
+    expect(getByTestId('pending').props.children).toBe(0);
+  });
+
+  it('does not flush when already online and going online again', async () => {
+    const { getByTestId } = renderHarness(true);
+
+    // Nothing queued; re-trigger "go online" — should not call endpoint
+    await act(async () => {
+      fireEvent.press(getByTestId('go-online'));
+    });
+
+    expect(mockCallFunction).not.toHaveBeenCalled();
+  });
+
+  it('sets isSyncing=true during flush and false when done', async () => {
+    let resolveFn!: () => void;
+    mockCallFunction.mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          resolveFn = resolve;
+        }),
+    );
+
+    const { getByTestId } = renderHarness(false);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('emit-add-to-cart'));
+    });
+
+    // Go online — flush starts
+    act(() => {
+      fireEvent.press(getByTestId('go-online'));
+    });
+
+    // Give the hook a tick to start syncing
+    await act(async () => {});
+    expect(getByTestId('syncing').props.children).toBe('true');
+
+    // Resolve the pending call
+    await act(async () => {
+      resolveFn();
+    });
+
+    await waitFor(() => {
+      expect(getByTestId('syncing').props.children).toBe('false');
+    });
+  });
+
+  it('clears queue even if some events fail during flush', async () => {
+    mockCallFunction
+      .mockResolvedValueOnce({ ok: true })
+      .mockRejectedValueOnce(new Error('server error'));
+
+    const { getByTestId } = renderHarness(false);
+
+    await act(async () => {
+      fireEvent.press(getByTestId('emit-add-to-cart'));
+      fireEvent.press(getByTestId('emit-ar-used'));
+    });
+
+    await act(async () => {
+      fireEvent.press(getByTestId('go-online'));
+    });
+
+    await waitFor(() => {
+      expect(mockCallFunction).toHaveBeenCalledTimes(2);
+    });
+
+    // Failed event stays in queue
+    expect(getQueue('gamification')).toHaveLength(1);
+  });
+});

--- a/src/hooks/useGamificationOfflineSync.tsx
+++ b/src/hooks/useGamificationOfflineSync.tsx
@@ -1,0 +1,80 @@
+/**
+ * @module useGamificationOfflineSync
+ *
+ * Connectivity-aware gamification event emitter — hq-94ado.
+ *
+ * - When online: fires events immediately via `trackEvent`.
+ * - When offline: queues events to AsyncStorage via `queueGamificationEvent`.
+ * - On reconnect: automatically flushes the queue to /_functions/gamificationEvent.
+ *
+ * Usage:
+ *   const { emitOrQueue, pendingCount, isSyncing } = useGamificationOfflineSync();
+ *   emitOrQueue('gamification_add_to_cart', { product_id, price });
+ *
+ * Must be rendered within a ConnectivityProvider.
+ */
+
+import { useEffect, useRef, useState, useCallback } from 'react';
+import { useOptionalConnectivity } from './useConnectivity';
+import { trackEvent } from '@/services/analytics';
+import {
+  queueGamificationEvent,
+  flushGamificationQueue,
+  getGamificationQueueLength,
+} from '@/services/gamificationOfflineQueue';
+import { getWixClientSingleton } from '@/services/wix/wixClientSingleton';
+
+export interface GamificationOfflineSyncResult {
+  /** Emit a gamification event — fires immediately when online, queues when offline. */
+  emitOrQueue(name: string, properties: Record<string, unknown>): void;
+  /** Number of gamification events currently waiting in the queue. */
+  pendingCount: number;
+  /** True while a queue flush is in progress. */
+  isSyncing: boolean;
+}
+
+export function useGamificationOfflineSync(): GamificationOfflineSyncResult {
+  const connectivity = useOptionalConnectivity();
+  const isOnline = connectivity?.isOnline ?? true;
+
+  const [pendingCount, setPendingCount] = useState(getGamificationQueueLength);
+  const [isSyncing, setIsSyncing] = useState(false);
+  const prevOnlineRef = useRef(isOnline);
+
+  // Flush queued events on transition from offline → online
+  useEffect(() => {
+    const wasOnline = prevOnlineRef.current;
+    prevOnlineRef.current = isOnline;
+
+    if (!wasOnline && isOnline) {
+      const client = getWixClientSingleton();
+      if (!client || getGamificationQueueLength() === 0) return;
+
+      setIsSyncing(true);
+      flushGamificationQueue(client)
+        .then(() => {
+          setPendingCount(getGamificationQueueLength());
+        })
+        .catch(() => {
+          setPendingCount(getGamificationQueueLength());
+        })
+        .finally(() => {
+          setIsSyncing(false);
+        });
+    }
+  }, [isOnline]);
+
+  const emitOrQueue = useCallback(
+    (name: string, properties: Record<string, unknown>) => {
+      if (isOnline) {
+        trackEvent(name as Parameters<typeof trackEvent>[0], properties);
+      } else {
+        queueGamificationEvent(name, properties);
+        setPendingCount(getGamificationQueueLength());
+      }
+    },
+    [isOnline],
+  );
+
+  return { emitOrQueue, pendingCount, isSyncing };
+}

--- a/src/services/__tests__/gamificationOfflineQueue.test.ts
+++ b/src/services/__tests__/gamificationOfflineQueue.test.ts
@@ -1,0 +1,197 @@
+/**
+ * gamificationOfflineQueue TDD tests — hq-94ado
+ *
+ * Tests written BEFORE implementation per CLAUDE.md mandate.
+ * Offline queue for gamification events: AsyncStorage persistence,
+ * unique eventId per event, replay to /_functions/gamificationEvent on reconnect.
+ */
+
+import {
+  queueGamificationEvent,
+  flushGamificationQueue,
+  getGamificationQueueLength,
+} from '../gamificationOfflineQueue';
+import { _resetForTesting, getQueue } from '@/services/offlineQueue';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function mockWixClient(callFunctionImpl?: jest.Mock) {
+  return {
+    callFunction: callFunctionImpl ?? jest.fn().mockResolvedValue({ ok: true }),
+  };
+}
+
+beforeEach(() => {
+  _resetForTesting();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+// ── queueGamificationEvent ────────────────────────────────────────────────────
+
+describe('queueGamificationEvent', () => {
+  it('stores event in the offline queue with domain=gamification', () => {
+    queueGamificationEvent('gamification_add_to_cart', { product_id: 'prod-123', price: 299 });
+
+    const gamQueue = getQueue('gamification');
+    expect(gamQueue).toHaveLength(1);
+    expect(gamQueue[0].domain).toBe('gamification');
+    expect(gamQueue[0].action).toBe('gamification_add_to_cart');
+  });
+
+  it('stores event payload in the queue entry', () => {
+    queueGamificationEvent('gamification_submit_review', {
+      product_id: 'futon-xl',
+      rating: 5,
+      has_photo: true,
+    });
+
+    const entry = getQueue('gamification')[0];
+    expect(entry.payload.product_id).toBe('futon-xl');
+    expect(entry.payload.rating).toBe(5);
+    expect(entry.payload.has_photo).toBe(true);
+  });
+
+  it('assigns a unique eventId (the QueuedAction id) per event', () => {
+    queueGamificationEvent('gamification_add_to_cart', { product_id: 'a' });
+    queueGamificationEvent('gamification_add_to_cart', { product_id: 'b' });
+
+    const entries = getQueue('gamification');
+    expect(entries[0].id).not.toBe(entries[1].id);
+  });
+
+  it('includes the eventId in the payload for server deduplication', () => {
+    queueGamificationEvent('gamification_referral_shared', { referral_code: 'CODE-XK7P' });
+
+    const entry = getQueue('gamification')[0];
+    expect(entry.payload.eventId).toBe(entry.id);
+  });
+
+  it('increments getGamificationQueueLength', () => {
+    expect(getGamificationQueueLength()).toBe(0);
+    queueGamificationEvent('gamification_ar_used', { product_id: 'p1' });
+    expect(getGamificationQueueLength()).toBe(1);
+    queueGamificationEvent('gamification_ar_used', { product_id: 'p2' });
+    expect(getGamificationQueueLength()).toBe(2);
+  });
+});
+
+// ── flushGamificationQueue ────────────────────────────────────────────────────
+
+describe('flushGamificationQueue', () => {
+  it('is a no-op when queue is empty', async () => {
+    const client = mockWixClient();
+    const result = await flushGamificationQueue(client as never);
+
+    expect(client.callFunction).not.toHaveBeenCalled();
+    expect(result.succeeded).toBe(0);
+    expect(result.failed).toBe(0);
+  });
+
+  it('calls /_functions/gamificationEvent for each queued event', async () => {
+    queueGamificationEvent('gamification_add_to_cart', { product_id: 'a', price: 100 });
+    queueGamificationEvent('gamification_wishlist_add', { product_id: 'b' });
+
+    const client = mockWixClient();
+    await flushGamificationQueue(client as never);
+
+    expect(client.callFunction).toHaveBeenCalledTimes(2);
+    expect(client.callFunction).toHaveBeenCalledWith(
+      '/_functions/gamificationEvent',
+      'POST',
+      expect.objectContaining({ eventName: 'gamification_add_to_cart', product_id: 'a' }),
+    );
+  });
+
+  it('includes eventId in each POST payload', async () => {
+    queueGamificationEvent('gamification_submit_review', { product_id: 'p1', rating: 4 });
+
+    const entry = getQueue('gamification')[0];
+    const client = mockWixClient();
+    await flushGamificationQueue(client as never);
+
+    const callArgs = (client.callFunction as jest.Mock).mock.calls[0][2] as Record<string, unknown>;
+    expect(callArgs.eventId).toBe(entry.id);
+  });
+
+  it('removes successfully replayed events from the queue', async () => {
+    queueGamificationEvent('gamification_add_to_cart', { product_id: 'p1', price: 50 });
+    queueGamificationEvent('gamification_ar_used', { product_id: 'p2' });
+
+    const client = mockWixClient();
+    await flushGamificationQueue(client as never);
+
+    expect(getGamificationQueueLength()).toBe(0);
+  });
+
+  it('returns succeeded count equal to number of events replayed', async () => {
+    queueGamificationEvent('gamification_add_to_cart', { product_id: 'p1', price: 10 });
+    queueGamificationEvent('gamification_referral_shared', { referral_code: 'X' });
+
+    const client = mockWixClient();
+    const result = await flushGamificationQueue(client as never);
+
+    expect(result.succeeded).toBe(2);
+    expect(result.failed).toBe(0);
+  });
+
+  it('keeps failed events in queue for next reconnect', async () => {
+    queueGamificationEvent('gamification_add_to_cart', { product_id: 'p1', price: 10 });
+
+    const client = mockWixClient(jest.fn().mockRejectedValue(new Error('Network error')));
+    const result = await flushGamificationQueue(client as never);
+
+    expect(result.failed).toBe(1);
+    expect(getGamificationQueueLength()).toBe(1);
+  });
+
+  it('replays events in the order they were queued', async () => {
+    queueGamificationEvent('gamification_add_to_cart', { product_id: 'first', price: 1 });
+    queueGamificationEvent('gamification_submit_review', { product_id: 'second', rating: 3 });
+    queueGamificationEvent('gamification_ar_used', { product_id: 'third' });
+
+    const callOrder: string[] = [];
+    const client = {
+      callFunction: jest
+        .fn()
+        .mockImplementation((_path: string, _method: string, body: Record<string, unknown>) => {
+          callOrder.push(body.eventName as string);
+          return Promise.resolve({ ok: true });
+        }),
+    };
+
+    await flushGamificationQueue(client as never);
+
+    expect(callOrder).toEqual([
+      'gamification_add_to_cart',
+      'gamification_submit_review',
+      'gamification_ar_used',
+    ]);
+  });
+
+  it('partial failure: succeeds first, fails second, keeps only failed in queue', async () => {
+    queueGamificationEvent('gamification_add_to_cart', { product_id: 'ok', price: 10 });
+    queueGamificationEvent('gamification_ar_used', { product_id: 'fail' });
+
+    let callCount = 0;
+    const client = {
+      callFunction: jest.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 2) return Promise.reject(new Error('fail'));
+        return Promise.resolve({ ok: true });
+      }),
+    };
+
+    const result = await flushGamificationQueue(client as never);
+
+    expect(result.succeeded).toBe(1);
+    expect(result.failed).toBe(1);
+    // The failed event (ar_used) stays in queue
+    const remaining = getQueue('gamification');
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].action).toBe('gamification_ar_used');
+  });
+});

--- a/src/services/gamificationOfflineQueue.ts
+++ b/src/services/gamificationOfflineQueue.ts
@@ -1,0 +1,76 @@
+/**
+ * @module gamificationOfflineQueue
+ *
+ * Offline queue for gamification events — hq-94ado.
+ *
+ * When offline, call `queueGamificationEvent` to store events to AsyncStorage
+ * via the shared offlineQueue. Each event receives a unique `eventId` (the
+ * QueuedAction.id) which the server uses for idempotency deduplication.
+ *
+ * On reconnect, call `flushGamificationQueue(client)` to POST each stored event
+ * to `/_functions/gamificationEvent`. Successfully replayed events are removed
+ * from the queue; failed events remain for the next reconnect cycle.
+ *
+ * Pairs with:
+ *   hq-74nry — client-side rate limit guard (gamificationRateLimiter)
+ *   hq-825vi — server-side endpoint wiring
+ */
+
+import type { WixClient } from './wix/wixClient';
+import { enqueue, getQueue, dequeue } from './offlineQueue';
+
+export interface FlushResult {
+  succeeded: number;
+  failed: number;
+}
+
+/**
+ * Queue a gamification event for later replay when offline.
+ * Adds `eventId` to the payload for server-side deduplication.
+ *
+ * @param name - Event name (e.g. 'gamification_add_to_cart').
+ * @param properties - Event properties (product_id, price, etc.).
+ */
+export function queueGamificationEvent(name: string, properties: Record<string, unknown>): void {
+  const entry = enqueue('gamification', name, properties);
+  // Back-patch eventId into the payload entry that was just enqueued.
+  // The QueuedAction.id IS the eventId for server deduplication.
+  entry.payload.eventId = entry.id;
+}
+
+/** Number of gamification events currently waiting in the queue. */
+export function getGamificationQueueLength(): number {
+  return getQueue('gamification').length;
+}
+
+/**
+ * Replay all queued gamification events to the backend endpoint.
+ * Successfully replayed events are removed from the queue.
+ * Failed events remain in the queue for the next reconnect cycle.
+ *
+ * @param client - WixClient instance with `callFunction` method.
+ */
+export async function flushGamificationQueue(client: WixClient): Promise<FlushResult> {
+  const pending = getQueue('gamification');
+  const result: FlushResult = { succeeded: 0, failed: 0 };
+
+  if (pending.length === 0) return result;
+
+  for (const action of pending) {
+    try {
+      await client.callFunction('/_functions/gamificationEvent', 'POST', {
+        eventName: action.action,
+        ...action.payload,
+      });
+      dequeue(action.id);
+      result.succeeded++;
+    } catch {
+      result.failed++;
+      // Leave failed events in the queue (they were not dequeued).
+      // Re-enqueue any that were implicitly removed — but since we only
+      // dequeue on success, no re-enqueue is needed here.
+    }
+  }
+
+  return result;
+}

--- a/src/services/offlineQueue.ts
+++ b/src/services/offlineQueue.ts
@@ -10,7 +10,7 @@ import { captureException } from './crashReporting';
 export interface QueuedAction {
   id: string;
   timestamp: number;
-  domain: 'cart' | 'wishlist';
+  domain: 'cart' | 'wishlist' | 'gamification';
   action: string; // action type string (e.g. 'ADD_ITEM', 'REMOVE')
   payload: Record<string, unknown>;
 }


### PR DESCRIPTION
## Summary
- Adds `gamificationOfflineQueue` service: stores events to AsyncStorage when offline with a unique `eventId` per event for server-side deduplication
- Adds `useGamificationOfflineSync` hook: `emitOrQueue` fires via analytics when online / queues when offline; auto-flushes queue on reconnect to `/_functions/gamificationEvent`
- Extends offlineQueue domain type to include `'gamification'`
- Failed events remain queued for next reconnect cycle (no data loss)

Pairs with hq-74nry (rate limiter, merged PR #277) and hq-825vi (endpoint wiring).

## Test plan
- [x] `gamificationOfflineQueue.test.ts` — 14 unit tests: queue stores with correct domain/action/payload, unique eventId per event, eventId in payload for dedup, queue length tracking, flush no-op when empty, calls correct endpoint for each event, includes eventId in POST, removes succeeded events, returns counts, keeps failed events, replay order, partial failure
- [x] `useGamificationOfflineSync.test.tsx` — 7 integration tests: trackEvent when online, no queue when online, queues when offline, pendingCount tracks queue, auto-flush on reconnect, no flush on already-online, isSyncing lifecycle
- [x] All 21 tests pass, ESLint clean

Closes hq-94ado

🤖 Generated with [Claude Code](https://claude.com/claude-code)