### PR TITLE
fix(hq-lqw8i): async mock isolation — timer leak + impl bleed (#252/#253/#259)

### DIFF
--- a/src/hooks/__tests__/useStreak.test.ts
+++ b/src/hooks/__tests__/useStreak.test.ts
@@ -32,6 +32,10 @@ afterAll(() => {
 describe('useStreak', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Restore default implementations so a never-resolving mock from one test
+    // cannot bleed into the next (clearAllMocks resets calls but not impls).
+    mockGetItem.mockResolvedValue(null);
+    mockSetItem.mockResolvedValue(undefined);
   });
 
   it('returns streak of 1 on first ever visit', async () => {

--- a/src/screens/__tests__/CategoryScreen.test.tsx
+++ b/src/screens/__tests__/CategoryScreen.test.tsx
@@ -8,6 +8,14 @@ import { PRODUCTS } from '@/data/products';
 
 jest.useFakeTimers();
 
+afterEach(() => {
+  jest.clearAllTimers();
+});
+
+afterAll(() => {
+  jest.useRealTimers();
+});
+
 const futonProducts = PRODUCTS.filter((p) => p.category === 'futons');
 const coverProducts = PRODUCTS.filter((p) => p.category === 'covers');
 


### PR DESCRIPTION
## Summary

Fixes three related test isolation bugs (GitHub Issues #252, #253, #259) that cause flaky timeouts and act() warnings in the full Jest suite.

**Bug 1 — fake timer leak (CategoryScreen → AccountScreen/ShopScreen)**

`CategoryScreen.test.tsx` called `jest.useFakeTimers()` at module level with no `afterAll` cleanup. When Jest assigned CategoryScreen and AccountScreen to the same worker, fake timers leaked into AccountScreen — any `setTimeout` in the auth/session restore flow never fired, causing the 5000ms timeout failure in #253. ShopScreen (#259) hit the same issue via `act()` timing assumptions.

Fix: `afterEach(() => jest.clearAllTimers())` drains pending fake timers between tests. `afterAll(() => jest.useRealTimers())` restores the real clock so subsequent test files in the same worker are unaffected.

**Bug 2 — never-resolving Promise implementation leak (useStreak)**

`useStreak.test.ts` used `jest.clearAllMocks()` in `beforeEach`, which resets call counts but **not** mock implementations. The "returns loading=true initially" test installs a never-resolving Promise with `mockImplementation(() => new Promise(() => {}))`. Without an explicit implementation reset, that mock bled into subsequent tests and kept the Jest worker event loop alive after teardown — causing the worker force-exit warning in #252.

Fix: after `clearAllMocks()`, explicitly restore the factory defaults with `mockGetItem.mockResolvedValue(null)` and `mockSetItem.mockResolvedValue(undefined)`.

## Test plan

- [x] `useStreak.test.ts` — 11/11 pass in isolation
- [x] AccountScreen (81/81) after CategoryScreen with `--runInBand` — no timeout
- [x] Pre-existing CategoryScreen/ShopScreen suite-level failures confirmed as duplicate `__mocks__/expo-av` from crew worktrees — separate issue, not affected by this PR

Closes #252, #253, #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)