### PR TITLE
feat(hq-elfso): challenge progress summary hero + useChallengeProgress hook

### DIFF
--- a/src/hooks/__tests__/useChallengeProgress.test.ts
+++ b/src/hooks/__tests__/useChallengeProgress.test.ts
@@ -1,0 +1,266 @@
+/**
+ * @module useChallengeProgress.test
+ *
+ * TDD tests for useChallengeProgress hook.
+ * Fetches member-specific challenge progress from MemberChallengeProgress CMS.
+ *
+ * hq-elfso
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+import { useChallengeProgress } from '../useChallengeProgress';
+
+// ── Mocks ──────────────────────────────────────────────────────────────
+
+const mockQueryData = jest.fn();
+const mockWixClient = { queryData: mockQueryData } as unknown;
+
+jest.mock('@/services/wix', () => ({
+  useOptionalWixClient: jest.fn(() => mockWixClient),
+}));
+
+const mockUseAuth = jest.fn(() => ({ user: { id: 'member-1' } }));
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+const { useOptionalWixClient } = require('@/services/wix');
+
+// ── Fixtures ────────────────────────────────────────────────────────────
+
+const PROGRESS_ITEMS = [
+  {
+    challengeId: 'ch-spring',
+    memberId: 'member-1',
+    progressValue: 3,
+    goalValue: 5,
+    pointsEarned: 0,
+    completedAt: null,
+    lastUpdated: '2026-03-20T12:00:00Z',
+  },
+  {
+    challengeId: 'ch-streak',
+    memberId: 'member-1',
+    progressValue: 7,
+    goalValue: 7,
+    pointsEarned: 100,
+    completedAt: '2026-03-19T08:00:00Z',
+    lastUpdated: '2026-03-19T08:00:00Z',
+  },
+  {
+    challengeId: 'ch-flash',
+    memberId: 'member-1',
+    progressValue: 1,
+    goalValue: 3,
+    pointsEarned: 0,
+    completedAt: null,
+    lastUpdated: '2026-03-18T10:00:00Z',
+  },
+];
+
+// ── Tests ───────────────────────────────────────────────────────────────
+
+describe('useChallengeProgress', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (useOptionalWixClient as jest.Mock).mockReturnValue(mockWixClient);
+    mockUseAuth.mockReturnValue({ user: { id: 'member-1' } });
+    mockQueryData.mockResolvedValue({ items: PROGRESS_ITEMS, totalResults: 3 });
+  });
+
+  it('fetches progress from MemberChallengeProgress CMS collection', async () => {
+    renderHook(() => useChallengeProgress());
+
+    await waitFor(() => {
+      expect(mockQueryData).toHaveBeenCalledWith(
+        'MemberChallengeProgress',
+        expect.objectContaining({
+          filter: expect.objectContaining({ memberId: 'member-1' }),
+        }),
+      );
+    });
+  });
+
+  it('returns loading=true initially', () => {
+    mockQueryData.mockReturnValue(new Promise(() => {})); // never resolves
+    const { result } = renderHook(() => useChallengeProgress());
+    expect(result.current.loading).toBe(true);
+  });
+
+  it('returns progress items after fetch', async () => {
+    const { result } = renderHook(() => useChallengeProgress());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.progressItems).toHaveLength(3);
+    expect(result.current.progressItems[0].challengeId).toBe('ch-spring');
+  });
+
+  it('calculates summary stats: totalPointsEarned', async () => {
+    const { result } = renderHook(() => useChallengeProgress());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.summary.totalPointsEarned).toBe(100);
+  });
+
+  it('calculates summary stats: completedCount', async () => {
+    const { result } = renderHook(() => useChallengeProgress());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.summary.completedCount).toBe(1);
+  });
+
+  it('calculates summary stats: activeCount', async () => {
+    const { result } = renderHook(() => useChallengeProgress());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.summary.activeCount).toBe(2);
+  });
+
+  it('returns error state on API failure', async () => {
+    mockQueryData.mockRejectedValue(new Error('CMS unavailable'));
+
+    const { result } = renderHook(() => useChallengeProgress());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Unable to load challenge progress.');
+    expect(result.current.progressItems).toHaveLength(0);
+  });
+
+  it('returns empty state when no wixClient', async () => {
+    (useOptionalWixClient as jest.Mock).mockReturnValue(null);
+
+    const { result } = renderHook(() => useChallengeProgress());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.progressItems).toHaveLength(0);
+    expect(result.current.summary.totalPointsEarned).toBe(0);
+    expect(mockQueryData).not.toHaveBeenCalled();
+  });
+
+  it('returns empty state when no user', async () => {
+    mockUseAuth.mockReturnValue({ user: null });
+
+    const { result } = renderHook(() => useChallengeProgress());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.progressItems).toHaveLength(0);
+    expect(mockQueryData).not.toHaveBeenCalled();
+  });
+
+  it('provides refresh function that re-fetches', async () => {
+    const { result } = renderHook(() => useChallengeProgress());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(mockQueryData).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.refresh();
+    });
+
+    await waitFor(() => {
+      expect(mockQueryData).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('handles empty CMS response gracefully', async () => {
+    mockQueryData.mockResolvedValue({ items: [], totalResults: 0 });
+
+    const { result } = renderHook(() => useChallengeProgress());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.progressItems).toHaveLength(0);
+    expect(result.current.summary.totalPointsEarned).toBe(0);
+    expect(result.current.summary.completedCount).toBe(0);
+    expect(result.current.summary.activeCount).toBe(0);
+  });
+
+  it('handles null items in CMS response', async () => {
+    mockQueryData.mockResolvedValue({ items: null, totalResults: 0 });
+
+    const { result } = renderHook(() => useChallengeProgress());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.progressItems).toHaveLength(0);
+  });
+
+  it('clamps progressRatio between 0 and 1', async () => {
+    mockQueryData.mockResolvedValue({
+      items: [
+        {
+          challengeId: 'ch-over',
+          memberId: 'member-1',
+          progressValue: 10,
+          goalValue: 5,
+          pointsEarned: 0,
+          completedAt: null,
+          lastUpdated: '2026-03-20T12:00:00Z',
+        },
+      ],
+      totalResults: 1,
+    });
+
+    const { result } = renderHook(() => useChallengeProgress());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.progressItems[0].progressRatio).toBe(1);
+  });
+
+  it('handles zero goalValue without division error', async () => {
+    mockQueryData.mockResolvedValue({
+      items: [
+        {
+          challengeId: 'ch-zero',
+          memberId: 'member-1',
+          progressValue: 3,
+          goalValue: 0,
+          pointsEarned: 0,
+          completedAt: null,
+          lastUpdated: '2026-03-20T12:00:00Z',
+        },
+      ],
+      totalResults: 1,
+    });
+
+    const { result } = renderHook(() => useChallengeProgress());
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+
+    expect(result.current.progressItems[0].progressRatio).toBe(0);
+    expect(Number.isFinite(result.current.progressItems[0].progressRatio)).toBe(true);
+  });
+});

--- a/src/hooks/useChallengeProgress.ts
+++ b/src/hooks/useChallengeProgress.ts
@@ -1,0 +1,138 @@
+/**
+ * @module useChallengeProgress
+ *
+ * Fetches member-specific challenge progress from the MemberChallengeProgress
+ * CMS collection and computes summary stats (points earned, completed count,
+ * active count).
+ *
+ * CMS collection: MemberChallengeProgress
+ * Fields: challengeId, memberId, progressValue, goalValue, pointsEarned,
+ *         completedAt, lastUpdated
+ *
+ * hq-elfso
+ */
+
+import { useState, useEffect } from 'react';
+import { useOptionalWixClient } from '@/services/wix';
+import { useAuth } from '@/hooks/useAuth';
+
+export interface ChallengeProgressItem {
+  challengeId: string;
+  memberId: string;
+  progressValue: number;
+  goalValue: number;
+  pointsEarned: number;
+  completedAt: string | null;
+  lastUpdated: string;
+  progressRatio: number;
+}
+
+export interface ChallengeProgressSummary {
+  totalPointsEarned: number;
+  completedCount: number;
+  activeCount: number;
+}
+
+export interface UseChallengeProgressResult {
+  progressItems: ChallengeProgressItem[];
+  summary: ChallengeProgressSummary;
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+interface CmsProgressItem {
+  challengeId: string;
+  memberId: string;
+  progressValue: number;
+  goalValue: number;
+  pointsEarned: number;
+  completedAt: string | null;
+  lastUpdated: string;
+}
+
+const EMPTY_SUMMARY: ChallengeProgressSummary = {
+  totalPointsEarned: 0,
+  completedCount: 0,
+  activeCount: 0,
+};
+
+function mapItem(raw: CmsProgressItem): ChallengeProgressItem {
+  const ratio = raw.goalValue > 0 ? raw.progressValue / raw.goalValue : 0;
+  return {
+    ...raw,
+    progressRatio: Math.min(1, Math.max(0, ratio)),
+  };
+}
+
+function computeSummary(items: ChallengeProgressItem[]): ChallengeProgressSummary {
+  let totalPointsEarned = 0;
+  let completedCount = 0;
+  let activeCount = 0;
+
+  for (const item of items) {
+    totalPointsEarned += item.pointsEarned;
+    if (item.completedAt) {
+      completedCount++;
+    } else {
+      activeCount++;
+    }
+  }
+
+  return { totalPointsEarned, completedCount, activeCount };
+}
+
+export function useChallengeProgress(): UseChallengeProgressResult {
+  const wixClient = useOptionalWixClient();
+  const { user } = useAuth();
+  const [progressItems, setProgressItems] = useState<ChallengeProgressItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshToken, setRefreshToken] = useState(0);
+
+  useEffect(() => {
+    if (!wixClient || !user?.id) {
+      setProgressItems([]);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    wixClient
+      .queryData<CmsProgressItem>('MemberChallengeProgress', {
+        filter: { memberId: user.id },
+        sort: [{ fieldName: 'lastUpdated', order: 'DESC' }],
+        limit: 50,
+      })
+      .then((res) => {
+        if (cancelled) return;
+        const items = Array.isArray(res?.items) ? res.items : [];
+        setProgressItems(items.map(mapItem));
+        setLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setError('Unable to load challenge progress.');
+        setProgressItems([]);
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [wixClient, user?.id, refreshToken]);
+
+  const refresh = () => setRefreshToken((t) => t + 1);
+
+  return {
+    progressItems,
+    summary: progressItems.length > 0 ? computeSummary(progressItems) : EMPTY_SUMMARY,
+    loading,
+    error,
+    refresh,
+  };
+}

--- a/src/screens/ChallengesScreen.tsx
+++ b/src/screens/ChallengesScreen.tsx
@@ -14,6 +14,7 @@ import React, { useEffect, useRef } from 'react';
 import { ActivityIndicator, ScrollView, StyleSheet, Text, View } from 'react-native';
 import { useTheme } from '@/theme';
 import { useChallengeCatalog, type CatalogChallenge } from '@/hooks/useChallengeCatalog';
+import { useChallengeProgress } from '@/hooks/useChallengeProgress';
 import { useLoyalty } from '@/hooks/useLoyalty';
 import { emitChallengeStarted } from '@/services/crossRigEventBus';
 import { getWixClientSingleton } from '@/services/wix/wixClientSingleton';
@@ -47,6 +48,85 @@ function SectionHeader({ label, testID }: { label: string; testID: string }) {
     >
       {label.toUpperCase()}
     </Text>
+  );
+}
+
+// ── Progress summary hero ─────────────────────────────────────────────────────
+
+function ProgressSummary({
+  summary,
+}: {
+  summary: { totalPointsEarned: number; completedCount: number; activeCount: number };
+}) {
+  const { colors, typography, spacing } = useTheme();
+  return (
+    <View
+      style={[
+        styles.summaryCard,
+        { backgroundColor: colors.sandDark, marginHorizontal: spacing.lg, marginTop: spacing.lg },
+      ]}
+      testID="challenge-progress-summary"
+    >
+      <View style={styles.summaryRow}>
+        <View style={styles.summaryItem}>
+          <Text
+            testID="progress-total-points"
+            style={[
+              styles.summaryValue,
+              { color: colors.mountainBlue, fontFamily: typography.bodyFamilyBold },
+            ]}
+          >
+            {String(summary.totalPointsEarned)}
+          </Text>
+          <Text
+            style={[
+              styles.summaryLabel,
+              { color: colors.espressoLight, fontFamily: typography.bodyFamily },
+            ]}
+          >
+            Points Earned
+          </Text>
+        </View>
+        <View style={styles.summaryItem}>
+          <Text
+            testID="progress-completed-count"
+            style={[
+              styles.summaryValue,
+              { color: colors.mountainBlue, fontFamily: typography.bodyFamilyBold },
+            ]}
+          >
+            {String(summary.completedCount)}
+          </Text>
+          <Text
+            style={[
+              styles.summaryLabel,
+              { color: colors.espressoLight, fontFamily: typography.bodyFamily },
+            ]}
+          >
+            Completed
+          </Text>
+        </View>
+        <View style={styles.summaryItem}>
+          <Text
+            testID="progress-active-count"
+            style={[
+              styles.summaryValue,
+              { color: colors.sunsetCoral, fontFamily: typography.bodyFamilyBold },
+            ]}
+          >
+            {String(summary.activeCount)}
+          </Text>
+          <Text
+            style={[
+              styles.summaryLabel,
+              { color: colors.espressoLight, fontFamily: typography.bodyFamily },
+            ]}
+          >
+            Active
+          </Text>
+        </View>
+      </View>
+    </View>
   );
 }
 
@@ -174,6 +254,7 @@ interface Props {
 export function ChallengesScreen({ testID }: Props) {
   const { colors, spacing } = useTheme();
   const { grouped, loading, error } = useChallengeCatalog();
+  const { summary: progressSummary } = useChallengeProgress();
   const { inProgress, available, completed, expired } = grouped;
   const { points } = useLoyalty();
   const challengesEmitted = useRef(false);
@@ -233,6 +314,8 @@ export function ChallengesScreen({ testID }: Props) {
       testID={testID ?? 'challenges-screen'}
       showsVerticalScrollIndicator={false}
     >
+      <ProgressSummary summary={progressSummary} />
+
       {inProgress.length > 0 && (
         <>
           <SectionHeader label="In Progress" testID="section-in-progress" />
@@ -275,6 +358,11 @@ export function ChallengesScreen({ testID }: Props) {
 const styles = StyleSheet.create({
   root: { flex: 1 },
   centered: { justifyContent: 'center', alignItems: 'center', padding: 32 },
+  summaryCard: { borderRadius: 12, padding: 16, marginBottom: 8 },
+  summaryRow: { flexDirection: 'row', justifyContent: 'space-around' },
+  summaryItem: { alignItems: 'center' },
+  summaryValue: { fontSize: 22, fontWeight: '700' },
+  summaryLabel: { fontSize: 11, marginTop: 2 },
   sectionHeader: {
     fontSize: 11,
     fontWeight: '700',

--- a/src/screens/__tests__/ChallengesScreen.crossRig.test.tsx
+++ b/src/screens/__tests__/ChallengesScreen.crossRig.test.tsx
@@ -33,6 +33,16 @@ jest.mock('@/hooks/useChallengeCatalog', () => ({
   useChallengeCatalog: () => mockHook(),
 }));
 
+jest.mock('@/hooks/useChallengeProgress', () => ({
+  useChallengeProgress: () => ({
+    progressItems: [],
+    summary: { totalPointsEarned: 0, completedCount: 0, activeCount: 0 },
+    loading: false,
+    error: null,
+    refresh: jest.fn(),
+  }),
+}));
+
 // ── Fixtures ─────────────────────────────────────────────────────────────────
 
 const FUTURE = '2027-01-01T00:00:00Z';

--- a/src/screens/__tests__/ChallengesScreen.test.tsx
+++ b/src/screens/__tests__/ChallengesScreen.test.tsx
@@ -56,6 +56,16 @@ jest.mock('@/hooks/useChallengeCatalog', () => ({
 }));
 const mockHook = useChallengeCatalog as jest.Mock;
 
+jest.mock('@/hooks/useChallengeProgress', () => ({
+  useChallengeProgress: () => ({
+    progressItems: [],
+    summary: { totalPointsEarned: 0, completedCount: 0, activeCount: 0 },
+    loading: false,
+    error: null,
+    refresh: jest.fn(),
+  }),
+}));
+
 function renderScreen() {
   return render(
     <ThemeProvider>

--- a/src/screens/__tests__/ChallengesScreenProgress.test.tsx
+++ b/src/screens/__tests__/ChallengesScreenProgress.test.tsx
@@ -1,0 +1,181 @@
+/**
+ * @module ChallengesScreenProgress.test
+ *
+ * Tests for the progress summary hero section added to ChallengesScreen.
+ * Verifies the progress summary card displays member stats from useChallengeProgress.
+ *
+ * hq-elfso
+ */
+
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { ThemeProvider } from '@/theme/ThemeProvider';
+import { ChallengesScreen } from '../ChallengesScreen';
+import type { GroupedChallenges, CatalogChallenge } from '@/hooks/useChallengeCatalog';
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+const FUTURE = '2027-01-01T00:00:00Z';
+
+function makeChallenge(overrides: Partial<CatalogChallenge> = {}): CatalogChallenge {
+  return {
+    id: 'ch-1',
+    title: 'Spring Refresh',
+    description: 'Browse 5 new arrivals',
+    goal: 5,
+    unit: 'products',
+    pointReward: 500,
+    expiresAt: FUTURE,
+    progress: 3,
+    progressRatio: 0.6,
+    completed: false,
+    isExpired: false,
+    ...overrides,
+  };
+}
+
+const emptyGrouped: GroupedChallenges = {
+  inProgress: [],
+  available: [],
+  completed: [],
+  expired: [],
+};
+
+// ── Mock hooks ──────────────────────────────────────────────────────
+
+const mockRefresh = jest.fn();
+const mockCatalog = jest.fn(() => ({
+  challenges: [],
+  grouped: emptyGrouped,
+  loading: false,
+  error: null,
+  refresh: mockRefresh,
+}));
+
+jest.mock('@/hooks/useChallengeCatalog', () => ({
+  useChallengeCatalog: () => mockCatalog(),
+}));
+
+const mockProgressRefresh = jest.fn();
+const mockProgress = jest.fn(() => ({
+  progressItems: [],
+  summary: { totalPointsEarned: 0, completedCount: 0, activeCount: 0 },
+  loading: false,
+  error: null,
+  refresh: mockProgressRefresh,
+}));
+
+jest.mock('@/hooks/useChallengeProgress', () => ({
+  useChallengeProgress: () => mockProgress(),
+}));
+
+function renderScreen() {
+  return render(
+    <ThemeProvider>
+      <ChallengesScreen />
+    </ThemeProvider>,
+  );
+}
+
+// ── Tests ───────────────────────────────────────────────────────────
+
+describe('ChallengesScreen — Progress Summary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockCatalog.mockReturnValue({
+      challenges: [makeChallenge()],
+      grouped: { ...emptyGrouped, inProgress: [makeChallenge()] },
+      loading: false,
+      error: null,
+      refresh: mockRefresh,
+    });
+    mockProgress.mockReturnValue({
+      progressItems: [],
+      summary: { totalPointsEarned: 750, completedCount: 3, activeCount: 2 },
+      loading: false,
+      error: null,
+      refresh: mockProgressRefresh,
+    });
+  });
+
+  it('renders progress summary section', () => {
+    const { getByTestId } = renderScreen();
+    expect(getByTestId('challenge-progress-summary')).toBeTruthy();
+  });
+
+  it('displays total points earned', () => {
+    const { getByTestId } = renderScreen();
+    const el = getByTestId('progress-total-points');
+    expect(el.props.children).toMatch(/750/);
+  });
+
+  it('displays completed challenge count', () => {
+    const { getByTestId } = renderScreen();
+    const el = getByTestId('progress-completed-count');
+    expect(el.props.children).toMatch(/3/);
+  });
+
+  it('displays active challenge count', () => {
+    const { getByTestId } = renderScreen();
+    const el = getByTestId('progress-active-count');
+    expect(el.props.children).toMatch(/2/);
+  });
+
+  it('hides progress summary when both hooks are loading', () => {
+    mockCatalog.mockReturnValue({
+      challenges: [],
+      grouped: emptyGrouped,
+      loading: true,
+      error: null,
+      refresh: mockRefresh,
+    });
+    mockProgress.mockReturnValue({
+      progressItems: [],
+      summary: { totalPointsEarned: 0, completedCount: 0, activeCount: 0 },
+      loading: true,
+      error: null,
+      refresh: mockProgressRefresh,
+    });
+    const { getByTestId, queryByTestId } = renderScreen();
+    expect(getByTestId('challenges-loading')).toBeTruthy();
+    expect(queryByTestId('challenge-progress-summary')).toBeNull();
+  });
+
+  it('shows progress summary even when progress hook has error (graceful degradation)', () => {
+    mockProgress.mockReturnValue({
+      progressItems: [],
+      summary: { totalPointsEarned: 0, completedCount: 0, activeCount: 0 },
+      loading: false,
+      error: 'Unable to load challenge progress.',
+      refresh: mockProgressRefresh,
+    });
+    const { getByTestId } = renderScreen();
+    // Summary still renders with zero values — doesn't block the catalog
+    expect(getByTestId('challenge-progress-summary')).toBeTruthy();
+  });
+
+  it('shows zero values when no progress data', () => {
+    mockProgress.mockReturnValue({
+      progressItems: [],
+      summary: { totalPointsEarned: 0, completedCount: 0, activeCount: 0 },
+      loading: false,
+      error: null,
+      refresh: mockProgressRefresh,
+    });
+    const { getByTestId } = renderScreen();
+    expect(getByTestId('progress-total-points').props.children).toMatch(/0/);
+  });
+
+  it('does not show progress summary on catalog error screen', () => {
+    mockCatalog.mockReturnValue({
+      challenges: [],
+      grouped: emptyGrouped,
+      loading: false,
+      error: 'Failed to load',
+      refresh: mockRefresh,
+    });
+    const { queryByTestId, getByTestId } = renderScreen();
+    expect(getByTestId('challenges-error')).toBeTruthy();
+    expect(queryByTestId('challenge-progress-summary')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Add `useChallengeProgress` hook: fetches member progress from `MemberChallengeProgress` CMS, computes summary stats (total points earned, completed count, active count)
- Add `ProgressSummary` hero card to `ChallengesScreen` showing member stats at top of scroll view
- Graceful degradation: summary shows zero values on progress error, hides entirely on catalog error/loading

## Test plan
- [x] 14 unit tests for `useChallengeProgress` hook (happy path, error, null items, zero goalValue, ratio clamping, refresh)
- [x] 8 integration tests for `ChallengesScreenProgress` (renders summary, displays stats, loading/error states, graceful degradation)
- [x] Existing `ChallengesScreen` tests pass (12 tests)
- [x] CrossRig tests updated with new hook mock (4 tests)
- [x] All 38 related tests passing