### PR TITLE
feat(cf-zlp): GameProfileCard — streak/rank/points hero widget

### DIFF
--- a/src/components/GameProfileCard.tsx
+++ b/src/components/GameProfileCard.tsx
@@ -1,0 +1,335 @@
+/**
+ * @module GameProfileCard
+ *
+ * Hero widget for Profile/Member screen.
+ * Displays current streak (with fire icon), leaderboard rank, total points,
+ * and tier badge. Per-slice loading skeletons.
+ *
+ * Tap streak → StreakDetail bottom sheet.
+ * Tap rank   → onNavigateToLeaderboard callback.
+ * Tap points → onNavigateToPointsHistory callback.
+ *
+ * Zero-streak hides the streak chip entirely.
+ *
+ * cf-zlp
+ */
+
+import React, { useState, useCallback } from 'react';
+import { View, Text, TouchableOpacity, Modal, StyleSheet } from 'react-native';
+import { useTheme } from '@/theme';
+import { darkPalette } from '@/theme/tokens';
+import { useGameProfile } from '@/hooks/useGameProfile';
+import type { LoyaltyTier } from '@/hooks/useLoyalty';
+
+// ── Props ─────────────────────────────────────────────────────────────────────
+
+export interface GameProfileCardProps {
+  onNavigateToLeaderboard?: () => void;
+  onNavigateToPointsHistory?: () => void;
+  testID?: string;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+const TIER_COLORS: Record<LoyaltyTier, string> = {
+  bronze: '#CD7F32',
+  silver: '#A8A9AD',
+  gold: '#FFD700',
+};
+
+const TIER_LABELS: Record<LoyaltyTier, string> = {
+  bronze: 'Bronze',
+  silver: 'Silver',
+  gold: 'Gold',
+};
+
+function formatDate(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+// ── Skeleton ──────────────────────────────────────────────────────────────────
+
+function SkeletonBar({ testID }: { testID: string }) {
+  return <View testID={testID} style={styles.skeleton} />;
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function GameProfileCard({
+  onNavigateToLeaderboard,
+  onNavigateToPointsHistory,
+  testID,
+}: GameProfileCardProps) {
+  const { colors, spacing, borderRadius } = useTheme();
+  const {
+    streakDays,
+    streakStartDate,
+    nextMilestoneDays,
+    rank,
+    totalPoints,
+    tier,
+    streakLoading,
+    rankLoading,
+    pointsLoading,
+  } = useGameProfile();
+
+  const [streakSheetOpen, setStreakSheetOpen] = useState(false);
+
+  const openStreakSheet = useCallback(() => setStreakSheetOpen(true), []);
+  const closeStreakSheet = useCallback(() => setStreakSheetOpen(false), []);
+
+  return (
+    <View
+      testID={testID ?? 'game-profile-card'}
+      style={[
+        styles.card,
+        {
+          backgroundColor: darkPalette.surfaceElevated,
+          borderRadius: borderRadius.card,
+          padding: spacing.md,
+        },
+      ]}
+    >
+      {/* ── Row of chips ─────────────────────────────────────────────────── */}
+      <View style={styles.row}>
+        {/* Streak chip */}
+        {streakLoading ? (
+          <SkeletonBar testID="streak-loading" />
+        ) : streakDays > 0 ? (
+          <TouchableOpacity
+            testID="streak-chip"
+            onPress={openStreakSheet}
+            style={[
+              styles.chip,
+              {
+                backgroundColor: darkPalette.surface,
+                borderRadius: borderRadius.md,
+                borderColor: '#FF6B35',
+              },
+            ]}
+            activeOpacity={0.7}
+          >
+            <Text style={styles.chipIcon}>🔥</Text>
+            <Text testID="streak-days" style={[styles.chipValue, { color: '#FF6B35' }]}>
+              {streakDays}
+            </Text>
+            <Text style={[styles.chipLabel, { color: darkPalette.textMuted }]}>days</Text>
+          </TouchableOpacity>
+        ) : null}
+
+        {/* Rank chip */}
+        {rankLoading ? (
+          <SkeletonBar testID="rank-loading" />
+        ) : (
+          <TouchableOpacity
+            testID="rank-chip"
+            onPress={onNavigateToLeaderboard}
+            style={[
+              styles.chip,
+              {
+                backgroundColor: darkPalette.surface,
+                borderRadius: borderRadius.md,
+                borderColor: colors.mountainBlue,
+              },
+            ]}
+            activeOpacity={0.7}
+          >
+            <Text style={styles.chipIcon}>🏆</Text>
+            <Text style={[styles.chipLabel, { color: darkPalette.textMuted }]}>#</Text>
+            <Text testID="rank-value" style={[styles.chipValue, { color: colors.mountainBlue }]}>
+              {rank ?? '—'}
+            </Text>
+          </TouchableOpacity>
+        )}
+
+        {/* Points chip */}
+        {pointsLoading ? (
+          <SkeletonBar testID="points-loading" />
+        ) : (
+          <TouchableOpacity
+            testID="points-chip"
+            onPress={onNavigateToPointsHistory}
+            style={[
+              styles.chip,
+              {
+                backgroundColor: darkPalette.surface,
+                borderRadius: borderRadius.md,
+                borderColor: TIER_COLORS[tier],
+              },
+            ]}
+            activeOpacity={0.7}
+          >
+            <Text style={styles.chipIcon}>⭐</Text>
+            <Text testID="points-value" style={[styles.chipValue, { color: TIER_COLORS[tier] }]}>
+              {totalPoints}
+            </Text>
+            <Text style={[styles.chipLabel, { color: darkPalette.textMuted }]}>pts</Text>
+          </TouchableOpacity>
+        )}
+
+        {/* Tier badge */}
+        <View
+          testID="tier-badge"
+          style={[
+            styles.tierBadge,
+            {
+              backgroundColor: darkPalette.surface,
+              borderRadius: borderRadius.pill,
+              borderColor: TIER_COLORS[tier],
+            },
+          ]}
+        >
+          <Text style={[styles.tierLabel, { color: TIER_COLORS[tier] }]}>{TIER_LABELS[tier]}</Text>
+        </View>
+      </View>
+
+      {/* ── Streak detail bottom sheet ────────────────────────────────────── */}
+      {streakSheetOpen && (
+        <Modal
+          testID="streak-sheet"
+          visible
+          transparent
+          animationType="slide"
+          onRequestClose={closeStreakSheet}
+        >
+          <View style={styles.sheetOverlay}>
+            <TouchableOpacity
+              style={StyleSheet.absoluteFillObject}
+              onPress={closeStreakSheet}
+              activeOpacity={1}
+            />
+            <View
+              style={[
+                styles.sheet,
+                {
+                  backgroundColor: darkPalette.surfaceElevated,
+                  borderRadius: borderRadius.xl ?? 16,
+                  padding: spacing.lg,
+                },
+              ]}
+            >
+              <Text style={styles.sheetEmoji}>🔥</Text>
+              <Text style={[styles.sheetTitle, { color: darkPalette.textPrimary }]}>
+                {streakDays}-Day Streak
+              </Text>
+              {streakStartDate ? (
+                <Text
+                  testID="streak-sheet-start-date"
+                  style={[styles.sheetDetail, { color: darkPalette.textMuted }]}
+                >
+                  Started: {formatDate(streakStartDate)}
+                </Text>
+              ) : null}
+              <Text
+                testID="streak-sheet-next-milestone"
+                style={[styles.sheetDetail, { color: colors.mountainBlueLight }]}
+              >
+                Next milestone: {nextMilestoneDays} days
+              </Text>
+              <TouchableOpacity
+                testID="streak-sheet-close"
+                onPress={closeStreakSheet}
+                style={[
+                  styles.closeBtn,
+                  {
+                    backgroundColor: colors.mountainBlue,
+                    borderRadius: borderRadius.button,
+                    marginTop: spacing.md,
+                  },
+                ]}
+              >
+                <Text style={[styles.closeBtnLabel, { color: darkPalette.textPrimary }]}>
+                  Close
+                </Text>
+              </TouchableOpacity>
+            </View>
+          </View>
+        </Modal>
+      )}
+    </View>
+  );
+}
+
+// ── Styles ────────────────────────────────────────────────────────────────────
+
+const styles = StyleSheet.create({
+  card: {
+    elevation: 2,
+  },
+  row: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    gap: 8,
+    alignItems: 'center',
+  },
+  chip: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    paddingHorizontal: 10,
+    paddingVertical: 8,
+    borderWidth: 1,
+    gap: 4,
+  },
+  chipIcon: {
+    fontSize: 16,
+  },
+  chipValue: {
+    fontSize: 18,
+    fontWeight: '700',
+  },
+  chipLabel: {
+    fontSize: 11,
+    fontWeight: '500',
+  },
+  tierBadge: {
+    paddingHorizontal: 12,
+    paddingVertical: 6,
+    borderWidth: 1,
+  },
+  tierLabel: {
+    fontSize: 12,
+    fontWeight: '700',
+    textTransform: 'uppercase',
+    letterSpacing: 0.5,
+  },
+  skeleton: {
+    width: 80,
+    height: 42,
+    borderRadius: 8,
+    backgroundColor: 'rgba(255,255,255,0.08)',
+  },
+  // Bottom sheet
+  sheetOverlay: {
+    flex: 1,
+    justifyContent: 'flex-end',
+    backgroundColor: 'rgba(0,0,0,0.5)',
+  },
+  sheet: {
+    alignItems: 'center',
+    paddingBottom: 32,
+  },
+  sheetEmoji: {
+    fontSize: 48,
+    marginBottom: 8,
+  },
+  sheetTitle: {
+    fontSize: 22,
+    fontWeight: '700',
+    marginBottom: 12,
+  },
+  sheetDetail: {
+    fontSize: 14,
+    marginBottom: 4,
+    textAlign: 'center',
+  },
+  closeBtn: {
+    width: '100%',
+    alignItems: 'center',
+    paddingVertical: 12,
+  },
+  closeBtnLabel: {
+    fontSize: 15,
+    fontWeight: '600',
+  },
+});

--- a/src/components/__tests__/GameProfileCard.test.tsx
+++ b/src/components/__tests__/GameProfileCard.test.tsx
@@ -1,0 +1,226 @@
+/**
+ * Tests for GameProfileCard — cf-zlp
+ * TDD: written before implementation.
+ *
+ * Covers: populated state, individual loading skeletons, zero-streak hides chip,
+ * tap-streak opens bottom sheet (startDate + next milestone), tap-rank callback,
+ * tap-points callback, sheet dismiss.
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { GameProfileCard } from '../GameProfileCard';
+import { ThemeProvider } from '@/theme/ThemeProvider';
+
+// ── Mock ──────────────────────────────────────────────────────────────────────
+
+const mockUseGameProfile = jest.fn();
+jest.mock('@/hooks/useGameProfile', () => ({
+  useGameProfile: () => mockUseGameProfile(),
+}));
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const POPULATED = {
+  streakDays: 14,
+  streakStartDate: '2026-03-09',
+  nextMilestoneDays: 30,
+  rank: 5,
+  totalPoints: 1250,
+  tier: 'silver' as const,
+  streakLoading: false,
+  rankLoading: false,
+  pointsLoading: false,
+  error: null,
+};
+
+const ZERO_STREAK = { ...POPULATED, streakDays: 0 };
+
+const STREAK_LOADING = { ...POPULATED, streakDays: 0, streakLoading: true };
+const RANK_LOADING = { ...POPULATED, rank: null, rankLoading: true };
+const POINTS_LOADING = { ...POPULATED, totalPoints: 0, pointsLoading: true };
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function wrap(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+const onNavigateToLeaderboard = jest.fn();
+const onNavigateToPointsHistory = jest.fn();
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseGameProfile.mockReturnValue(POPULATED);
+});
+
+// ── Root container ────────────────────────────────────────────────────────────
+
+describe('GameProfileCard — root', () => {
+  it('renders game-profile-card testID', () => {
+    const { getByTestId } = wrap(<GameProfileCard />);
+    expect(getByTestId('game-profile-card')).toBeTruthy();
+  });
+
+  it('accepts custom testID', () => {
+    const { getByTestId } = wrap(<GameProfileCard testID="my-card" />);
+    expect(getByTestId('my-card')).toBeTruthy();
+  });
+});
+
+// ── Streak chip ───────────────────────────────────────────────────────────────
+
+describe('Streak chip', () => {
+  it('renders streak-chip when streak > 0', () => {
+    const { getByTestId } = wrap(<GameProfileCard />);
+    expect(getByTestId('streak-chip')).toBeTruthy();
+  });
+
+  it('shows streak day count', () => {
+    const { getByTestId } = wrap(<GameProfileCard />);
+    expect(getByTestId('streak-days').props.children).toBe(14);
+  });
+
+  it('hides streak-chip when streakDays = 0', () => {
+    mockUseGameProfile.mockReturnValue(ZERO_STREAK);
+    const { queryByTestId } = wrap(<GameProfileCard />);
+    expect(queryByTestId('streak-chip')).toBeNull();
+  });
+
+  it('shows streak-loading skeleton while streak loads', () => {
+    mockUseGameProfile.mockReturnValue(STREAK_LOADING);
+    const { getByTestId } = wrap(<GameProfileCard />);
+    expect(getByTestId('streak-loading')).toBeTruthy();
+  });
+
+  it('hides streak-chip while streak loads', () => {
+    mockUseGameProfile.mockReturnValue(STREAK_LOADING);
+    const { queryByTestId } = wrap(<GameProfileCard />);
+    expect(queryByTestId('streak-chip')).toBeNull();
+  });
+});
+
+// ── Rank chip ─────────────────────────────────────────────────────────────────
+
+describe('Rank chip', () => {
+  it('renders rank-chip', () => {
+    const { getByTestId } = wrap(<GameProfileCard />);
+    expect(getByTestId('rank-chip')).toBeTruthy();
+  });
+
+  it('shows rank value', () => {
+    const { getByTestId } = wrap(<GameProfileCard />);
+    expect(getByTestId('rank-value').props.children).toBe(5);
+  });
+
+  it('shows rank-loading skeleton while rank loads', () => {
+    mockUseGameProfile.mockReturnValue(RANK_LOADING);
+    const { getByTestId } = wrap(<GameProfileCard />);
+    expect(getByTestId('rank-loading')).toBeTruthy();
+  });
+
+  it('hides rank-value while rank loads', () => {
+    mockUseGameProfile.mockReturnValue(RANK_LOADING);
+    const { queryByTestId } = wrap(<GameProfileCard />);
+    expect(queryByTestId('rank-value')).toBeNull();
+  });
+});
+
+// ── Points chip ───────────────────────────────────────────────────────────────
+
+describe('Points chip', () => {
+  it('renders points-chip', () => {
+    const { getByTestId } = wrap(<GameProfileCard />);
+    expect(getByTestId('points-chip')).toBeTruthy();
+  });
+
+  it('shows total points value', () => {
+    const { getByTestId } = wrap(<GameProfileCard />);
+    expect(getByTestId('points-value').props.children).toBe(1250);
+  });
+
+  it('shows points-loading skeleton while points loads', () => {
+    mockUseGameProfile.mockReturnValue(POINTS_LOADING);
+    const { getByTestId } = wrap(<GameProfileCard />);
+    expect(getByTestId('points-loading')).toBeTruthy();
+  });
+
+  it('hides points-value while points loads', () => {
+    mockUseGameProfile.mockReturnValue(POINTS_LOADING);
+    const { queryByTestId } = wrap(<GameProfileCard />);
+    expect(queryByTestId('points-value')).toBeNull();
+  });
+});
+
+// ── Tier badge ────────────────────────────────────────────────────────────────
+
+describe('Tier badge', () => {
+  it('renders tier-badge', () => {
+    const { getByTestId } = wrap(<GameProfileCard />);
+    expect(getByTestId('tier-badge')).toBeTruthy();
+  });
+});
+
+// ── Streak bottom sheet ───────────────────────────────────────────────────────
+
+describe('Streak bottom sheet', () => {
+  it('sheet is closed initially', () => {
+    const { queryByTestId } = wrap(<GameProfileCard />);
+    expect(queryByTestId('streak-sheet')).toBeNull();
+  });
+
+  it('tapping streak-chip opens streak-sheet', () => {
+    const { getByTestId } = wrap(<GameProfileCard />);
+    fireEvent.press(getByTestId('streak-chip'));
+    expect(getByTestId('streak-sheet')).toBeTruthy();
+  });
+
+  it('sheet shows streak start date', () => {
+    const { getByTestId } = wrap(<GameProfileCard />);
+    fireEvent.press(getByTestId('streak-chip'));
+    expect(getByTestId('streak-sheet-start-date')).toBeTruthy();
+  });
+
+  it('sheet shows next milestone text', () => {
+    const { getByTestId } = wrap(<GameProfileCard />);
+    fireEvent.press(getByTestId('streak-chip'));
+    expect(getByTestId('streak-sheet-next-milestone')).toBeTruthy();
+  });
+
+  it('sheet close button dismisses sheet', () => {
+    const { getByTestId, queryByTestId } = wrap(<GameProfileCard />);
+    fireEvent.press(getByTestId('streak-chip'));
+    fireEvent.press(getByTestId('streak-sheet-close'));
+    expect(queryByTestId('streak-sheet')).toBeNull();
+  });
+});
+
+// ── Navigation callbacks ──────────────────────────────────────────────────────
+
+describe('Navigation callbacks', () => {
+  it('tapping rank-chip calls onNavigateToLeaderboard', () => {
+    const { getByTestId } = wrap(
+      <GameProfileCard onNavigateToLeaderboard={onNavigateToLeaderboard} />,
+    );
+    fireEvent.press(getByTestId('rank-chip'));
+    expect(onNavigateToLeaderboard).toHaveBeenCalledTimes(1);
+  });
+
+  it('tapping points-chip calls onNavigateToPointsHistory', () => {
+    const { getByTestId } = wrap(
+      <GameProfileCard onNavigateToPointsHistory={onNavigateToPointsHistory} />,
+    );
+    fireEvent.press(getByTestId('points-chip'));
+    expect(onNavigateToPointsHistory).toHaveBeenCalledTimes(1);
+  });
+
+  it('tapping rank-chip is safe with no callback', () => {
+    const { getByTestId } = wrap(<GameProfileCard />);
+    expect(() => fireEvent.press(getByTestId('rank-chip'))).not.toThrow();
+  });
+
+  it('tapping points-chip is safe with no callback', () => {
+    const { getByTestId } = wrap(<GameProfileCard />);
+    expect(() => fireEvent.press(getByTestId('points-chip'))).not.toThrow();
+  });
+});

--- a/src/hooks/useGameProfile.ts
+++ b/src/hooks/useGameProfile.ts
@@ -1,0 +1,61 @@
+/**
+ * @module useGameProfile
+ *
+ * Aggregates streak, rank, points, and tier data for GameProfileCard.
+ * Composes useStreak + useLoyalty + useLeaderboard in parallel.
+ *
+ * cf-zlp
+ */
+
+import { useStreak } from './useStreak';
+import { useLoyalty } from './useLoyalty';
+import { useLeaderboard } from './useLeaderboard';
+import type { LoyaltyTier } from './useLoyalty';
+
+const MILESTONES = [7, 14, 30, 60, 100, 365];
+
+function computeStreakStartDate(streakDays: number): string | null {
+  if (streakDays <= 0) return null;
+  const d = new Date();
+  d.setDate(d.getDate() - (streakDays - 1));
+  return d.toISOString().split('T')[0];
+}
+
+function computeNextMilestone(streakDays: number): number {
+  for (const m of MILESTONES) {
+    if (m > streakDays) return m;
+  }
+  return MILESTONES[MILESTONES.length - 1];
+}
+
+export interface UseGameProfileResult {
+  streakDays: number;
+  streakStartDate: string | null;
+  nextMilestoneDays: number;
+  rank: number | null;
+  totalPoints: number;
+  tier: LoyaltyTier;
+  streakLoading: boolean;
+  rankLoading: boolean;
+  pointsLoading: boolean;
+  error: string | null;
+}
+
+export function useGameProfile(): UseGameProfileResult {
+  const { streak, loading: streakLoading } = useStreak();
+  const { points, tier, loading: pointsLoading, error: pointsError } = useLoyalty();
+  const { currentUserRank, loading: rankLoading, error: rankError } = useLeaderboard();
+
+  return {
+    streakDays: streak,
+    streakStartDate: computeStreakStartDate(streak),
+    nextMilestoneDays: computeNextMilestone(streak),
+    rank: currentUserRank,
+    totalPoints: points,
+    tier,
+    streakLoading,
+    rankLoading,
+    pointsLoading,
+    error: pointsError ?? rankError ?? null,
+  };
+}


### PR DESCRIPTION
## Summary
- **`useGameProfile` hook** — composes `useStreak` + `useLoyalty` + `useLeaderboard` in parallel; surfaces `streakDays`, `streakStartDate`, `nextMilestoneDays`, `rank`, `totalPoints`, `tier`, and per-slice loading flags
- **`GameProfileCard`** — hero widget with 4 chips in a row: streak (🔥, hidden when 0), rank (🏆), points (⭐), tier badge; each chip has tier/brand-color border
- Per-slice loading skeletons — streak/rank/points each show a skeleton independently
- Tap streak → Modal bottom sheet with start date + next milestone target
- `onNavigateToLeaderboard` / `onNavigateToPointsHistory` optional callbacks (safe to omit)

## Test plan
- [x] Root testID renders; accepts custom testID
- [x] Streak chip visible/hidden (streakDays > 0 / === 0)
- [x] Streak loading shows skeleton, hides chip
- [x] Rank and points chips render with correct values
- [x] Rank/points loading skeletons hide values
- [x] Tier badge renders
- [x] Streak sheet opens on tap, shows start date + next milestone, dismisses on close
- [x] Navigation callbacks called on rank/points tap; no-callback taps don't throw
- [x] 25 tests, 0 failures; full suite 353 passed, 0 failures

Closes cf-zlp

🤖 Generated with [Claude Code](https://claude.com/claude-code)