### PR TITLE
fix(hq-00y93): tree canopy fill — #4A7C59 web alignment

### DIFF
--- a/src/components/MountainSkyline.tsx
+++ b/src/components/MountainSkyline.tsx
@@ -171,7 +171,7 @@ export function MountainSkyline({
               <Path
                 key={`canopy-${i}-${j}`}
                 d={canopy.path}
-                fill={colors.treeDark}
+                fill={colors.treeFill}
                 opacity={canopy.opacity}
               />
             ))}

--- a/src/components/__tests__/MountainSkyline.test.tsx
+++ b/src/components/__tests__/MountainSkyline.test.tsx
@@ -48,17 +48,21 @@ describe('MountainSkyline', () => {
     expect(colors.espresso).toBe('#3A2518');
   });
 
-  it('treeDark token is forest dark green #2E4A38', () => {
+  it('treeDark token is dark linework #2E4A38', () => {
     expect(colors.treeDark).toBe('#2E4A38');
   });
 
-  it('tree fill uses forest dark green (#2E4A38)', () => {
+  it('treeFill token is forest green #4A7C59', () => {
+    expect(colors.treeFill).toBe('#4A7C59');
+  });
+
+  it('tree canopy fill uses forest green (#4A7C59)', () => {
     const { toJSON } = render(<MountainSkyline testID="skyline-tree-color" showDetails />, {
       wrapper,
     });
     const json = JSON.stringify(toJSON());
-    // Trees (trunk Rect + canopy Path) should render with forest dark green
-    expect(json).toContain('"fill":"#2E4A38"');
+    // Canopy paths should use treeFill (forest green), trunk stays treeDark
+    expect(json).toContain('"fill":"#4A7C59"');
   });
 
   it('renders 7 mountain layers', () => {

--- a/src/theme/tokens.ts
+++ b/src/theme/tokens.ts
@@ -61,7 +61,9 @@ export const colors = {
   // --- Decorative gradients ---
   skyGradientTop: '#B8D4E3',
   skyGradientBottom: '#F0C87A',
-  /** Forest dark green for pine tree illustration fills — matches web mountain-skyline-figma.svg */
+  /** Primary canopy fill — matches web #4A7C59 (forest green) */
+  treeFill: '#4A7C59',
+  /** Dark linework/shadow/trunk outlines — matches web #2E4A38 */
   treeDark: '#2E4A38',
 
   // --- Neutrals ---


### PR DESCRIPTION
## Summary
- Add `treeFill: #4A7C59` token for primary canopy fill (matches web forest green)
- `treeDark: #2E4A38` stays for trunk/shadow linework
- MountainSkyline canopy Path uses treeFill, trunk Rect stays treeDark
- Confirmed by melania (definitive answer hq-wisp-bzh9)

## Test plan
- [x] 36 MountainSkyline tests pass
- [x] New test: treeFill token = #4A7C59
- [x] Updated test: canopy fill uses #4A7C59

🤖 Generated with [Claude Code](https://claude.com/claude-code)