### PR TITLE
feat(cm-u35ub): event bus auth hardening — remove userId from payload, 401 retry

### DIFF
--- a/src/services/__tests__/crossRigEventBus.test.ts
+++ b/src/services/__tests__/crossRigEventBus.test.ts
@@ -29,7 +29,11 @@ import {
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 
-function mockClient(response: object = { success: true }, shouldThrow?: Error) {
+function mockClient(
+  response: object = { success: true },
+  shouldThrow?: Error,
+  opts: { refreshTokens?: jest.Mock } = {},
+) {
   return {
     callFunction: jest.fn(
       async (_name: string, _method: string, _body: Record<string, unknown>) => {
@@ -37,17 +41,16 @@ function mockClient(response: object = { success: true }, shouldThrow?: Error) {
         return response;
       },
     ),
+    refreshTokens: opts.refreshTokens ?? jest.fn(async () => {}),
   };
 }
-
-const USER = 'member-abc123';
 
 // ── Schema validation ──────────────────────────────────────────────────────
 
 describe('event schema', () => {
   it('includes eventId as UUID v4 format', async () => {
     const client = mockClient();
-    await emitStreakExtended(client, { userId: USER, streak: 5, delta: 50, newTotal: 550 });
+    await emitStreakExtended(client, { streak: 5, delta: 50, newTotal: 550 });
     const body = client.callFunction.mock.calls[0][2] as Record<string, unknown>;
     expect(body.eventId).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
@@ -56,14 +59,14 @@ describe('event schema', () => {
 
   it('includes schemaVersion 1.0', async () => {
     const client = mockClient();
-    await emitStreakExtended(client, { userId: USER, streak: 3, delta: 30, newTotal: 330 });
+    await emitStreakExtended(client, { streak: 3, delta: 30, newTotal: 330 });
     const body = client.callFunction.mock.calls[0][2] as Record<string, unknown>;
     expect(body.schemaVersion).toBe('1.0');
   });
 
   it('includes traceId with trace_ prefix', async () => {
     const client = mockClient();
-    await emitStreakExtended(client, { userId: USER, streak: 3, delta: 30, newTotal: 330 });
+    await emitStreakExtended(client, { streak: 3, delta: 30, newTotal: 330 });
     const body = client.callFunction.mock.calls[0][2] as Record<string, unknown>;
     expect(typeof body.traceId).toBe('string');
     expect((body.traceId as string).startsWith('trace_')).toBe(true);
@@ -71,21 +74,21 @@ describe('event schema', () => {
 
   it('includes source: mobile', async () => {
     const client = mockClient();
-    await emitStreakExtended(client, { userId: USER, streak: 3, delta: 30, newTotal: 330 });
+    await emitStreakExtended(client, { streak: 3, delta: 30, newTotal: 330 });
     const body = client.callFunction.mock.calls[0][2] as Record<string, unknown>;
     expect(body.source).toBe('mobile');
   });
 
   it('includes platform as ios or android', async () => {
     const client = mockClient();
-    await emitStreakExtended(client, { userId: USER, streak: 3, delta: 30, newTotal: 330 });
+    await emitStreakExtended(client, { streak: 3, delta: 30, newTotal: 330 });
     const body = client.callFunction.mock.calls[0][2] as Record<string, unknown>;
     expect(['ios', 'android']).toContain(body.platform);
   });
 
   it('includes appVersion as a string', async () => {
     const client = mockClient();
-    await emitStreakExtended(client, { userId: USER, streak: 3, delta: 30, newTotal: 330 });
+    await emitStreakExtended(client, { streak: 3, delta: 30, newTotal: 330 });
     const body = client.callFunction.mock.calls[0][2] as Record<string, unknown>;
     expect(typeof body.appVersion).toBe('string');
     expect((body.appVersion as string).length).toBeGreaterThan(0);
@@ -94,7 +97,7 @@ describe('event schema', () => {
   it('includes ts as epoch-ms integer', async () => {
     const before = Date.now();
     const client = mockClient();
-    await emitStreakExtended(client, { userId: USER, streak: 3, delta: 50, newTotal: 350 });
+    await emitStreakExtended(client, { streak: 3, delta: 50, newTotal: 350 });
     const after = Date.now();
     const body = client.callFunction.mock.calls[0][2] as Record<string, unknown>;
     expect(typeof body.ts).toBe('number');
@@ -104,8 +107,8 @@ describe('event schema', () => {
 
   it('each emission generates a unique eventId', async () => {
     const client = mockClient();
-    await emitStreakExtended(client, { userId: USER, streak: 1, delta: 10, newTotal: 110 });
-    await emitStreakExtended(client, { userId: USER, streak: 2, delta: 20, newTotal: 220 });
+    await emitStreakExtended(client, { streak: 1, delta: 10, newTotal: 110 });
+    await emitStreakExtended(client, { streak: 2, delta: 20, newTotal: 220 });
     const id1 = (client.callFunction.mock.calls[0][2] as Record<string, unknown>).eventId;
     const id2 = (client.callFunction.mock.calls[1][2] as Record<string, unknown>).eventId;
     expect(id1).not.toBe(id2);
@@ -113,8 +116,8 @@ describe('event schema', () => {
 
   it('each emission generates a unique traceId', async () => {
     const client = mockClient();
-    await emitChallengeStarted(client, { userId: USER, challengeId: 'ch-1', currentPoints: 100 });
-    await emitChallengeStarted(client, { userId: USER, challengeId: 'ch-2', currentPoints: 200 });
+    await emitChallengeStarted(client, { challengeId: 'ch-1', currentPoints: 100 });
+    await emitChallengeStarted(client, { challengeId: 'ch-2', currentPoints: 200 });
     const t1 = (client.callFunction.mock.calls[0][2] as Record<string, unknown>).traceId;
     const t2 = (client.callFunction.mock.calls[1][2] as Record<string, unknown>).traceId;
     expect(t1).not.toBe(t2);
@@ -126,21 +129,20 @@ describe('event schema', () => {
 describe('emitStreakExtended', () => {
   it('sends event: streak_extended', async () => {
     const client = mockClient();
-    await emitStreakExtended(client, { userId: USER, streak: 7, delta: 70, newTotal: 770 });
+    await emitStreakExtended(client, { streak: 7, delta: 70, newTotal: 770 });
     const body = client.callFunction.mock.calls[0][2] as Record<string, unknown>;
     expect(body.event).toBe('streak_extended');
   });
 
   it('includes streak count in payload', async () => {
     const client = mockClient();
-    await emitStreakExtended(client, { userId: USER, streak: 12, delta: 120, newTotal: 1200 });
+    await emitStreakExtended(client, { streak: 12, delta: 120, newTotal: 1200 });
     const body = client.callFunction.mock.calls[0][2] as Record<string, unknown>;
     expect(body.streak).toBe(12);
   });
 
   it('returns success:true on 200 response', async () => {
     const result = await emitStreakExtended(mockClient(), {
-      userId: USER,
       streak: 5,
       delta: 50,
       newTotal: 550,
@@ -150,7 +152,6 @@ describe('emitStreakExtended', () => {
 
   it('queues and returns queued:true when client is null', async () => {
     const result = await emitStreakExtended(null, {
-      userId: USER,
       streak: 3,
       delta: 30,
       newTotal: 330,
@@ -162,7 +163,6 @@ describe('emitStreakExtended', () => {
   it('queues and returns queued:true on network error', async () => {
     const client = mockClient({}, new Error('Network timeout'));
     const result = await emitStreakExtended(client, {
-      userId: USER,
       streak: 3,
       delta: 30,
       newTotal: 330,
@@ -178,7 +178,6 @@ describe('emitChallengeStarted', () => {
   it('sends event: challenge_started', async () => {
     const client = mockClient();
     await emitChallengeStarted(client, {
-      userId: USER,
       challengeId: 'ch-sunrise-hike',
       currentPoints: 400,
     });
@@ -189,7 +188,6 @@ describe('emitChallengeStarted', () => {
   it('includes challengeId in payload', async () => {
     const client = mockClient();
     await emitChallengeStarted(client, {
-      userId: USER,
       challengeId: 'ch-sunrise-hike',
       currentPoints: 400,
     });
@@ -199,7 +197,7 @@ describe('emitChallengeStarted', () => {
 
   it('sends delta:0 and newTotal:currentPoints (consistent envelope shape)', async () => {
     const client = mockClient();
-    await emitChallengeStarted(client, { userId: USER, challengeId: 'ch-1', currentPoints: 750 });
+    await emitChallengeStarted(client, { challengeId: 'ch-1', currentPoints: 750 });
     const body = client.callFunction.mock.calls[0][2] as Record<string, unknown>;
     expect(body.delta).toBe(0);
     expect(body.newTotal).toBe(750);
@@ -207,7 +205,6 @@ describe('emitChallengeStarted', () => {
 
   it('returns success:true on 200', async () => {
     const result = await emitChallengeStarted(mockClient(), {
-      userId: USER,
       challengeId: 'ch-1',
       currentPoints: 400,
     });
@@ -216,7 +213,6 @@ describe('emitChallengeStarted', () => {
 
   it('queues when client null', async () => {
     const result = await emitChallengeStarted(null, {
-      userId: USER,
       challengeId: 'ch-1',
       currentPoints: 400,
     });
@@ -229,14 +225,14 @@ describe('emitChallengeStarted', () => {
 describe('emitRedemptionInitiated', () => {
   it('sends event: redemption_initiated', async () => {
     const client = mockClient();
-    await emitRedemptionInitiated(client, { userId: USER, pointsRedeemed: 200, newTotal: 800 });
+    await emitRedemptionInitiated(client, { pointsRedeemed: 200, newTotal: 800 });
     const body = client.callFunction.mock.calls[0][2] as Record<string, unknown>;
     expect(body.event).toBe('redemption_initiated');
   });
 
   it('sends delta as negative pointsRedeemed and includes newTotal', async () => {
     const client = mockClient();
-    await emitRedemptionInitiated(client, { userId: USER, pointsRedeemed: 500, newTotal: 1500 });
+    await emitRedemptionInitiated(client, { pointsRedeemed: 500, newTotal: 1500 });
     const body = client.callFunction.mock.calls[0][2] as Record<string, unknown>;
     expect(body.delta).toBe(-500);
     expect(body.newTotal).toBe(1500);
@@ -244,7 +240,6 @@ describe('emitRedemptionInitiated', () => {
 
   it('returns success:true on 200', async () => {
     const result = await emitRedemptionInitiated(mockClient(), {
-      userId: USER,
       pointsRedeemed: 100,
       newTotal: 900,
     });
@@ -253,7 +248,6 @@ describe('emitRedemptionInitiated', () => {
 
   it('queues when client null', async () => {
     const result = await emitRedemptionInitiated(null, {
-      userId: USER,
       pointsRedeemed: 100,
       newTotal: 900,
     });
@@ -268,7 +262,6 @@ describe('400 rejection handling', () => {
     const client = mockClient({ success: false, status: 400, error: 'missing eventId' });
     // A 400-like response: success:false, not a thrown error
     const result = await emitStreakExtended(client, {
-      userId: USER,
       streak: 1,
       delta: 10,
       newTotal: 110,
@@ -282,7 +275,6 @@ describe('400 rejection handling', () => {
     err.status = 400;
     const client = mockClient({}, err);
     const result = await emitStreakExtended(client, {
-      userId: USER,
       streak: 1,
       delta: 10,
       newTotal: 110,
@@ -307,8 +299,8 @@ describe('replayCrossRigQueue', () => {
 
   it('replays queued events on reconnect', async () => {
     // Queue 2 events while offline
-    await emitStreakExtended(null, { userId: USER, streak: 3, delta: 30, newTotal: 330 });
-    await emitChallengeStarted(null, { userId: USER, challengeId: 'ch-1', currentPoints: 400 });
+    await emitStreakExtended(null, { streak: 3, delta: 30, newTotal: 330 });
+    await emitChallengeStarted(null, { challengeId: 'ch-1', currentPoints: 400 });
 
     const client = mockClient();
     const result = await replayCrossRigQueue(client);
@@ -318,7 +310,7 @@ describe('replayCrossRigQueue', () => {
   });
 
   it('clears queue after successful replay', async () => {
-    await emitStreakExtended(null, { userId: USER, streak: 1, delta: 10, newTotal: 110 });
+    await emitStreakExtended(null, { streak: 1, delta: 10, newTotal: 110 });
     await replayCrossRigQueue(mockClient());
 
     // Re-replay should find nothing
@@ -327,7 +319,7 @@ describe('replayCrossRigQueue', () => {
   });
 
   it('keeps failed events in queue for next retry', async () => {
-    await emitRedemptionInitiated(null, { userId: USER, pointsRedeemed: 100, newTotal: 900 });
+    await emitRedemptionInitiated(null, { pointsRedeemed: 100, newTotal: 900 });
 
     const failingClient = mockClient({}, new Error('Server error'));
     const result = await replayCrossRigQueue(failingClient);
@@ -340,7 +332,7 @@ describe('replayCrossRigQueue', () => {
   });
 
   it('preserves eventId across queue → replay (idempotency)', async () => {
-    await emitStreakExtended(null, { userId: USER, streak: 5, delta: 50, newTotal: 550 });
+    await emitStreakExtended(null, { streak: 5, delta: 50, newTotal: 550 });
     const client = mockClient();
     await replayCrossRigQueue(client);
     const body = client.callFunction.mock.calls[0][2] as Record<string, unknown>;
@@ -348,5 +340,105 @@ describe('replayCrossRigQueue', () => {
     expect(body.eventId).toMatch(
       /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
     );
+  });
+});
+
+// ── Security: userId absent from payload ──────────────────────────────────
+//
+// Server resolves memberId from the Wix session token — payload userId
+// is a forgeable IDOR vector and must not be sent. hq-u35ub.
+
+describe('security — userId not in payload', () => {
+  it('emitStreakExtended does not include userId in body', async () => {
+    const client = mockClient();
+    await emitStreakExtended(client, { streak: 5, delta: 50, newTotal: 550 });
+    const body = client.callFunction.mock.calls[0][2] as Record<string, unknown>;
+    expect(body).not.toHaveProperty('userId');
+  });
+
+  it('emitChallengeStarted does not include userId in body', async () => {
+    const client = mockClient();
+    await emitChallengeStarted(client, { challengeId: 'ch-1', currentPoints: 400 });
+    const body = client.callFunction.mock.calls[0][2] as Record<string, unknown>;
+    expect(body).not.toHaveProperty('userId');
+  });
+
+  it('emitRedemptionInitiated does not include userId in body', async () => {
+    const client = mockClient();
+    await emitRedemptionInitiated(client, { pointsRedeemed: 200, newTotal: 800 });
+    const body = client.callFunction.mock.calls[0][2] as Record<string, unknown>;
+    expect(body).not.toHaveProperty('userId');
+  });
+
+  it('queued events do not include userId', async () => {
+    await emitStreakExtended(null, { streak: 3, delta: 30, newTotal: 330 });
+    const raw = await AsyncStorage.getItem('@cf_cross_rig_queue');
+    const queue = JSON.parse(raw!);
+    expect(queue[0].body).not.toHaveProperty('userId');
+  });
+});
+
+// ── 401 auth error handling ────────────────────────────────────────────────
+//
+// On 401: refresh token and retry once. If retry succeeds, return success.
+// If retry still fails, return error — do NOT queue (stale auth, not transient).
+
+describe('401 auth error handling', () => {
+  beforeEach(async () => {
+    await AsyncStorage.clear();
+  });
+
+  it('calls refreshTokens and retries on 401', async () => {
+    const authErr = Object.assign(new Error('Unauthorized'), { status: 401 });
+    const callFunction = jest
+      .fn()
+      .mockRejectedValueOnce(authErr)
+      .mockResolvedValueOnce({ success: true });
+    const refreshTokens = jest.fn(async () => {});
+    const client = { callFunction, refreshTokens };
+
+    const result = await emitStreakExtended(client, { streak: 5, delta: 50, newTotal: 550 });
+
+    expect(refreshTokens).toHaveBeenCalledTimes(1);
+    expect(callFunction).toHaveBeenCalledTimes(2);
+    expect(result.success).toBe(true);
+  });
+
+  it('does not queue on 401 — auth errors are not transient', async () => {
+    const authErr = Object.assign(new Error('Unauthorized'), { status: 401 });
+    const client = mockClient({}, authErr);
+
+    const result = await emitStreakExtended(client, { streak: 5, delta: 50, newTotal: 550 });
+
+    expect(result.queued).toBeUndefined();
+    expect(result.success).toBe(false);
+  });
+
+  it('returns error if retry after refresh also fails', async () => {
+    const authErr = Object.assign(new Error('Unauthorized'), { status: 401 });
+    const callFunction = jest.fn().mockRejectedValue(authErr);
+    const refreshTokens = jest.fn(async () => {});
+    const client = { callFunction, refreshTokens };
+
+    const result = await emitChallengeStarted(client, { challengeId: 'ch-1', currentPoints: 400 });
+
+    expect(refreshTokens).toHaveBeenCalledTimes(1);
+    expect(result.success).toBe(false);
+    expect(result.queued).toBeUndefined();
+  });
+
+  it('retries with the same body (same eventId for idempotency)', async () => {
+    const authErr = Object.assign(new Error('Unauthorized'), { status: 401 });
+    const callFunction = jest
+      .fn()
+      .mockRejectedValueOnce(authErr)
+      .mockResolvedValueOnce({ success: true });
+    const client = { callFunction, refreshTokens: jest.fn(async () => {}) };
+
+    await emitRedemptionInitiated(client, { pointsRedeemed: 100, newTotal: 900 });
+
+    const body1 = callFunction.mock.calls[0][2] as Record<string, unknown>;
+    const body2 = callFunction.mock.calls[1][2] as Record<string, unknown>;
+    expect(body1.eventId).toBe(body2.eventId);
   });
 });

--- a/src/services/crossRigEventBus.ts
+++ b/src/services/crossRigEventBus.ts
@@ -32,6 +32,8 @@ interface ReplayResult {
 
 interface WixClientLike {
   callFunction: (name: string, method: string, body: Record<string, unknown>) => Promise<unknown>;
+  /** Refreshes the Wix session token. Called once on 401 before retry. */
+  refreshTokens?: () => Promise<void>;
 }
 
 interface QueuedEvent {
@@ -62,6 +64,11 @@ function buildBody(event: string, payload: Record<string, unknown>): Record<stri
 
 function is400(err: unknown): boolean {
   if (err instanceof Error && (err as Error & { status?: number }).status === 400) return true;
+  return false;
+}
+
+function is401(err: unknown): boolean {
+  if (err instanceof Error && (err as Error & { status?: number }).status === 401) return true;
   return false;
 }
 
@@ -100,6 +107,19 @@ async function emit(
       captureException(err instanceof Error ? err : new Error(String(err)));
       return { success: false, error: (err as Error).message };
     }
+    if (is401(err)) {
+      // Refresh session token and retry once — 401 is not a queueable transient error
+      try {
+        await client.refreshTokens?.();
+        await client.callFunction(WIX_FN, 'POST', body);
+        return { success: true };
+      } catch (retryErr) {
+        return {
+          success: false,
+          error: retryErr instanceof Error ? retryErr.message : 'auth_error',
+        };
+      }
+    }
     // Network / transient error → queue
     await enqueue(body);
     return { success: false, queued: true };
@@ -108,12 +128,15 @@ async function emit(
 
 // ── Public API ────────────────────────────────────────────────────────────────
 
+// NOTE: userId is intentionally absent from all payloads — the server resolves
+// memberId from the Wix session token via getMemberIdentity(). Sending userId
+// in the body is an IDOR forgery vector. hq-u35ub.
+
 export async function emitStreakExtended(
   client: WixClientLike | null,
-  input: { userId: string; streak: number; delta: number; newTotal: number },
+  input: { streak: number; delta: number; newTotal: number },
 ): Promise<CrossRigEventResult> {
   return emit(client, 'streak_extended', {
-    userId: input.userId,
     streak: input.streak,
     delta: input.delta,
     newTotal: input.newTotal,
@@ -122,10 +145,9 @@ export async function emitStreakExtended(
 
 export async function emitChallengeStarted(
   client: WixClientLike | null,
-  input: { userId: string; challengeId: string; currentPoints: number },
+  input: { challengeId: string; currentPoints: number },
 ): Promise<CrossRigEventResult> {
   return emit(client, 'challenge_started', {
-    userId: input.userId,
     challengeId: input.challengeId,
     delta: 0, // no points change on challenge start — consistent envelope shape per cf-44r
     newTotal: input.currentPoints,
@@ -134,10 +156,9 @@ export async function emitChallengeStarted(
 
 export async function emitRedemptionInitiated(
   client: WixClientLike | null,
-  input: { userId: string; pointsRedeemed: number; newTotal: number },
+  input: { pointsRedeemed: number; newTotal: number },
 ): Promise<CrossRigEventResult> {
   return emit(client, 'redemption_initiated', {
-    userId: input.userId,
     delta: -input.pointsRedeemed, // negative: points leaving the account
     newTotal: input.newTotal,
   });


### PR DESCRIPTION
## Security Fix — hq-u35ub

**Class:** IDOR forgery vector — payload identity trust

### Problem
`crossRigEventBus` sends `userId` in the event body for all 3 event types (`streak_extended`, `challenge_started`, `redemption_initiated`). If the server reads `memberId` from the payload rather than the Wix session token, any mobile client can forge gamification events for arbitrary members via static analysis or memory dump of the shared secret.

Same class as PR #790 fix (`getZipLeaderboard` memberId param).

### Changes

**`crossRigEventBus.ts`**
- Remove `userId` from all 3 emit function signatures and payloads — server must resolve memberId from auth token via `getMemberIdentity()`
- Add `refreshTokens?: () => Promise<void>` to `WixClientLike`
- On 401: call `refreshTokens()` → retry once with same body (same `eventId` for idempotency) → return error if still failing. **Never queue on 401** — stale auth is not a transient/retriable condition.
- Add `is401()` helper

### Tests — 38 passing (+8 new)

**New security suite:**
- `emitStreakExtended` does not include userId in body
- `emitChallengeStarted` does not include userId in body
- `emitRedemptionInitiated` does not include userId in body
- Queued events do not include userId

**New 401 suite:**
- Calls `refreshTokens` and retries on 401
- Does not queue on 401 (auth errors are not transient)
- Returns error if retry after refresh also fails
- Retries with same body / same `eventId` (idempotency preserved)

### Scope note
Server-side fix (httpFunction reads `memberId` from token only via `getMemberIdentity()`) is a separate Wix backend bead — coordinate before wiring any callers to the bus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)