### PR TITLE
fix(hq-gbo6f): safe area bottom inset for BadgeToast and PointsToast

### DIFF
--- a/src/components/BadgeToast.tsx
+++ b/src/components/BadgeToast.tsx
@@ -10,6 +10,7 @@
  */
 import React, { useEffect } from 'react';
 import { AccessibilityInfo, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -29,6 +30,7 @@ interface Props {
 
 export function BadgeToast({ badgeName, visible, testID }: Props) {
   const { colors, borderRadius } = useTheme();
+  const insets = useSafeAreaInsets();
 
   const opacity = useSharedValue(0);
   const translateY = useSharedValue(0);
@@ -65,7 +67,7 @@ export function BadgeToast({ badgeName, visible, testID }: Props) {
 
   return (
     <Animated.View
-      style={[styles.container, animatedStyle]}
+      style={[styles.container, { bottom: 120 + insets.bottom }, animatedStyle]}
       testID={testID ?? 'badge-toast'}
       accessibilityLabel={`Badge Unlocked: ${badgeName}`}
       accessibilityElementsHidden={!visible}

--- a/src/components/PointsToast.tsx
+++ b/src/components/PointsToast.tsx
@@ -11,6 +11,7 @@
 
 import React, { useEffect } from 'react';
 import { AccessibilityInfo, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -30,6 +31,7 @@ interface Props {
 
 export function PointsToast({ points, visible, testID }: Props) {
   const { colors, borderRadius } = useTheme();
+  const insets = useSafeAreaInsets();
 
   const opacity = useSharedValue(0);
   const translateY = useSharedValue(0);
@@ -66,7 +68,7 @@ export function PointsToast({ points, visible, testID }: Props) {
 
   return (
     <Animated.View
-      style={[styles.container, animatedStyle]}
+      style={[styles.container, { bottom: 100 + insets.bottom }, animatedStyle]}
       testID={testID ?? 'points-toast'}
       accessibilityLabel={`${points} points earned`}
       accessibilityElementsHidden={!visible}

--- a/src/components/__tests__/BadgeToast.test.tsx
+++ b/src/components/__tests__/BadgeToast.test.tsx
@@ -3,9 +3,15 @@
  * TDD tests for the BadgeToast component — hq-v0a2z.
  */
 import React from 'react';
+import { StyleSheet } from 'react-native';
 import { render } from '@testing-library/react-native';
 import { ThemeProvider } from '@/theme/ThemeProvider';
 import { BadgeToast } from '../BadgeToast';
+
+const mockInsets = { top: 0, right: 0, bottom: 0, left: 0 };
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => mockInsets,
+}));
 
 function renderToast(props: { badgeName: string; visible: boolean; testID?: string }) {
   return render(
@@ -73,6 +79,26 @@ describe('BadgeToast', () => {
         getByTestId('badge-toast', { includeHiddenElements: true }).props
           .accessibilityElementsHidden,
       ).toBe(true);
+    });
+  });
+
+  describe('safe area insets (hq-gbo6f)', () => {
+    beforeEach(() => {
+      mockInsets.bottom = 0;
+    });
+
+    it('adds safe area inset to bottom position (non-zero inset)', () => {
+      mockInsets.bottom = 34;
+      const { getByTestId } = renderToast({ badgeName: 'Explorer Badge', visible: true });
+      const flatStyle = StyleSheet.flatten(getByTestId('badge-toast').props.style);
+      expect(flatStyle.bottom).toBe(154);
+    });
+
+    it('uses base bottom (120) when safe area inset is zero', () => {
+      mockInsets.bottom = 0;
+      const { getByTestId } = renderToast({ badgeName: 'Explorer Badge', visible: true });
+      const flatStyle = StyleSheet.flatten(getByTestId('badge-toast').props.style);
+      expect(flatStyle.bottom).toBe(120);
     });
   });
 

--- a/src/components/__tests__/PointsToast.test.tsx
+++ b/src/components/__tests__/PointsToast.test.tsx
@@ -5,10 +5,15 @@
  */
 
 import React from 'react';
-import { AccessibilityInfo } from 'react-native';
+import { AccessibilityInfo, StyleSheet } from 'react-native';
 import { render } from '@testing-library/react-native';
 import { PointsToast } from '../PointsToast';
 import { ThemeProvider } from '@/theme/ThemeProvider';
+
+const mockInsets = { top: 0, right: 0, bottom: 0, left: 0 };
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => mockInsets,
+}));
 
 // Mock reanimated — animation mechanics not under test
 jest.mock('react-native-reanimated', () => {
@@ -92,6 +97,26 @@ describe('PointsToast', () => {
   it('renders with large point value (10000)', () => {
     const { getByText } = renderToast({ points: 10000, visible: true });
     expect(getByText(/\+10000/)).toBeTruthy();
+  });
+
+  // ── Safe area insets (hq-gbo6f) ───────────────────────────────────
+
+  beforeEach(() => {
+    mockInsets.bottom = 0;
+  });
+
+  it('adds safe area inset to bottom position (non-zero inset)', () => {
+    mockInsets.bottom = 34;
+    const { getByTestId } = renderToast({ points: 100, visible: true });
+    const flatStyle = StyleSheet.flatten(getByTestId('points-toast').props.style);
+    expect(flatStyle.bottom).toBe(134);
+  });
+
+  it('uses base bottom (100) when safe area inset is zero', () => {
+    mockInsets.bottom = 0;
+    const { getByTestId } = renderToast({ points: 100, visible: true });
+    const flatStyle = StyleSheet.flatten(getByTestId('points-toast').props.style);
+    expect(flatStyle.bottom).toBe(100);
   });
 
   // cm-jest-coverage: reducedMotion === true branch (lines 46-47)


### PR DESCRIPTION
## Summary

- `BadgeToast` and `PointsToast` had hardcoded `bottom` positions (120/100) that clipped on devices with a home indicator (iPhone X+)
- Add `useSafeAreaInsets().bottom` inline override, matching the pattern already used in `ChallengeCompletedToast` and `TierUpgradeToast`

## Test plan

- [ ] 2 new safe-area inset tests per component (4 total)
- [ ] Full suite: 348 suites pass, 0 regressions

Bead: hq-gbo6f

🤖 Generated with [Claude Code](https://claude.ai/code)