### PR TITLE
fix(#259): stabilize CategoryScreen + ShopScreen flaky tests

### DIFF
--- a/src/screens/__tests__/CategoryScreen.test.tsx
+++ b/src/screens/__tests__/CategoryScreen.test.tsx
@@ -31,10 +31,18 @@ async function renderCategory(props: Partial<React.ComponentProps<typeof Categor
       </WishlistProvider>
     </ThemeProvider>,
   );
-  // Advance past initial loading skeleton (600ms) and flush async SWR cache
+  // Advance past initial loading skeleton (600ms) and fire any pending timers
   await act(async () => {
     jest.advanceTimersByTime(700);
   });
+  // Flush the full useDataCache async chain (AsyncStorage.getItem → fetcher →
+  // AsyncStorage.setItem → multiple setState calls). advanceTimersByTime only
+  // fires timer callbacks — it does NOT resolve the Promise microtask queue,
+  // so state updates from the SWR cache settle on later ticks. Under full-suite
+  // event-loop pressure this caused flaky testID lookup failures.
+  // Multiple act flushes drain the nested promise chain completely.
+  await act(async () => {});
+  await act(async () => {});
   return { ...result, onProductPress, onBack };
 }
 

--- a/src/screens/__tests__/ShopScreen.test.tsx
+++ b/src/screens/__tests__/ShopScreen.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, act } from '@testing-library/react-native';
+import { render, fireEvent, waitFor } from '@testing-library/react-native';
 import { ShopScreen } from '../ShopScreen';
 import { ThemeProvider } from '@/theme/ThemeProvider';
 import { WishlistProvider } from '@/hooks/useWishlist';
@@ -17,8 +17,13 @@ async function renderShop(props: { onProductPress?: jest.Mock } = {}) {
       </WishlistProvider>
     </ThemeProvider>,
   );
-  // Flush async effects: useDataCache AsyncStorage + fetchProducts chain
-  await act(async () => {});
+  // Wait for useDataCache async chain (AsyncStorage.getItem → fetcher → setState)
+  // to fully settle before returning. A bare `act(async () => {})` only flushes one
+  // microtask tick, which is insufficient when the event loop is under load in the
+  // full test suite — causing flaky testID lookups.
+  await waitFor(() => {
+    result.getByTestId('product-list');
+  });
   return { ...result, onProductPress };
 }
 


### PR DESCRIPTION
## Summary
- CategoryScreen and ShopScreen tests failed intermittently in full-suite runs due to insufficient async flushing
- **CategoryScreen**: Added extra `act(async () => {})` flushes after `advanceTimersByTime` to drain the useDataCache Promise chain (AsyncStorage.getItem → fetcher → AsyncStorage.setItem → setState)
- **ShopScreen**: Replaced bare `act(async () => {})` with `waitFor(() => getByTestId('product-list'))` which polls until data loading settles

## Root cause
`useDataCache` triggers a multi-step async chain (AsyncStorage read → fetch → AsyncStorage write → multiple setState calls). Under full-suite event-loop pressure, a single `act` tick wasn't enough to flush all pending microtasks, causing `getByTestId` to fail before the component finished rendering.

## Test plan
- [x] CategoryScreen: 18/18 tests pass
- [x] ShopScreen: 20/20 tests pass  
- [x] Full suite: 394/394 suites pass (6906 tests), run 2x consecutively
- [ ] Manual: verify no act() warnings in CI full run

Closes #259

🤖 Generated with [Claude Code](https://claude.com/claude-code)