### PR TITLE
fix(cm-261): stabilize flaky Sentry + PDP tests under full-suite load

### DIFF
--- a/src/screens/__tests__/ProductDetailScreen.test.tsx
+++ b/src/screens/__tests__/ProductDetailScreen.test.tsx
@@ -159,10 +159,12 @@ function renderDetail(props: Partial<React.ComponentProps<typeof ProductDetailSc
 }
 
 beforeEach(() => {
-  mockAddItem.mockClear();
-  mockAlert.mockClear();
-  mockNavigate.mockClear();
+  jest.clearAllMocks();
   mockUseProductReviews.mockReturnValue(mockProductReviewsResult);
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
 });
 
 describe('ProductDetailScreen', () => {
@@ -418,9 +420,10 @@ describe('ProductDetailScreen', () => {
     it('does not throw when Share.share rejects', async () => {
       shareSpy.mockRejectedValueOnce(new Error('share failed'));
       const { getByTestId } = renderDetail();
-      fireEvent.press(getByTestId('detail-share-button'));
-      await new Promise((r) => setTimeout(r, 50));
-      // no crash
+      await act(async () => {
+        fireEvent.press(getByTestId('detail-share-button'));
+      });
+      // no crash — rejection handled gracefully
     });
   });
 

--- a/src/services/providers/__tests__/sentryCrashReporting.withSentry.test.ts
+++ b/src/services/providers/__tests__/sentryCrashReporting.withSentry.test.ts
@@ -1,10 +1,10 @@
 /**
  * Tests for SentryCrashReportingProvider when @sentry/react-native IS available.
  *
- * jest.mock with { virtual: true } intercepts the require('@sentry/react-native')
- * call in the provider's module-level try/catch so that Sentry = mock object.
- * No jest.resetModules() is needed — Jest gives each test file a fresh module
- * registry, so the provider is always loaded fresh with the mock active.
+ * Uses jest.isolateModules() to guarantee a fresh module registry per test,
+ * preventing state leaks when Jest reuses workers across test files.
+ * The module-level `let Sentry` in sentryCrashReporting.ts retains its value
+ * within a cached module — resetModules + isolateModules ensures a clean load.
  */
 export {};
 
@@ -28,10 +28,6 @@ const mockNavigationIntegration = { registerNavigationContainer: jest.fn() };
 const mockReactNavigationIntegration = jest.fn(() => mockNavigationIntegration);
 const mockMobileReplayIntegration = jest.fn(() => ({ name: 'MobileReplay' }));
 
-// The mock factory must be declared before any require() so the provider's
-// module-level try/catch picks up this mock when the module is first loaded.
-// jest.mock() calls are hoisted above imports/requires by Jest's transform,
-// so this registration is always in effect before require('../sentryCrashReporting').
 jest.mock('@sentry/react-native', () => ({
   init: mockInit,
   captureException: mockCaptureException,
@@ -44,11 +40,30 @@ jest.mock('@sentry/react-native', () => ({
   mobileReplayIntegration: mockMobileReplayIntegration,
 }));
 
-// eslint-disable-next-line @typescript-eslint/no-var-requires
-const { SentryCrashReportingProvider, wrapWithSentry } = require('../sentryCrashReporting');
+// Load the module fresh so the module-level `Sentry` picks up our mock
+let SentryCrashReportingProvider: any;
+let wrapWithSentry: any;
 
 beforeEach(() => {
   jest.clearAllMocks();
+  jest.resetModules();
+  jest.isolateModules(() => {
+    // Re-register the mock inside the isolated registry
+    jest.mock('@sentry/react-native', () => ({
+      init: mockInit,
+      captureException: mockCaptureException,
+      captureMessage: mockCaptureMessage,
+      setUser: mockSetUser,
+      addBreadcrumb: mockAddBreadcrumb,
+      withScope: mockWithScope,
+      wrap: mockWrap,
+      reactNavigationIntegration: mockReactNavigationIntegration,
+      mobileReplayIntegration: mockMobileReplayIntegration,
+    }));
+    const mod = require('../sentryCrashReporting');
+    SentryCrashReportingProvider = mod.SentryCrashReportingProvider;
+    wrapWithSentry = mod.wrapWithSentry;
+  });
 });
 
 describe('SentryCrashReportingProvider (with Sentry)', () => {


### PR DESCRIPTION
## Summary
- **Sentry withSentry test**: Uses jest.isolateModules() + resetModules() in beforeEach to guarantee a fresh module registry per test, preventing state leaks from Jest worker reuse across files
- **PDP test**: Replaces individual mockClear() with clearAllMocks()/restoreAllMocks() and wraps async Share rejection test in act() instead of fragile setTimeout

## Test plan
- [x] sentryCrashReporting.withSentry.test.ts — 14/14 pass
- [x] ProductDetailScreen.test.tsx — 209/209 pass (4 suites)
- [x] Full suite: 394 passed, 2 skipped, 0 failures (75s)