### PR TITLE
feat(hq-elfso): wire ChallengesScreen into navigation from AccountScreen

### DIFF
--- a/src/navigation/AppNavigator.tsx
+++ b/src/navigation/AppNavigator.tsx
@@ -169,6 +169,11 @@ const AvatarEquipScreen = lazy(() =>
     default: withScreenErrorBoundary(m.AvatarEquipScreen, 'AvatarEquip'),
   })),
 );
+const ChallengesScreen = lazy(() =>
+  import('@/screens/ChallengesScreen').then((m) => ({
+    default: withScreenErrorBoundary(m.ChallengesScreen, 'Challenges'),
+  })),
+);
 
 function LazyFallback() {
   return (
@@ -216,6 +221,7 @@ export type RootStackParamList = {
   Loyalty: undefined;
   Leaderboard: undefined;
   AvatarEquip: undefined;
+  Challenges: undefined;
   ReferralLanding: { code: string };
 };
 
@@ -483,6 +489,7 @@ export function AppNavigator() {
             component={AvatarEquipScreen}
             options={{ title: 'Customize Avatar', ...modalTransition }}
           />
+          <Stack.Screen name="Challenges" component={ChallengesScreen} options={fadeTransition} />
           <Stack.Screen name="ReferralLanding" component={ReferralLandingScreen} />
         </Stack.Navigator>
       </Suspense>

--- a/src/navigation/TabNavigator.tsx
+++ b/src/navigation/TabNavigator.tsx
@@ -48,6 +48,7 @@ function AccountScreenWithNav() {
       onStyleQuiz={() => nav.navigate('StyleQuiz')}
       onPrivacyPolicy={() => nav.navigate('PrivacyPolicy')}
       onLeaderboard={() => nav.navigate('Leaderboard')}
+      onChallenges={() => nav.navigate('Challenges')}
     />
   );
 }

--- a/src/screens/AccountScreen.tsx
+++ b/src/screens/AccountScreen.tsx
@@ -63,6 +63,8 @@ interface Props {
   onLoyalty?: () => void;
   /** Callback to navigate to the loyalty leaderboard screen. */
   onLeaderboard?: () => void;
+  /** Callback to navigate to the challenges screen. */
+  onChallenges?: () => void;
   /** Test identifier for end-to-end tests. */
   testID?: string;
 }
@@ -82,6 +84,7 @@ export function AccountScreen({
   onPrivacyPolicy,
   onLoyalty,
   onLeaderboard,
+  onChallenges,
   testID,
 }: Props) {
   const { colors, spacing, borderRadius, shadows, typography } = useTheme();
@@ -518,6 +521,14 @@ export function AccountScreen({
             borderRadius={borderRadius}
             shadows={shadows}
             testID="account-leaderboard"
+          />
+          <MenuItem
+            label="Challenges"
+            onPress={onChallenges}
+            colors={colors}
+            borderRadius={borderRadius}
+            shadows={shadows}
+            testID="account-challenges"
           />
           <MenuItem
             label={`Saved Addresses${addressBook.addresses.length > 0 ? ` (${addressBook.addresses.length})` : ''}`}

--- a/src/screens/__tests__/AccountScreen.test.tsx
+++ b/src/screens/__tests__/AccountScreen.test.tsx
@@ -1242,4 +1242,21 @@ describe('AccountScreen', () => {
       await waitFor(() => expect(queryByTestId('account-streak-badge')).toBeNull());
     });
   });
+
+  // ── Challenges navigation (hq-elfso) ─────────────────────────────────────
+
+  describe('Challenges navigation', () => {
+    it('shows Challenges menu item when authenticated', async () => {
+      const { getByTestId } = renderAccount({}, true);
+      await waitFor(() => expect(getByTestId('account-challenges')).toBeTruthy());
+    });
+
+    it('calls onChallenges when Challenges menu item is pressed', async () => {
+      const onChallenges = jest.fn();
+      const { getByTestId } = renderAccount({ onChallenges }, true);
+      await waitFor(() => expect(getByTestId('account-challenges')).toBeTruthy());
+      fireEvent.press(getByTestId('account-challenges'));
+      expect(onChallenges).toHaveBeenCalledTimes(1);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Registers `ChallengesScreen` as a named route (`Challenges`) in `AppNavigator` with lazy-loading and fade transition
- Adds `onChallenges?` prop to `AccountScreen` with a "Challenges" menu item between Leaderboard and Saved Addresses
- Wires `onChallenges={() => nav.navigate('Challenges')}` in `TabNavigator`'s `AccountScreenWithNav`

Closes hq-elfso.

## Test plan

- [x] `AccountScreen` shows "Challenges" menu item when authenticated (`testID="account-challenges"`)
- [x] Pressing "Challenges" calls `onChallenges` callback
- [x] All existing `AccountScreen` tests pass (118 total)
- [x] `ChallengesScreen` tests unchanged and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)