### PR TITLE
feat(hq-oq1gk): LivingSkyLoadingView — golden-hour splash screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,13 +1,12 @@
 import 'react-native-url-polyfill/auto';
 import React, { useCallback, useEffect, useState } from 'react';
-import { View, StyleSheet } from 'react-native';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { NavigationContainer } from '@react-navigation/native';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 import { StripeProvider } from '@stripe/stripe-react-native';
 import { useFonts } from 'expo-font';
 import * as SplashScreen from 'expo-splash-screen';
-import { BrandedSpinner } from '@/components/BrandedSpinner';
+import { LivingSkyLoadingView } from '@/components/LivingSkyLoadingView';
 import { ThemeProvider } from '@/theme';
 import { AuthProvider } from '@/hooks/useAuth';
 import { CartProvider } from '@/hooks/useCart';
@@ -113,11 +112,7 @@ function App() {
   }, [fontsLoaded]);
 
   if (!fontsLoaded) {
-    return (
-      <View style={styles.loading}>
-        <BrandedSpinner size="large" color="#E8845C" />
-      </View>
-    );
+    return <LivingSkyLoadingView />;
   }
 
   return (
@@ -190,11 +185,3 @@ function App() {
 
 export default wrapWithSentry(App);
 
-const styles = StyleSheet.create({
-  loading: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-    backgroundColor: '#E8D5B7',
-  },
-});

--- a/src/components/LivingSkyLoadingView.tsx
+++ b/src/components/LivingSkyLoadingView.tsx
@@ -1,0 +1,54 @@
+/**
+ * @module LivingSkyLoadingView
+ *
+ * Splash/loading screen shown while fonts load on app startup.
+ * Renders the Living Sky at golden hour (totalMinutes=1170, h=19.5)
+ * — the most dramatic Blue Ridge scene.
+ *
+ * hq-oq1gk
+ */
+
+import React from 'react';
+import { View, StyleSheet } from 'react-native';
+import { LivingSkyMountainSkyline } from '@/components/LivingSkyMountainSkyline';
+import { BrandedSpinner } from '@/components/BrandedSpinner';
+import { useLivingSky } from '@/hooks/useLivingSky';
+
+/** Golden hour: h=19.5 in skyTable — deep purple-blue sky, near-black ridges, warm rim light */
+const GOLDEN_HOUR_MINUTES = 1170;
+
+export function LivingSkyLoadingView() {
+  const skyState = useLivingSky(GOLDEN_HOUR_MINUTES);
+
+  return (
+    <View testID="living-sky-loading-view" style={styles.root}>
+      <LivingSkyMountainSkyline
+        state={skyState}
+        style={styles.skyline}
+        testID="living-sky-loading-skyline"
+      />
+      <View style={styles.spinnerContainer}>
+        <BrandedSpinner size="large" color="#E8845C" />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+    backgroundColor: '#100E1E', // deep dusk — matches golden-hour navBg
+    justifyContent: 'flex-end',
+  },
+  skyline: {
+    position: 'absolute',
+    bottom: 0,
+    left: 0,
+    right: 0,
+  },
+  spinnerContainer: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+});

--- a/src/components/__tests__/LivingSkyLoadingView.test.tsx
+++ b/src/components/__tests__/LivingSkyLoadingView.test.tsx
@@ -1,0 +1,93 @@
+/**
+ * @file LivingSkyLoadingView.test.tsx
+ * @description TDD tests for LivingSkyLoadingView — golden-hour splash screen.
+ * hq-oq1gk
+ *
+ * Covers:
+ *  - Renders the skyline with testID living-sky-loading-skyline
+ *  - Renders the brand spinner
+ *  - Uses golden-hour state (totalMinutes=1170)
+ *  - Passes state with high rimOpacity (golden hour signature)
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { LivingSkyLoadingView } from '../LivingSkyLoadingView';
+
+const mockUseLivingSky = jest.fn();
+
+jest.mock('@/hooks/useLivingSky', () => ({
+  useLivingSky: (minutes: number) => mockUseLivingSky(minutes),
+}));
+
+jest.mock('@/components/LivingSkyMountainSkyline', () => ({
+  LivingSkyMountainSkyline: ({ testID }: { testID?: string }) => {
+    const { View } = require('react-native');
+    return <View testID={testID ?? 'living-sky'} />;
+  },
+}));
+
+jest.mock('@/components/BrandedSpinner', () => ({
+  BrandedSpinner: () => {
+    const { View } = require('react-native');
+    return <View testID="branded-spinner" />;
+  },
+}));
+
+const GOLDEN_HOUR_MINUTES = 1170;
+
+const mockGoldenHourState = {
+  skyColors: ['#201840', '#5C2C60', '#C85038', '#F08828'] as [string, string, string, string],
+  glowColors: ['#FFD050', '#E05000'] as [string, string],
+  ridgeColors: { r1: '#140230', r2: '#300850', r3: '#4C1468', r4: '#703480', tree: '#080118' },
+  sunPos: { cx: 920, cy: 140, r: 18, opacity: 0.95 },
+  moonPos: { cx: 200, cy: 200, opacity: 0, phase: 0, shadowOffset: { dx: 0, dy: 0 } },
+  starOpacity: 0,
+  cloudOpacity: 0,
+  birdOpacity: 1,
+  fireflyOpacity: 0.08,
+  owlOpacity: 0,
+  rimOpacity: 0.95,
+  rimColor: '#FF7010',
+  navBg: '#F5EFE6',
+  navText: '#3D2310',
+  season: 'summer' as const,
+  precipitationOpacity: 0,
+  precipitationType: 'none' as const,
+};
+
+describe('LivingSkyLoadingView', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseLivingSky.mockReturnValue(mockGoldenHourState);
+  });
+
+  it('renders the skyline with testID living-sky-loading-skyline', () => {
+    const { getByTestId } = render(<LivingSkyLoadingView />);
+    expect(getByTestId('living-sky-loading-skyline')).toBeTruthy();
+  });
+
+  it('renders the branded spinner', () => {
+    const { getByTestId } = render(<LivingSkyLoadingView />);
+    expect(getByTestId('branded-spinner')).toBeTruthy();
+  });
+
+  it('calls useLivingSky with golden-hour totalMinutes (1170)', () => {
+    render(<LivingSkyLoadingView />);
+    expect(mockUseLivingSky).toHaveBeenCalledWith(GOLDEN_HOUR_MINUTES);
+  });
+
+  it('receives state with high rimOpacity (golden hour signature)', () => {
+    const { getByTestId } = render(<LivingSkyLoadingView />);
+    // Component renders without crashing with golden-hour state
+    expect(getByTestId('living-sky-loading-skyline')).toBeTruthy();
+    expect(mockUseLivingSky).toHaveBeenCalledWith(GOLDEN_HOUR_MINUTES);
+    const state = mockUseLivingSky.mock.results[0].value;
+    expect(state.rimOpacity).toBeGreaterThan(0.5);
+  });
+
+  it('has testID living-sky-loading-view on root container', () => {
+    const { getByTestId } = render(<LivingSkyLoadingView />);
+    expect(getByTestId('living-sky-loading-view')).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- **`src/components/LivingSkyLoadingView.tsx`** — Splash/loading component shown while fonts load. Calls `useLivingSky(1170)` (h=19.5, golden hour) for a static, no-interval scene. Renders `LivingSkyMountainSkyline` anchored to the bottom with the spinner centered above.
- **`App.tsx`** — `if (!fontsLoaded)` now returns `<LivingSkyLoadingView />` instead of the plain spinner. Removed unused `View`, `StyleSheet`, and `BrandedSpinner` imports.

Golden hour (h=19.5): deep purple-blue sky, near-black silhouette ridges, warm orange rim light, birds in flight — the most dramatic Blue Ridge scene per the Phase 7 spec.

## Test plan
- [x] 5 unit tests — all passing
  - Renders skyline testID + spinner
  - Calls useLivingSky with exactly 1170
  - Golden-hour state has rimOpacity > 0.5
  - Root container testID present

🤖 Generated with [Claude Code](https://claude.com/claude-code)