### PR TITLE
test(cm-1wq): strengthen orderSaga compensation failure — CRITICAL Sentry path

### DIFF
--- a/src/services/__tests__/orderSaga.test.ts
+++ b/src/services/__tests__/orderSaga.test.ts
@@ -115,6 +115,116 @@ describe('executeOrderSaga', () => {
     expect(mockCaptureException).toHaveBeenCalled();
   });
 
+  // ── Compensation failure — CRITICAL Sentry path ─────────────────────────
+
+  it('captures with fatal severity when refund fails', async () => {
+    mockConfirmOrder.mockRejectedValue(new Error('Wix down'));
+    mockRefundPayment.mockRejectedValue(new Error('Stripe refund failed'));
+
+    const promise = executeOrderSaga(baseInput);
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+      jest.advanceTimersByTime(5000);
+    }
+    await promise;
+
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      'fatal',
+      expect.any(Object),
+    );
+  });
+
+  it('includes paymentIntentId in Sentry context on refund failure', async () => {
+    mockConfirmOrder.mockRejectedValue(new Error('Wix down'));
+    mockRefundPayment.mockRejectedValue(new Error('Stripe refund failed'));
+
+    const promise = executeOrderSaga(baseInput);
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+      jest.advanceTimersByTime(5000);
+    }
+    await promise;
+
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      'fatal',
+      expect.objectContaining({ paymentIntentId: 'pi_test_123' }),
+    );
+  });
+
+  it('includes original Wix error in Sentry context on refund failure', async () => {
+    mockConfirmOrder.mockRejectedValue(new Error('Wix order failed'));
+    mockRefundPayment.mockRejectedValue(new Error('Stripe refund failed'));
+
+    const promise = executeOrderSaga(baseInput);
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+      jest.advanceTimersByTime(5000);
+    }
+    await promise;
+
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      'fatal',
+      expect.objectContaining({ originalError: 'Wix order failed' }),
+    );
+  });
+
+  it('returns paymentIntentId in refund_failed result for manual resolution', async () => {
+    mockConfirmOrder.mockRejectedValue(new Error('Wix down'));
+    mockRefundPayment.mockRejectedValue(new Error('Stripe refund failed'));
+
+    const promise = executeOrderSaga(baseInput);
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+      jest.advanceTimersByTime(5000);
+    }
+    const result = await promise;
+
+    expect(result.paymentIntentId).toBe('pi_test_123');
+    expect(result.requiresManualResolution).toBe(true);
+  });
+
+  it('handles non-Error thrown by refundPayment (string rejection)', async () => {
+    mockConfirmOrder.mockRejectedValue(new Error('Wix down'));
+    mockRefundPayment.mockRejectedValue('network timeout');
+
+    const promise = executeOrderSaga(baseInput);
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+      jest.advanceTimersByTime(5000);
+    }
+    const result = await promise;
+
+    expect(result.status).toBe('refund_failed');
+    expect(result.requiresManualResolution).toBe(true);
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      'fatal',
+      expect.objectContaining({ paymentIntentId: 'pi_test_123' }),
+    );
+  });
+
+  it('handles non-Error thrown by confirmOrder (string rejection)', async () => {
+    mockConfirmOrder.mockRejectedValue('Wix timeout string');
+    mockRefundPayment.mockRejectedValue(new Error('Stripe refund failed'));
+
+    const promise = executeOrderSaga(baseInput);
+    for (let i = 0; i < 5; i++) {
+      await Promise.resolve();
+      jest.advanceTimersByTime(5000);
+    }
+    const result = await promise;
+
+    expect(result.status).toBe('refund_failed');
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.any(Error),
+      'fatal',
+      expect.objectContaining({ originalError: 'Wix timeout string' }),
+    );
+  });
+
   it('succeeds on retry within 3 attempts', async () => {
     let callCount = 0;
     mockConfirmOrder.mockImplementation(() => {


### PR DESCRIPTION
## Summary
- Adds 6 targeted tests verifying the fatal Sentry capture when Stripe refund throws during order saga rollback
- Confirms captureException called with 'fatal' severity
- Verifies paymentIntentId and originalError in Sentry context for manual resolution
- Covers non-Error throws from both compensation paths

## Test plan
- [ ] All 13 orderSaga tests pass
- [ ] Fatal severity and context verified in Sentry capture assertions

Closes cm-1wq

🤖 Generated with Claude Code