### PR TITLE
feat(hq-paclo): streak multiplier always visible in AccountScreen header

### DIFF
--- a/src/components/StreakBadge.tsx
+++ b/src/components/StreakBadge.tsx
@@ -15,12 +15,14 @@ interface Props {
   /** Number of consecutive days in the current streak. */
   streak: number;
   testID?: string;
+  /** Force-show the 1× multiplier chip even when streak is below the threshold. */
+  showBaseMultiplier?: boolean;
 }
 
-export function StreakBadge({ streak, testID }: Props) {
+export function StreakBadge({ streak, testID, showBaseMultiplier }: Props) {
   const { colors, borderRadius } = useTheme();
   const multiplier = getStreakMultiplier(streak);
-  const showMultiplier = multiplier > 1;
+  const showMultiplier = multiplier > 1 || showBaseMultiplier === true;
 
   return (
     <View

--- a/src/components/__tests__/StreakBadge.test.tsx
+++ b/src/components/__tests__/StreakBadge.test.tsx
@@ -9,10 +9,10 @@ import { render } from '@testing-library/react-native';
 import { StreakBadge } from '../StreakBadge';
 import { ThemeProvider } from '@/theme/ThemeProvider';
 
-function renderBadge(streak: number, testID?: string) {
+function renderBadge(streak: number, testID?: string, showBaseMultiplier?: boolean) {
   return render(
     <ThemeProvider>
-      <StreakBadge streak={streak} testID={testID} />
+      <StreakBadge streak={streak} testID={testID} showBaseMultiplier={showBaseMultiplier} />
     </ThemeProvider>,
   );
 }
@@ -98,5 +98,28 @@ describe('StreakBadge', () => {
     const { getByTestId } = renderBadge(7);
     const badge = getByTestId('streak-badge');
     expect(badge.props.accessibilityLabel).toMatch(/2×.*points/);
+  });
+
+  // ── showBaseMultiplier prop (hq-paclo) ────────────────────────────
+
+  it('shows "1×" chip when showBaseMultiplier=true and streak < 3', () => {
+    const { getByTestId } = renderBadge(2, undefined, true);
+    expect(getByTestId('streak-multiplier')).toBeTruthy();
+  });
+
+  it('shows "1×" text when showBaseMultiplier=true and streak = 0', () => {
+    const { getByText } = renderBadge(0, undefined, true);
+    expect(getByText('1×')).toBeTruthy();
+  });
+
+  it('still hides multiplier chip for base streak without showBaseMultiplier', () => {
+    const { queryByTestId } = renderBadge(2);
+    expect(queryByTestId('streak-multiplier')).toBeNull();
+  });
+
+  it('includes 1× in accessibility label when showBaseMultiplier=true', () => {
+    const { getByTestId } = renderBadge(1, undefined, true);
+    const badge = getByTestId('streak-badge');
+    expect(badge.props.accessibilityLabel).toMatch(/1×.*points/);
   });
 });

--- a/src/screens/AccountScreen.tsx
+++ b/src/screens/AccountScreen.tsx
@@ -340,8 +340,8 @@ export function AccountScreen({
                 activeOpacity={0.7}
               >
                 <LoyaltyTierBadge points={loyalty.points} />
-                {!streakLoading && streak > 0 && (
-                  <StreakBadge streak={streak} testID="account-streak-badge" />
+                {!streakLoading && (
+                  <StreakBadge streak={streak} testID="account-streak-badge" showBaseMultiplier />
                 )}
                 <TierProgressBar points={loyalty.points} testID="account-tier-progress" />
               </TouchableOpacity>

--- a/src/screens/__tests__/AccountScreen.test.tsx
+++ b/src/screens/__tests__/AccountScreen.test.tsx
@@ -131,6 +131,11 @@ jest.mock('@/hooks/useLoyalty', () => ({
   }),
 }));
 
+const mockUseStreak = jest.fn();
+jest.mock('@/hooks/useStreak', () => ({
+  useStreak: () => mockUseStreak(),
+}));
+
 jest.mock('@/hooks/useReferral', () => ({
   useReferral: () => ({
     code: null,
@@ -205,6 +210,7 @@ describe('AccountScreen', () => {
     };
     mockBiometricAuth.isEnabled = false;
     mockBiometricAuth.loading = false;
+    mockUseStreak.mockReturnValue({ streak: 0, loading: false });
   });
 
   describe('Guest state', () => {
@@ -1204,6 +1210,36 @@ describe('AccountScreen', () => {
       await waitFor(() => expect(getByTestId('address-form')).toBeTruthy());
       fireEvent.press(getByTestId('address-cancel-button'));
       await waitFor(() => expect(queryByTestId('address-form')).toBeNull());
+    });
+  });
+
+  // ── Streak multiplier in header (hq-paclo) ────────────────────────
+  describe('Streak multiplier display (hq-paclo)', () => {
+    it('shows streak badge with 1× multiplier when streak is 0', async () => {
+      mockUseStreak.mockReturnValue({ streak: 0, loading: false });
+      const { getByTestId } = renderAccount({}, true);
+      await waitFor(() => {
+        expect(getByTestId('account-streak-badge')).toBeTruthy();
+        expect(getByTestId('streak-multiplier')).toBeTruthy();
+      });
+    });
+
+    it('shows 1.5× multiplier chip when streak is 3 days', async () => {
+      mockUseStreak.mockReturnValue({ streak: 3, loading: false });
+      const { getByText } = renderAccount({}, true);
+      await waitFor(() => expect(getByText('1.5×')).toBeTruthy());
+    });
+
+    it('shows 2× multiplier chip when streak is 7 days', async () => {
+      mockUseStreak.mockReturnValue({ streak: 7, loading: false });
+      const { getByText } = renderAccount({}, true);
+      await waitFor(() => expect(getByText('2×')).toBeTruthy());
+    });
+
+    it('hides streak badge while streak is loading', async () => {
+      mockUseStreak.mockReturnValue({ streak: 0, loading: true });
+      const { queryByTestId } = renderAccount({}, true);
+      await waitFor(() => expect(queryByTestId('account-streak-badge')).toBeNull());
     });
   });
 });


### PR DESCRIPTION
## Summary
- `StreakBadge`: added `showBaseMultiplier?: boolean` prop — when true, forces the multiplier chip visible even at the 1× base tier
- `AccountScreen`: removed `streak > 0` guard; always renders `StreakBadge` with `showBaseMultiplier` so the multiplier (1×/1.5×/2×) is always shown in the profile header

## Behavior
| Streak | Before | After |
|--------|--------|-------|
| 0 days | badge hidden | 🔥 0 day streak **1×** |
| 2 days | badge shown, no multiplier | 🔥 2 day streak **1×** |
| 3 days | 🔥 3 day streak **1.5×** | unchanged |
| 7 days | 🔥 7 day streak **2×** | unchanged |

## Test plan
- [x] `StreakBadge`: `showBaseMultiplier=true` shows 1× chip for streak=0 and streak=2
- [x] `StreakBadge`: default behavior unchanged (no chip for streak=2 without prop)
- [x] `AccountScreen`: shows multiplier at 0/3/7 days, hidden while loading
- [x] Full suite: 363 suites, 6392 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)