### PR TITLE
feat(cf-7l2): wire LivingSkyBackground into HomeScreen + dynamic tab bar tint

### DIFF
--- a/src/navigation/AnimatedTabBar.tsx
+++ b/src/navigation/AnimatedTabBar.tsx
@@ -66,7 +66,9 @@ function TabButton({
   const { options } = descriptor;
   const label = options.tabBarLabel ?? route.name;
   const badge = options.tabBarBadge;
-  const color = isFocused ? ACTIVE_COLOR : INACTIVE_COLOR;
+  const color = isFocused
+    ? ((options.tabBarActiveTintColor as string) ?? ACTIVE_COLOR)
+    : ((options.tabBarInactiveTintColor as string) ?? INACTIVE_COLOR);
 
   return (
     <Pressable

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -14,6 +14,7 @@ import { useTheme } from '@/theme';
 import { useCart } from '@/hooks/useCart';
 import { useStreak } from '@/hooks/useStreak';
 import { useLoyalty } from '@/hooks/useLoyalty';
+import { useLivingSky } from '@/hooks/useLivingSky';
 import { HomeScreen } from '@/screens/HomeScreen';
 import { ShopScreen } from '@/screens/ShopScreen';
 import { CartScreen } from '@/screens/CartScreen';
@@ -59,6 +60,7 @@ export function TabNavigator() {
   const { itemCount } = useCart();
   const { streak } = useStreak();
   const { tier } = useLoyalty();
+  const skyState = useLivingSky();
 
   return (
     <View style={tabStyles.container}>
@@ -66,8 +68,9 @@ export function TabNavigator() {
         tabBar={(props) => <AnimatedTabBar {...props} />}
         screenOptions={{
           headerShown: false,
-          tabBarActiveTintColor: colors.sunsetCoral,
-          tabBarInactiveTintColor: colors.espressoLight,
+          tabBarActiveTintColor: skyState.navText,
+          tabBarInactiveTintColor: skyState.navText,
+          tabBarStyle: { backgroundColor: skyState.navBg },
         }}
       >
         <Tab.Screen

--- a/src/navigation/__tests__/AnimatedTabBar.test.tsx
+++ b/src/navigation/__tests__/AnimatedTabBar.test.tsx
@@ -41,6 +41,34 @@ jest.mock('expo-blur', () => {
 });
 
 // Build a mock BottomTabBarProps-like state
+function createMockPropsWithTint(activeTint: string, inactiveTint: string, activeIndex = 0) {
+  const routes = [
+    { key: 'Home-1', name: 'Home' },
+    { key: 'Shop-2', name: 'Shop' },
+    { key: 'Cart-3', name: 'Cart' },
+    { key: 'Account-4', name: 'Account' },
+  ];
+  const navigation = {
+    emit: jest.fn(() => ({ defaultPrevented: false })),
+    navigate: jest.fn(),
+  };
+  const descriptors: Record<string, any> = {};
+  routes.forEach((route) => {
+    descriptors[route.key] = {
+      options: {
+        tabBarLabel: route.name,
+        tabBarIcon: ({ focused, color }: any) => (
+          <Text testID={`icon-${route.name}`}>{route.name[0]}</Text>
+        ),
+        tabBarBadge: route.name === 'Cart' ? 2 : undefined,
+        tabBarActiveTintColor: activeTint,
+        tabBarInactiveTintColor: inactiveTint,
+      },
+    };
+  });
+  return { state: { index: activeIndex, routes }, descriptors, navigation } as any;
+}
+
 function createMockProps(activeIndex = 0) {
   const routes = [
     { key: 'Home-1', name: 'Home' },
@@ -122,6 +150,32 @@ describe('AnimatedTabBar', () => {
     const props = createMockProps(0);
     const { getByTestId } = render(<AnimatedTabBar {...props} />);
     expect(getByTestId('tab-bar-blur')).toBeTruthy();
+  });
+
+  describe('dynamic tint from options (cf-7l2)', () => {
+    it('uses tabBarActiveTintColor from options for the focused tab label', () => {
+      const { StyleSheet } = require('react-native');
+      const props = createMockPropsWithTint('#FF0000', '#0000FF', 0); // Home active
+      const { getByText } = render(<AnimatedTabBar {...props} />);
+      const flatStyle = StyleSheet.flatten(getByText('Home').props.style);
+      expect(flatStyle.color).toBe('#FF0000');
+    });
+
+    it('uses tabBarInactiveTintColor from options for unfocused tab labels', () => {
+      const { StyleSheet } = require('react-native');
+      const props = createMockPropsWithTint('#FF0000', '#0000FF', 0);
+      const { getByText } = render(<AnimatedTabBar {...props} />);
+      const flatStyle = StyleSheet.flatten(getByText('Shop').props.style);
+      expect(flatStyle.color).toBe('#0000FF');
+    });
+
+    it('falls back to ACTIVE_COLOR constant when options lack tint colors', () => {
+      const { StyleSheet } = require('react-native');
+      const props = createMockProps(0);
+      const { getByText } = render(<AnimatedTabBar {...props} />);
+      const flatStyle = StyleSheet.flatten(getByText('Home').props.style);
+      expect(flatStyle.color).toBe('#F5F0EB');
+    });
   });
 
   describe('Accessibility', () => {

--- a/src/navigation/__tests__/TabNavigator.test.tsx
+++ b/src/navigation/__tests__/TabNavigator.test.tsx
@@ -13,16 +13,41 @@ import { TabNavigator } from '../TabNavigator';
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
+let mockCapturedScreenOptions: any = null;
+
 jest.mock('@react-navigation/bottom-tabs', () => {
-  const { View, Text, TouchableOpacity } = require('react-native');
+  const { View } = require('react-native');
   const createBottomTabNavigator = () => ({
-    Navigator: ({ children, screenOptions: _so, tabBar: _tb }: any) => (
-      <View testID="tab-navigator">{children}</View>
-    ),
-    Screen: ({ name, component: Comp }: any) => <View testID={`tab-screen-${name}`} />,
+    Navigator: ({ children, screenOptions, tabBar: _tb }: any) => {
+      mockCapturedScreenOptions = screenOptions;
+      return <View testID="tab-navigator">{children}</View>;
+    },
+    Screen: ({ name }: any) => <View testID={`tab-screen-${name}`} />,
   });
   return { createBottomTabNavigator };
 });
+
+jest.mock('@/hooks/useLivingSky', () => ({
+  useLivingSky: () => ({
+    navBg: '#0A0F1C',
+    navText: '#8BAFC8',
+    skyColors: ['#050810', '#080D1C', '#0D1628', '#141E30'] as [string, string, string, string],
+    glowColors: ['transparent', 'transparent'] as [string, string],
+    ridgeColors: { r1: '#0C1838', r2: '#162850', r3: '#283860', r4: '#3C4E6A', tree: '#080E1E' },
+    sunPos: { cx: 520, cy: 220, r: 14, opacity: 0 },
+    moonPos: { cx: 200, cy: 200, opacity: 1, phase: 0, shadowOffset: { dx: 0, dy: 0 } },
+    starOpacity: 0.9,
+    cloudOpacity: 0,
+    birdOpacity: 0,
+    fireflyOpacity: 0.55,
+    owlOpacity: 0.9,
+    rimOpacity: 0.12,
+    rimColor: '#4A6E8A',
+    season: 'winter' as const,
+    precipitationOpacity: 0.5,
+    precipitationType: 'snow' as const,
+  }),
+}));
 
 jest.mock('../AnimatedTabBar', () => ({ AnimatedTabBar: () => null }));
 jest.mock('../withScreenErrorBoundary', () => ({
@@ -68,6 +93,7 @@ function renderTabs() {
 
 beforeEach(() => {
   jest.clearAllMocks();
+  mockCapturedScreenOptions = null;
   mockUseCart.mockReturnValue({ itemCount: 2, items: [], subtotal: 0 });
 });
 
@@ -83,5 +109,22 @@ describe('TabNavigator — structure', () => {
   it('does not render CartFAB — it lives in MiniCartDrawerHost (cm-377)', () => {
     const { queryByTestId } = renderTabs();
     expect(queryByTestId('cart-fab')).toBeNull();
+  });
+});
+
+describe('TabNavigator — living sky tint (cf-7l2)', () => {
+  it('sets tabBarActiveTintColor from skyState.navText', () => {
+    renderTabs();
+    expect(mockCapturedScreenOptions?.tabBarActiveTintColor).toBe('#8BAFC8');
+  });
+
+  it('sets tabBarInactiveTintColor from skyState.navText', () => {
+    renderTabs();
+    expect(mockCapturedScreenOptions?.tabBarInactiveTintColor).toBe('#8BAFC8');
+  });
+
+  it('sets tabBarStyle.backgroundColor from skyState.navBg', () => {
+    renderTabs();
+    expect(mockCapturedScreenOptions?.tabBarStyle?.backgroundColor).toBe('#0A0F1C');
   });
 });

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -10,7 +10,7 @@
  * users into the two main engagement paths.
  */
 
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 import { StyleSheet, Text, View, ScrollView, Dimensions, Pressable, Platform } from 'react-native';
 import { StreakBadge } from '@/components/StreakBadge';
 import { useStreak } from '@/hooks/useStreak';
@@ -24,6 +24,7 @@ import { GlassCard } from '@/components/GlassCard';
 import { CollectionCard } from '@/components/CollectionCard';
 import { SkeletonCarouselRow } from '@/components/SkeletonCarouselItem';
 import { MountainSkyline } from '@/components/MountainSkyline';
+import { LivingSkyBackground } from '@/components/LivingSkyBackground';
 import { LivingSkyMountainSkyline } from '@/components/LivingSkyMountainSkyline';
 import { useLivingSky } from '@/hooks/useLivingSky';
 import { PromoBannerCarousel } from '@/components/PromoBannerCarousel';
@@ -78,6 +79,14 @@ export function HomeScreen({ onOpenAR, onOpenShop, onCollectionPress }: Props) {
   const { triggers, dismiss } = useTriggerMoments();
   const skyState = useLivingSky();
 
+  // cf-7l2 — propagate sky nav colours to navigator options (e.g. for status bar theming)
+  useEffect(() => {
+    navigation.setOptions?.({
+      headerStyle: { backgroundColor: skyState.navBg },
+      headerTintColor: skyState.navText,
+    });
+  }, [skyState.navBg, skyState.navText, navigation]);
+
   const handleOpenAR = useCallback(() => {
     if (Platform.OS !== 'web') {
       Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
@@ -115,6 +124,8 @@ export function HomeScreen({ onOpenAR, onOpenShop, onCollectionPress }: Props) {
 
   return (
     <View style={styles.root}>
+      {/* cf-7l2 — full-screen sky gradient, absolute behind all content */}
+      <LivingSkyBackground />
       <ScrollView
         style={[styles.container, { backgroundColor: colors.sandBase }]}
         contentContainerStyle={[

--- a/src/screens/__tests__/HomeScreen.test.tsx
+++ b/src/screens/__tests__/HomeScreen.test.tsx
@@ -4,6 +4,11 @@ import { NavigationContainer } from '@react-navigation/native';
 import { HomeScreen } from '../HomeScreen';
 import { ThemeProvider } from '@/theme/ThemeProvider';
 
+jest.mock('@/components/LivingSkyBackground', () => {
+  const { View } = require('react-native');
+  return { LivingSkyBackground: () => <View testID="living-sky-background" /> };
+});
+
 jest.mock('@/hooks/useLivingSky', () => ({
   useLivingSky: () => ({
     skyColors: ['#2858A0', '#4878A8', '#88B0C4', '#A4C8DC'] as [string, string, string, string],
@@ -439,5 +444,29 @@ describe('HomeScreen', () => {
   it('imports LivingSkyMountainSkyline without crashing', () => {
     const mod = require('../../components/LivingSkyMountainSkyline');
     expect(mod.LivingSkyMountainSkyline).toBeDefined();
+  });
+
+  // cf-7l2 — LivingSkyBackground integration
+  describe('LivingSkyBackground integration (cf-7l2)', () => {
+    it('renders LivingSkyBackground behind screen content', () => {
+      const { getByTestId } = renderHomeScreen();
+      expect(getByTestId('living-sky-background')).toBeTruthy();
+    });
+
+    it('calls navigation.setOptions with navBg and navText from sky state', () => {
+      const mockSetOptions = jest.fn();
+      jest.spyOn(require('@react-navigation/native'), 'useNavigation').mockReturnValue({
+        navigate: jest.fn(),
+        setOptions: mockSetOptions,
+      });
+      renderHomeScreen();
+      expect(mockSetOptions).toHaveBeenCalledWith(
+        expect.objectContaining({
+          headerStyle: expect.objectContaining({ backgroundColor: '#ffffff' }),
+          headerTintColor: '#1E2A3A',
+        }),
+      );
+      jest.restoreAllMocks();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Renders `LivingSkyBackground` behind all HomeScreen content (absolute-positioned, z-index -1, driven by `useLivingSky`)
- HomeScreen propagates `navBg`/`navText` from sky state to `navigation.setOptions` via `useEffect`
- `TabNavigator` subscribes to `useLivingSky` and passes `navBg`/`navText` to `tabBarStyle.backgroundColor`, `tabBarActiveTintColor`, `tabBarInactiveTintColor` in `screenOptions`
- `AnimatedTabBar` reads tint colors from `descriptor.options` (falling back to hardcoded constants) so the sky-driven colors actually render on tab labels and icons

## Test plan

- [ ] 2 new tests in `HomeScreen.test.tsx` — LivingSkyBackground renders, setOptions called with navBg/navText
- [ ] 3 new tests in `TabNavigator.test.tsx` — screenOptions receive navBg/navText from useLivingSky
- [ ] 3 new tests in `AnimatedTabBar.test.tsx` — dynamic tint colors from options, fallback to constants
- [ ] All 51 affected tests pass (`HomeScreen.test`, `TabNavigator.test`, `AnimatedTabBar.test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)