### PR TITLE
fix(hq-gbo6f): safe area bottom inset for BadgeToast

### DIFF
--- a/src/components/BadgeToast.tsx
+++ b/src/components/BadgeToast.tsx
@@ -10,6 +10,7 @@
  */
 import React, { useEffect } from 'react';
 import { AccessibilityInfo, StyleSheet, Text, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import Animated, {
   useSharedValue,
   useAnimatedStyle,
@@ -30,8 +31,12 @@ interface Props {
   testID?: string;
 }
 
+const TAB_BAR_HEIGHT = 49;
+const TOAST_BOTTOM_PADDING = 8;
+
 export function BadgeToast({ badgeName, visible, badgeKey, testID }: Props) {
   const { colors, borderRadius } = useTheme();
+  const { bottom: bottomInset } = useSafeAreaInsets();
 
   const opacity = useSharedValue(0);
   const translateY = useSharedValue(0);
@@ -68,7 +73,7 @@ export function BadgeToast({ badgeName, visible, badgeKey, testID }: Props) {
 
   return (
     <Animated.View
-      style={[styles.container, animatedStyle]}
+      style={[styles.container, { bottom: TAB_BAR_HEIGHT + bottomInset + TOAST_BOTTOM_PADDING }, animatedStyle]}
       testID={testID ?? 'badge-toast'}
       accessibilityLabel={`Badge Unlocked: ${badgeName}`}
       accessibilityElementsHidden={!visible}
@@ -94,7 +99,6 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: 0,
     right: 0,
-    bottom: 120,
     zIndex: 1000,
     pointerEvents: 'none',
   },

--- a/src/components/__tests__/BadgeToast.test.tsx
+++ b/src/components/__tests__/BadgeToast.test.tsx
@@ -3,9 +3,15 @@
  * TDD tests for the BadgeToast component — hq-v0a2z.
  */
 import React from 'react';
+import { StyleSheet } from 'react-native';
 import { render } from '@testing-library/react-native';
 import { ThemeProvider } from '@/theme/ThemeProvider';
 import { BadgeToast } from '../BadgeToast';
+
+const mockInsets = { bottom: 0, top: 0, left: 0, right: 0 };
+jest.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => mockInsets,
+}));
 
 function renderToast(props: { badgeName: string; visible: boolean; testID?: string }) {
   return render(
@@ -87,6 +93,30 @@ describe('BadgeToast', () => {
       const { getByText } = renderToast({ badgeName: '🏔️ Summit Seeker', visible: true });
       expect(getByText(/Summit Seeker/i)).toBeTruthy();
     });
+  });
+
+  // ── Safe area bottom positioning (hq-gbo6f) ───────────────────────
+
+  afterEach(() => {
+    mockInsets.bottom = 0;
+  });
+
+  it('positions above tab bar + home indicator (inset=34)', () => {
+    mockInsets.bottom = 34;
+    const { getByTestId } = renderToast({ badgeName: 'Explorer Badge', visible: true });
+    const toast = getByTestId('badge-toast');
+    const flatStyle = StyleSheet.flatten(toast.props.style);
+    // TAB_BAR_HEIGHT(49) + bottom(34) + padding(8) = 91
+    expect(flatStyle.bottom).toBe(91);
+  });
+
+  it('positions above tab bar on non-indicator devices (inset=0)', () => {
+    mockInsets.bottom = 0;
+    const { getByTestId } = renderToast({ badgeName: 'Explorer Badge', visible: true });
+    const toast = getByTestId('badge-toast');
+    const flatStyle = StyleSheet.flatten(toast.props.style);
+    // TAB_BAR_HEIGHT(49) + bottom(0) + padding(8) = 57
+    expect(flatStyle.bottom).toBe(57);
   });
 
   describe('badgeKey SVG icon (hq-zarsg)', () => {


### PR DESCRIPTION
## Summary

- \`BadgeToast\` had hardcoded \`bottom: 120\` that clips on devices with a home indicator (iPhone X+)
- Apply \`useSafeAreaInsets().bottom\` using \`TAB_BAR_HEIGHT(49) + bottomInset + TOAST_BOTTOM_PADDING(8)\`, matching the pattern already used in \`PointsToast\`
- Note: \`PointsToast\` was already fixed on main; this PR only updates \`BadgeToast\`

## Test plan

- [x] \`BadgeToast.test.tsx\`: 17 tests pass, including 2 new safe area positioning tests
  - inset=34 → bottom=91 (49+34+8)
  - inset=0 → bottom=57 (49+0+8)
- [x] Replaces closed PR #313 which was branched from stale main (12,106 phantom deletions)

Fixes: hq-gbo6f

🤖 Generated with [Claude Code](https://claude.ai/code)