### PR TITLE
feat(cf-fv7): useLivingSky — isLoading: boolean return field

### DIFF
--- a/src/hooks/__tests__/useLivingSky.test.ts
+++ b/src/hooks/__tests__/useLivingSky.test.ts
@@ -231,4 +231,17 @@ describe('useLivingSky', () => {
     expect(typeof result.current.rimColor).toBe('string');
     expect(result.current.rimColor.length).toBeGreaterThan(0);
   });
+
+  it('isLoading is false on first render (synchronous computation)', () => {
+    const { result } = renderHook(() => useLivingSky(720));
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('isLoading remains false after interval tick', () => {
+    const { result } = renderHook(() => useLivingSky());
+    act(() => {
+      jest.advanceTimersByTime(30000);
+    });
+    expect(result.current.isLoading).toBe(false);
+  });
 });

--- a/src/hooks/useLivingSky.ts
+++ b/src/hooks/useLivingSky.ts
@@ -610,8 +610,9 @@ function currentTotalMinutes(): number {
 /**
  * React hook that returns the living sky state for the current time.
  * Updates every 30 seconds. Pass `overrideMinutes` for static/testing use.
+ * `isLoading` is always false — state is computed synchronously on mount.
  */
-export function useLivingSky(overrideMinutes?: number): LivingSkyState {
+export function useLivingSky(overrideMinutes?: number): LivingSkyState & { isLoading: boolean } {
   const [state, setState] = useState<LivingSkyState>(() =>
     computeSkyState(overrideMinutes ?? currentTotalMinutes()),
   );
@@ -632,5 +633,5 @@ export function useLivingSky(overrideMinutes?: number): LivingSkyState {
     return () => clearInterval(id);
   }, [overrideMinutes]);
 
-  return state;
+  return { ...state, isLoading: false };
 }


### PR DESCRIPTION
## Summary

Closes cf-fv7 — satisfies the final spec item: `LivingSkyState & { isLoading: boolean }` return type.

The hook already computes sky state synchronously on mount (no async work), so `isLoading` is always `false`. Adding it to the return type allows consumers to pattern-match on it for skeleton/fallback logic without needing to change call sites.

The existing implementation (merged in #280 via hq-u0aqm + hq-4wgr3) already covered all other cf-fv7 acceptance criteria:
- Full time-of-day interpolation engine ✓
- `overrideMinutes` for static/testing use ✓
- 30s interval updates ✓
- No timer leaks (clearInterval on unmount) ✓
- 120 tests passing ✓

## Test plan

- [x] `isLoading is false on first render (synchronous computation)` — new
- [x] `isLoading remains false after interval tick` — new
- [x] All 120 existing useLivingSky tests still pass (122 total)

🤖 Generated with [Claude Code](https://claude.com/claude-code)