### PR TITLE
feat(cf-7l2): wire LivingSkyBackground into HomeScreen + tab bar tint

### DIFF
--- a/src/navigation/AnimatedTabBar.tsx
+++ b/src/navigation/AnimatedTabBar.tsx
@@ -24,11 +24,13 @@ function TabButton({
   descriptor,
   isFocused,
   navigation,
+  activeColor,
 }: {
   route: { key: string; name: string };
   descriptor: any;
   isFocused: boolean;
   navigation: any;
+  activeColor?: string;
 }) {
   const reduceMotion = useReducedMotion();
   const scale = useSharedValue(1);
@@ -66,7 +68,7 @@ function TabButton({
   const { options } = descriptor;
   const label = options.tabBarLabel ?? route.name;
   const badge = options.tabBarBadge;
-  const color = isFocused ? ACTIVE_COLOR : INACTIVE_COLOR;
+  const color = isFocused ? (activeColor ?? ACTIVE_COLOR) : INACTIVE_COLOR;
 
   return (
     <Pressable
@@ -95,7 +97,13 @@ function TabButton({
 }
 
 /** Custom tab bar rendered by the BottomTabNavigator; safe-area aware. */
-export function AnimatedTabBar({ state, descriptors, navigation }: BottomTabBarProps) {
+export function AnimatedTabBar({
+  state,
+  descriptors,
+  navigation,
+  navBg,
+  navText,
+}: BottomTabBarProps & { navBg?: string; navText?: string }) {
   const insets = useSafeAreaInsets();
 
   return (
@@ -103,7 +111,11 @@ export function AnimatedTabBar({ state, descriptors, navigation }: BottomTabBarP
       testID="tab-bar-blur"
       intensity={40}
       tint="dark"
-      style={[styles.blurContainer, { paddingBottom: insets.bottom || 8 }]}
+      style={[
+        styles.blurContainer,
+        { paddingBottom: insets.bottom || 8 },
+        navBg != null ? { backgroundColor: navBg } : null,
+      ]}
     >
       <View testID="animated-tab-bar" style={styles.container}>
         {state.routes.map((route, index) => (
@@ -113,6 +125,7 @@ export function AnimatedTabBar({ state, descriptors, navigation }: BottomTabBarP
             descriptor={descriptors[route.key]}
             isFocused={state.index === index}
             navigation={navigation}
+            activeColor={navText}
           />
         ))}
       </View>

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -20,6 +20,7 @@ import { CartScreen } from '@/screens/CartScreen';
 import { AccountScreen } from '@/screens/AccountScreen';
 import { CompareFAB } from '@/components/CompareFAB';
 import { AnimatedTabBar } from './AnimatedTabBar';
+import { useLivingSky } from '@/hooks/useLivingSky';
 import { withScreenErrorBoundary } from './withScreenErrorBoundary';
 import { HomeTabIcon, ShopTabIcon, CartTabIcon, AccountTabIcon } from './TabIcons';
 import type { RootStackParamList } from './AppNavigator';
@@ -59,11 +60,12 @@ export function TabNavigator() {
   const { itemCount } = useCart();
   const { streak } = useStreak();
   const { tier } = useLoyalty();
+  const { navBg, navText } = useLivingSky();
 
   return (
     <View style={tabStyles.container}>
       <Tab.Navigator
-        tabBar={(props) => <AnimatedTabBar {...props} />}
+        tabBar={(props) => <AnimatedTabBar {...props} navBg={navBg} navText={navText} />}
         screenOptions={{
           headerShown: false,
           tabBarActiveTintColor: colors.sunsetCoral,

--- a/src/navigation/__tests__/TabNavigator.test.tsx
+++ b/src/navigation/__tests__/TabNavigator.test.tsx
@@ -10,21 +10,53 @@ import { render } from '@testing-library/react-native';
 import { NavigationContainer } from '@react-navigation/native';
 import { ThemeProvider } from '@/theme/ThemeProvider';
 import { TabNavigator } from '../TabNavigator';
+import { AnimatedTabBar } from '../AnimatedTabBar';
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
 jest.mock('@react-navigation/bottom-tabs', () => {
-  const { View, Text, TouchableOpacity } = require('react-native');
+  const { View } = require('react-native');
   const createBottomTabNavigator = () => ({
-    Navigator: ({ children, screenOptions: _so, tabBar: _tb }: any) => (
-      <View testID="tab-navigator">{children}</View>
+    Navigator: ({ children, screenOptions: _so, tabBar: TabBarComponent }: any) => (
+      <View testID="tab-navigator">
+        {TabBarComponent && (
+          <TabBarComponent
+            state={{ routes: [], index: 0 }}
+            descriptors={{}}
+            navigation={{ emit: jest.fn(), navigate: jest.fn() }}
+          />
+        )}
+        {children}
+      </View>
     ),
-    Screen: ({ name, component: Comp }: any) => <View testID={`tab-screen-${name}`} />,
+    Screen: ({ name }: any) => <View testID={`tab-screen-${name}`} />,
   });
   return { createBottomTabNavigator };
 });
 
-jest.mock('../AnimatedTabBar', () => ({ AnimatedTabBar: () => null }));
+jest.mock('../AnimatedTabBar', () => ({ AnimatedTabBar: jest.fn(() => null) }));
+
+jest.mock('@/hooks/useLivingSky', () => ({
+  useLivingSky: jest.fn(() => ({
+    skyColors: ['#0A0F1C', '#0C1628', '#101E2E', '#141E2C'] as [string, string, string, string],
+    glowColors: ['transparent', 'transparent'] as [string, string],
+    ridgeColors: { r1: '#0C1838', r2: '#162850', r3: '#283860', r4: '#3C4E6A', tree: '#080E1E' },
+    sunPos: { cx: 524, cy: 52, r: 16, opacity: 0 },
+    moonPos: { cx: 100, cy: 100, opacity: 1, phase: 0, shadowOffset: { dx: 0, dy: 0 } },
+    starOpacity: 1,
+    cloudOpacity: 0,
+    birdOpacity: 0,
+    fireflyOpacity: 0,
+    owlOpacity: 0,
+    rimOpacity: 0,
+    rimColor: '#FFFCE8',
+    navBg: '#0A0F1C',
+    navText: '#8BAFC8',
+    season: 'winter' as const,
+    precipitationOpacity: 0,
+    precipitationType: 'none' as const,
+  })),
+}));
 jest.mock('../withScreenErrorBoundary', () => ({
   withScreenErrorBoundary: (C: any) => C,
 }));
@@ -69,6 +101,26 @@ function renderTabs() {
 beforeEach(() => {
   jest.clearAllMocks();
   mockUseCart.mockReturnValue({ itemCount: 2, items: [], subtotal: 0 });
+});
+
+const mockAnimatedTabBar = AnimatedTabBar as jest.Mock;
+
+describe('TabNavigator — living sky tint (cf-7l2)', () => {
+  it('passes navBg from useLivingSky to AnimatedTabBar', () => {
+    renderTabs();
+    expect(mockAnimatedTabBar).toHaveBeenCalledWith(
+      expect.objectContaining({ navBg: '#0A0F1C' }),
+      expect.anything(),
+    );
+  });
+
+  it('passes navText from useLivingSky to AnimatedTabBar', () => {
+    renderTabs();
+    expect(mockAnimatedTabBar).toHaveBeenCalledWith(
+      expect.objectContaining({ navText: '#8BAFC8' }),
+      expect.anything(),
+    );
+  });
 });
 
 describe('TabNavigator — structure', () => {

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -25,6 +25,7 @@ import { CollectionCard } from '@/components/CollectionCard';
 import { SkeletonCarouselRow } from '@/components/SkeletonCarouselItem';
 import { MountainSkyline } from '@/components/MountainSkyline';
 import { LivingSkyMountainSkyline } from '@/components/LivingSkyMountainSkyline';
+import { LivingSkyBackground } from '@/components/LivingSkyBackground';
 import { useLivingSky } from '@/hooks/useLivingSky';
 import { PromoBannerCarousel } from '@/components/PromoBannerCarousel';
 import { useCollections } from '@/hooks/useCollections';
@@ -115,6 +116,7 @@ export function HomeScreen({ onOpenAR, onOpenShop, onCollectionPress }: Props) {
 
   return (
     <View style={styles.root}>
+      <LivingSkyBackground />
       <ScrollView
         style={[styles.container, { backgroundColor: colors.sandBase }]}
         contentContainerStyle={[

--- a/src/screens/__tests__/HomeScreen.test.tsx
+++ b/src/screens/__tests__/HomeScreen.test.tsx
@@ -440,4 +440,10 @@ describe('HomeScreen', () => {
     const mod = require('../../components/LivingSkyMountainSkyline');
     expect(mod.LivingSkyMountainSkyline).toBeDefined();
   });
+
+  // cf-7l2 — LivingSkyBackground wired into HomeScreen
+  it('renders LivingSkyBackground', () => {
+    const { getByTestId } = renderHomeScreen();
+    expect(getByTestId('living-sky-background')).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- `LivingSkyBackground` rendered as first child of `HomeScreen` root View (absolute, zIndex -1)
- `TabNavigator` reads `navBg`/`navText` from `useLivingSky()` and passes to `AnimatedTabBar`
- `AnimatedTabBar` accepts optional `navBg`/`navText` props — `navBg` overrides glass background color, `navText` drives active tab icon/label color

## Test plan
- [x] New test: `HomeScreen` renders element with testID `living-sky-background`
- [x] New test: `TabNavigator` passes `navBg` from `useLivingSky` to `AnimatedTabBar`
- [x] New test: `TabNavigator` passes `navText` from `useLivingSky` to `AnimatedTabBar`
- [x] All 10 existing `AnimatedTabBar` tests pass unchanged
- [x] Full suite: 359 suites, 6272 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)