### PR TITLE
feat(hq-rag7a): Enhanced Compare Tool — progressive disclosure, diff highlighting, fabric swatches, share

### DIFF
--- a/src/screens/CompareScreen.tsx
+++ b/src/screens/CompareScreen.tsx
@@ -1,10 +1,11 @@
-import React from 'react';
-import { StyleSheet, View, Text, ScrollView, TouchableOpacity } from 'react-native';
+import React, { useState, useCallback } from 'react';
+import { StyleSheet, View, Text, ScrollView, TouchableOpacity, Share } from 'react-native';
 import { Image } from 'expo-image';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { useTheme } from '@/theme';
 import type { Product } from '@/data/products';
 import { getStockStatus } from '@/data/products';
+import { FABRICS } from '@/data/futons';
 import { formatPrice } from '@/utils';
 import { MAX_COMPARE_ITEMS } from '@/hooks/useCompare';
 
@@ -18,13 +19,43 @@ interface Props {
 
 interface CompareRow {
   label: string;
-  values: (product: Product) => React.ReactNode;
+  key: string;
+  /** Returns a comparable string for diff highlighting */
+  comparable: (product: Product) => string;
+  values: (product: Product, isDiff: boolean) => React.ReactNode;
 }
+
+interface Section {
+  title: string;
+  key: string;
+  defaultExpanded: boolean;
+  rows: CompareRow[];
+}
+
+// --- Fabric color lookup ---
+
+const FABRIC_COLOR_MAP = new Map(FABRICS.map((f) => [f.name, f.color]));
+const FALLBACK_SWATCH_COLOR = '#B0B0B0';
+
+function getFabricColor(fabricName: string): string {
+  return FABRIC_COLOR_MAP.get(fabricName) ?? FALLBACK_SWATCH_COLOR;
+}
+
+// --- Helpers ---
 
 function formatDimensions(d: Product['dimensions'] | undefined): string {
   if (!d) return '-';
   return `${d.width}" × ${d.depth}" × ${d.height}"`;
 }
+
+function buildShareMessage(products: Product[]): string {
+  const lines = products.map(
+    (p) => `${p.name} — ${formatPrice(p.price)} (${p.rating} stars)`,
+  );
+  return `Compare Futons:\n${lines.join('\n')}\n\nvia Carolina Futons`;
+}
+
+// --- Sub-components ---
 
 function StockLabel({ product }: { product: Product }) {
   const { colors } = useTheme();
@@ -39,6 +70,96 @@ function StockLabel({ product }: { product: Product }) {
   return <Text style={{ color: colors.success }}>In Stock</Text>;
 }
 
+function FabricSwatches({ product }: { product: Product }) {
+  const { colors } = useTheme();
+  return (
+    <View testID={`fabric-swatches-${product.id}`} style={swatchStyles.container}>
+      <View style={swatchStyles.row}>
+        {product.fabricOptions.map((fabricName) => (
+          <View
+            key={fabricName}
+            testID={`swatch-${product.id}-${fabricName}`}
+            accessibilityLabel={fabricName}
+            style={[
+              swatchStyles.dot,
+              { backgroundColor: getFabricColor(fabricName), borderColor: colors.sandDark },
+            ]}
+          />
+        ))}
+      </View>
+      <Text style={[swatchStyles.count, { color: colors.espressoLight }]}>
+        {product.fabricOptions.length}
+      </Text>
+    </View>
+  );
+}
+
+function SectionHeader({
+  title,
+  sectionKey,
+  expanded,
+  onToggle,
+}: {
+  title: string;
+  sectionKey: string;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  const { colors } = useTheme();
+  return (
+    <TouchableOpacity
+      testID={`section-${sectionKey}-header`}
+      accessibilityLabel={`Toggle ${title} section`}
+      accessibilityRole="button"
+      onPress={onToggle}
+      style={[sectionHeaderStyles.container, { borderBottomColor: colors.sandDark }]}
+    >
+      <Text style={[sectionHeaderStyles.text, { color: colors.espresso }]}>{title}</Text>
+      <Text style={[sectionHeaderStyles.chevron, { color: colors.espressoLight }]}>
+        {expanded ? '▾' : '▸'}
+      </Text>
+    </TouchableOpacity>
+  );
+}
+
+function Header({
+  onBack,
+  onShare,
+}: {
+  onBack?: () => void;
+  onShare?: () => void;
+}) {
+  const { colors } = useTheme();
+  return (
+    <View style={[headerStyles.container, { borderBottomColor: colors.sandDark }]}>
+      {onBack && (
+        <TouchableOpacity
+          testID="back-button"
+          onPress={onBack}
+          style={headerStyles.backButton}
+          accessibilityLabel="Go back"
+        >
+          <Text style={[headerStyles.backText, { color: colors.mountainBlue }]}>←</Text>
+        </TouchableOpacity>
+      )}
+      <Text style={[headerStyles.title, { color: colors.espresso }]}>Compare</Text>
+      <View style={headerStyles.spacer} />
+      {onShare && (
+        <TouchableOpacity
+          testID="compare-share-button"
+          onPress={onShare}
+          style={headerStyles.shareButton}
+          accessibilityLabel="Share comparison"
+        >
+          <Text style={[headerStyles.shareText, { color: colors.mountainBlue }]}>Share</Text>
+        </TouchableOpacity>
+      )}
+    </View>
+  );
+}
+
+// --- Main component ---
+
 export function CompareScreen({
   products: rawProducts,
   onRemove,
@@ -49,8 +170,24 @@ export function CompareScreen({
   const { colors, borderRadius } = useTheme();
   const insets = useSafeAreaInsets();
 
-  // Cap products to max
   const products = rawProducts.slice(0, MAX_COMPARE_ITEMS);
+
+  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({
+    'basic-info': true,
+    details: false,
+  });
+
+  const toggleSection = useCallback((key: string) => {
+    setExpandedSections((prev) => ({ ...prev, [key]: !prev[key] }));
+  }, []);
+
+  const handleShare = useCallback(async () => {
+    try {
+      await Share.share({ message: buildShareMessage(products) });
+    } catch {
+      // Share cancelled or failed — no action needed
+    }
+  }, [products]);
 
   if (products.length === 0) {
     return (
@@ -74,66 +211,118 @@ export function CompareScreen({
   const lowestPriceCount = products.filter((p) => p.price === lowestPrice).length;
   const highlightLowest = products.length > 1 && lowestPriceCount === 1;
 
-  const rows: CompareRow[] = [
+  // Check if a row has differing values across products (for diff highlighting)
+  function hasDiff(row: CompareRow): boolean {
+    if (products.length <= 1) return false;
+    const first = row.comparable(products[0]);
+    return products.some((p) => row.comparable(p) !== first);
+  }
+
+  const sections: Section[] = [
     {
-      label: 'Price',
-      values: (product) => {
-        const isBest = highlightLowest && product.price === lowestPrice;
-        return (
-          <View testID={isBest ? `price-best-${product.id}` : undefined}>
+      title: 'Basic Info',
+      key: 'basic-info',
+      defaultExpanded: true,
+      rows: [
+        {
+          label: 'Price',
+          key: 'price',
+          comparable: (p) => String(p.price),
+          values: (product, isDiff) => {
+            const isBest = highlightLowest && product.price === lowestPrice;
+            return (
+              <View
+                testID={
+                  isBest
+                    ? `price-best-${product.id}`
+                    : isDiff
+                      ? `diff-price-${product.id}`
+                      : undefined
+                }
+              >
+                <Text
+                  style={[
+                    styles.cellValue,
+                    {
+                      color: isBest ? colors.success : colors.espresso,
+                      fontWeight: isBest ? '700' : '400',
+                    },
+                  ]}
+                >
+                  {formatPrice(product.price)}
+                </Text>
+                {product.originalPrice != null && (
+                  <Text style={[styles.originalPrice, { color: colors.espressoLight }]}>
+                    {formatPrice(product.originalPrice)}
+                  </Text>
+                )}
+              </View>
+            );
+          },
+        },
+        {
+          label: 'Rating',
+          key: 'rating',
+          comparable: (p) => String(p.rating),
+          values: (product, isDiff) => (
             <Text
-              style={[
-                styles.cellValue,
-                {
-                  color: isBest ? colors.success : colors.espresso,
-                  fontWeight: isBest ? '700' : '400',
-                },
-              ]}
+              testID={isDiff ? `diff-rating-${product.id}` : undefined}
+              style={[styles.cellValue, { color: colors.espresso }]}
             >
-              {formatPrice(product.price)}
+              {product.rating}
             </Text>
-            {product.originalPrice != null && (
-              <Text style={[styles.originalPrice, { color: colors.espressoLight }]}>
-                {formatPrice(product.originalPrice)}
-              </Text>
-            )}
-          </View>
-        );
-      },
+          ),
+        },
+        {
+          label: 'Availability',
+          key: 'availability',
+          comparable: (p) => getStockStatus(p),
+          values: (product, isDiff) => (
+            <View testID={isDiff ? `diff-availability-${product.id}` : undefined}>
+              <StockLabel product={product} />
+            </View>
+          ),
+        },
+      ],
     },
     {
-      label: 'Rating',
-      values: (product) => (
-        <Text style={[styles.cellValue, { color: colors.espresso }]}>{product.rating}</Text>
-      ),
-    },
-    {
-      label: 'Size',
-      values: (product) => (
-        <Text style={[styles.cellValue, { color: colors.espresso }]}>
-          {product.size ? product.size.charAt(0).toUpperCase() + product.size.slice(1) : '-'}
-        </Text>
-      ),
-    },
-    {
-      label: 'Dimensions',
-      values: (product) => (
-        <Text style={[styles.cellValue, { color: colors.espresso }]}>
-          {formatDimensions(product.dimensions)}
-        </Text>
-      ),
-    },
-    {
-      label: 'Fabrics',
-      values: (product) => (
-        <Text style={[styles.cellValue, { color: colors.espresso }]}>
-          {product.fabricOptions.length} options
-        </Text>
-      ),
-    },
-    {
-      label: 'Availability',
-      values: (product) => <StockLabel product={product} />,
+      title: 'Details',
+      key: 'details',
+      defaultExpanded: false,
+      rows: [
+        {
+          label: 'Size',
+          key: 'size',
+          comparable: (p) => p.size ?? '-',
+          values: (product, isDiff) => (
+            <Text
+              testID={isDiff ? `diff-size-${product.id}` : undefined}
+              style={[styles.cellValue, { color: colors.espresso }]}
+            >
+              {product.size ? product.size.charAt(0).toUpperCase() + product.size.slice(1) : '-'}
+            </Text>
+          ),
+        },
+        {
+          label: 'Dimensions',
+          key: 'dimensions',
+          comparable: (p) => formatDimensions(p.dimensions),
+          values: (product, isDiff) => (
+            <Text
+              testID={isDiff ? `diff-dimensions-${product.id}` : undefined}
+              style={[styles.cellValue, { color: colors.espresso }]}
+            >
+              {formatDimensions(product.dimensions)}
+            </Text>
+          ),
+        },
+        {
+          label: 'Fabrics',
+          key: 'fabrics',
+          comparable: (p) => p.fabricOptions.sort().join(','),
+          values: (product) => <FabricSwatches product={product} />,
+        },
+      ],
     },
   ];
 
@@ -143,7 +332,7 @@ export function CompareScreen({
       accessibilityLabel="Compare products"
       testID={testID}
     >
-      <Header onBack={onBack} />
+      <Header onBack={onBack} onShare={handleShare} />
 
       {/* Sticky product header — outside ScrollView so it never scrolls away */}
       <View
@@ -190,57 +379,57 @@ export function CompareScreen({
         style={styles.scrollView}
         showsVerticalScrollIndicator={false}
       >
-        {/* Comparison rows */}
-        {rows.map((row, index) => (
-          <View
-            key={row.label}
-            style={[
-              styles.comparisonRow,
-              {
-                backgroundColor: index % 2 === 0 ? colors.offWhite : colors.sandBase,
-                borderColor: colors.sandDark,
-              },
-            ]}
-          >
-            <View style={styles.labelCell}>
-              <Text style={[styles.rowLabel, { color: colors.espressoLight }]}>{row.label}</Text>
+        {sections.map((section) => {
+          const isExpanded = expandedSections[section.key] ?? section.defaultExpanded;
+          return (
+            <View key={section.key} testID={`section-${section.key}`}>
+              <SectionHeader
+                title={section.title}
+                sectionKey={section.key}
+                expanded={isExpanded}
+                onToggle={() => toggleSection(section.key)}
+              />
+              {isExpanded &&
+                section.rows.map((row, index) => {
+                  const isDiff = hasDiff(row);
+                  return (
+                    <View
+                      key={row.key}
+                      style={[
+                        styles.comparisonRow,
+                        {
+                          backgroundColor:
+                            index % 2 === 0 ? colors.offWhite : colors.sandBase,
+                          borderColor: colors.sandDark,
+                        },
+                        isDiff && { backgroundColor: colors.sandLight + '80' },
+                      ]}
+                    >
+                      <View style={styles.labelCell}>
+                        <Text style={[styles.rowLabel, { color: colors.espressoLight }]}>
+                          {row.label}
+                        </Text>
+                      </View>
+                      {products.map((product) => (
+                        <View key={product.id} style={styles.productCell}>
+                          {row.values(product, isDiff)}
+                        </View>
+                      ))}
+                    </View>
+                  );
+                })}
             </View>
-            {products.map((product) => (
-              <View key={product.id} style={styles.productCell}>
-                {row.values(product)}
-              </View>
-            ))}
-          </View>
-        ))}
+          );
+        })}
       </ScrollView>
     </View>
   );
 }
 
-function Header({ onBack }: { onBack?: () => void }) {
-  const { colors } = useTheme();
-  return (
-    <View style={[styles.header, { borderBottomColor: colors.sandDark }]}>
-      {onBack && (
-        <TouchableOpacity
-          testID="back-button"
-          onPress={onBack}
-          style={styles.backButton}
-          accessibilityLabel="Go back"
-        >
-          <Text style={[styles.backText, { color: colors.mountainBlue }]}>←</Text>
-        </TouchableOpacity>
-      )}
-      <Text style={[styles.title, { color: colors.espresso }]}>Compare</Text>
-    </View>
-  );
-}
+// --- Styles ---
 
-const styles = StyleSheet.create({
+const headerStyles = StyleSheet.create({
   container: {
-    flex: 1,
-  },
-  header: {
     flexDirection: 'row',
     alignItems: 'center',
     paddingHorizontal: 16,
@@ -257,6 +446,63 @@ const styles = StyleSheet.create({
   title: {
     fontSize: 20,
     fontWeight: '700',
+  },
+  spacer: {
+    flex: 1,
+  },
+  shareButton: {
+    padding: 4,
+  },
+  shareText: {
+    fontSize: 14,
+    fontWeight: '600',
+  },
+});
+
+const sectionHeaderStyles = StyleSheet.create({
+  container: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    borderBottomWidth: StyleSheet.hairlineWidth,
+  },
+  text: {
+    fontSize: 14,
+    fontWeight: '700',
+  },
+  chevron: {
+    fontSize: 14,
+  },
+});
+
+const swatchStyles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+  },
+  row: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    gap: 4,
+    marginBottom: 4,
+  },
+  dot: {
+    width: 16,
+    height: 16,
+    borderRadius: 8,
+    borderWidth: 1,
+  },
+  count: {
+    fontSize: 11,
+    textAlign: 'center',
+  },
+});
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
   },
   scrollView: {
     flex: 1,
@@ -278,11 +524,6 @@ const styles = StyleSheet.create({
     borderBottomWidth: 1,
     zIndex: 1,
     elevation: 2,
-  },
-  headerRow: {
-    flexDirection: 'row',
-    paddingVertical: 12,
-    paddingHorizontal: 8,
   },
   comparisonRow: {
     flexDirection: 'row',

--- a/src/screens/__tests__/CompareScreen.test.tsx
+++ b/src/screens/__tests__/CompareScreen.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { render, fireEvent, within } from '@testing-library/react-native';
+import { Share } from 'react-native';
+import { render, fireEvent, within, act } from '@testing-library/react-native';
 import { CompareScreen } from '../CompareScreen';
 import { PRODUCTS } from '@/data/products';
 import type { Product } from '@/data/products';
@@ -77,7 +78,9 @@ describe('CompareScreen', () => {
   // --- COMPARISON ROWS ---
 
   it('displays dimension comparison rows', () => {
-    const { getAllByText, getByText } = render(<CompareScreen products={[productA, productB]} />);
+    const { getByText, getByTestId } = render(<CompareScreen products={[productA, productB]} />);
+    // Expand Details section (collapsed by default)
+    fireEvent.press(getByTestId('section-details-header'));
     expect(getByText('Dimensions')).toBeTruthy();
     // Dimensions formatted as W×D×H
     const dimA = `${productA.dimensions.width}" × ${productA.dimensions.depth}" × ${productA.dimensions.height}"`;
@@ -102,10 +105,12 @@ describe('CompareScreen', () => {
   });
 
   it('displays fabric options', () => {
-    const { getByText } = render(<CompareScreen products={[productA, productB]} />);
+    const { getByText, getByTestId } = render(<CompareScreen products={[productA, productB]} />);
+    // Expand Details section (collapsed by default)
+    fireEvent.press(getByTestId('section-details-header'));
     expect(getByText('Fabrics')).toBeTruthy();
-    // Each product's fabric count
-    expect(getByText(`${productA.fabricOptions.length} options`)).toBeTruthy();
+    // Fabric count shown as number alongside swatches
+    expect(getByText(`${productA.fabricOptions.length}`)).toBeTruthy();
   });
 
   it('displays stock status', () => {
@@ -114,7 +119,9 @@ describe('CompareScreen', () => {
   });
 
   it('displays size row when products have sizes', () => {
-    const { getByText } = render(<CompareScreen products={[productA, productB]} />);
+    const { getByText, getByTestId } = render(<CompareScreen products={[productA, productB]} />);
+    // Expand Details section (collapsed by default)
+    fireEvent.press(getByTestId('section-details-header'));
     expect(getByText('Size')).toBeTruthy();
   });
 
@@ -160,8 +167,10 @@ describe('CompareScreen', () => {
       badge: undefined,
       stockCount: undefined,
     };
-    const { getByText } = render(<CompareScreen products={[sparseProduct, productB]} />);
+    const { getByText, getByTestId } = render(<CompareScreen products={[sparseProduct, productB]} />);
     expect(getByText('Sparse Product')).toBeTruthy();
+    // Expand Details to see Size row
+    fireEvent.press(getByTestId('section-details-header'));
     // Size row should show '-' for missing size
     expect(getByText('-')).toBeTruthy();
   });
@@ -217,10 +226,12 @@ describe('CompareScreen', () => {
       name: 'No Dims Futon',
       dimensions: undefined as any,
     };
-    const { getByText, getAllByText } = render(
+    const { getByText, getAllByText, getByTestId } = render(
       <CompareScreen products={[noDimsProduct, productB]} />,
     );
     expect(getByText('No Dims Futon')).toBeTruthy();
+    // Expand Details to see Dimensions row
+    fireEvent.press(getByTestId('section-details-header'));
     // Should show '-' for missing dimensions
     expect(getAllByText('-').length).toBeGreaterThanOrEqual(1);
   });
@@ -298,5 +309,224 @@ describe('CompareScreen', () => {
     // Product names are inside the sticky header
     expect(within(header).getByText(productA.name)).toBeTruthy();
     expect(within(header).getByText(productB.name)).toBeTruthy();
+  });
+
+  // --- PROGRESSIVE DISCLOSURE (hq-rag7a) ---
+
+  describe('Progressive Disclosure', () => {
+    it('renders section headers for Basic Info and Details', () => {
+      const { getByText } = render(<CompareScreen products={[productA, productB]} />);
+      expect(getByText('Basic Info')).toBeTruthy();
+      expect(getByText('Details')).toBeTruthy();
+    });
+
+    it('Basic Info section is expanded by default', () => {
+      const { getByTestId } = render(<CompareScreen products={[productA, productB]} />);
+      const section = getByTestId('section-basic-info');
+      // The rows within should be visible
+      expect(within(section).getByText('Price')).toBeTruthy();
+    });
+
+    it('Details section is collapsed by default', () => {
+      const { getByTestId } = render(<CompareScreen products={[productA, productB]} />);
+      const section = getByTestId('section-details');
+      // Dimensions row should NOT be visible when collapsed
+      expect(within(section).queryByText('Dimensions')).toBeNull();
+    });
+
+    it('toggles Details section on press', () => {
+      const { getByTestId, getByText } = render(
+        <CompareScreen products={[productA, productB]} />,
+      );
+      // Expand Details
+      fireEvent.press(getByText('Details'));
+      const section = getByTestId('section-details');
+      expect(within(section).getByText('Dimensions')).toBeTruthy();
+
+      // Collapse Details
+      fireEvent.press(getByText('Details'));
+      expect(within(section).queryByText('Dimensions')).toBeNull();
+    });
+
+    it('toggles Basic Info section on press', () => {
+      const { getByTestId, getByText } = render(
+        <CompareScreen products={[productA, productB]} />,
+      );
+      // Collapse Basic Info
+      fireEvent.press(getByText('Basic Info'));
+      const section = getByTestId('section-basic-info');
+      expect(within(section).queryByText('Price')).toBeNull();
+
+      // Re-expand
+      fireEvent.press(getByText('Basic Info'));
+      expect(within(section).getByText('Price')).toBeTruthy();
+    });
+
+    it('section header has accessible role and label', () => {
+      const { getByLabelText } = render(<CompareScreen products={[productA, productB]} />);
+      expect(getByLabelText('Toggle Basic Info section')).toBeTruthy();
+      expect(getByLabelText('Toggle Details section')).toBeTruthy();
+    });
+  });
+
+  // --- SPEC COMPARISON TABLE — DIFFERENCE HIGHLIGHTING (hq-rag7a) ---
+
+  describe('Spec Difference Highlighting', () => {
+    it('highlights cells where values differ across products', () => {
+      // productA and productB have different ratings
+      const { getByTestId } = render(<CompareScreen products={[productA, productB]} />);
+      // Expand Details section first
+      fireEvent.press(getByTestId('section-details-header'));
+
+      // If ratings differ, cells should have diff-highlight testID
+      if (productA.rating !== productB.rating) {
+        expect(getByTestId(`diff-rating-${productA.id}`)).toBeTruthy();
+        expect(getByTestId(`diff-rating-${productB.id}`)).toBeTruthy();
+      }
+    });
+
+    it('does not highlight cells where values are identical', () => {
+      const identicalProduct: Product = {
+        ...productA,
+        id: 'prod-identical' as any,
+        name: 'Identical Futon',
+      };
+      const { queryByTestId } = render(
+        <CompareScreen products={[productA, identicalProduct]} />,
+      );
+      // Same price → no highlight
+      expect(queryByTestId(`diff-price-${productA.id}`)).toBeNull();
+      expect(queryByTestId('diff-price-prod-identical')).toBeNull();
+    });
+
+    it('does not apply diff highlighting with only one product', () => {
+      const { queryByTestId } = render(<CompareScreen products={[productA]} />);
+      expect(queryByTestId(`diff-price-${productA.id}`)).toBeNull();
+    });
+  });
+
+  // --- COLOR SWATCH VISUALIZATION (hq-rag7a) ---
+
+  describe('Color Swatch Visualization', () => {
+    it('renders fabric swatches instead of plain text count', () => {
+      const { getByTestId } = render(<CompareScreen products={[productA, productB]} />);
+      // Expand Details to see Fabrics row
+      fireEvent.press(getByTestId('section-details-header'));
+      expect(getByTestId(`fabric-swatches-${productA.id}`)).toBeTruthy();
+    });
+
+    it('renders one swatch per fabric option', () => {
+      const { getByTestId, getAllByTestId } = render(<CompareScreen products={[productA, productB]} />);
+      fireEvent.press(getByTestId('section-details-header'));
+      // Each fabric option should have a swatch
+      const swatches = getAllByTestId(new RegExp(`^swatch-${productA.id}-`));
+      expect(swatches.length).toBe(productA.fabricOptions.length);
+    });
+
+    it('swatch has accessible label with fabric name', () => {
+      const { getByTestId } = render(<CompareScreen products={[productA, productB]} />);
+      fireEvent.press(getByTestId('section-details-header'));
+      const swatchContainer = getByTestId(`fabric-swatches-${productA.id}`);
+      const firstFabric = productA.fabricOptions[0];
+      const firstSwatch = within(swatchContainer).getByLabelText(firstFabric);
+      expect(firstSwatch).toBeTruthy();
+    });
+
+    it('renders fallback swatch color for unknown fabric names', () => {
+      const customProduct: Product = {
+        ...productA,
+        id: 'prod-unknown-fabric' as any,
+        name: 'Unknown Fabric Futon',
+        fabricOptions: ['Alien Purple'],
+      };
+      const { getByTestId } = render(<CompareScreen products={[customProduct, productB]} />);
+      fireEvent.press(getByTestId('section-details-header'));
+      // Should still render swatch (with fallback gray)
+      expect(getByTestId('fabric-swatches-prod-unknown-fabric')).toBeTruthy();
+    });
+
+    it('shows fabric count label alongside swatches', () => {
+      const { getByTestId } = render(<CompareScreen products={[productA, productB]} />);
+      fireEvent.press(getByTestId('section-details-header'));
+      const swatchContainer = getByTestId(`fabric-swatches-${productA.id}`);
+      expect(
+        within(swatchContainer).getByText(`${productA.fabricOptions.length}`),
+      ).toBeTruthy();
+    });
+  });
+
+  // --- SHARE TO SOCIAL (hq-rag7a) ---
+
+  describe('Share Comparison', () => {
+    const shareSpy = jest.spyOn(Share, 'share').mockResolvedValue({
+      action: Share.sharedAction,
+      activityType: undefined,
+    });
+
+    afterEach(() => {
+      shareSpy.mockClear();
+    });
+
+    it('renders share button when products are present', () => {
+      const { getByTestId } = render(<CompareScreen products={[productA, productB]} />);
+      expect(getByTestId('compare-share-button')).toBeTruthy();
+    });
+
+    it('does not render share button in empty state', () => {
+      const { queryByTestId } = render(<CompareScreen products={[]} />);
+      expect(queryByTestId('compare-share-button')).toBeNull();
+    });
+
+    it('calls Share.share with comparison text on press', async () => {
+      const { getByTestId } = render(<CompareScreen products={[productA, productB]} />);
+      await act(async () => {
+        fireEvent.press(getByTestId('compare-share-button'));
+      });
+      expect(shareSpy).toHaveBeenCalledTimes(1);
+      const shareArg = shareSpy.mock.calls[0][0];
+      expect(shareArg.message).toContain(productA.name);
+      expect(shareArg.message).toContain(productB.name);
+      expect(shareArg.message).toContain(formatPrice(productA.price));
+      expect(shareArg.message).toContain(formatPrice(productB.price));
+    });
+
+    it('includes all products in share text', async () => {
+      const { getByTestId } = render(
+        <CompareScreen products={[productA, productB, productC]} />,
+      );
+      await act(async () => {
+        fireEvent.press(getByTestId('compare-share-button'));
+      });
+      const shareArg = shareSpy.mock.calls[0][0];
+      expect(shareArg.message).toContain(productA.name);
+      expect(shareArg.message).toContain(productB.name);
+      expect(shareArg.message).toContain(productC.name);
+    });
+
+    it('does not crash when Share.share rejects', async () => {
+      shareSpy.mockRejectedValueOnce(new Error('share cancelled'));
+      const { getByTestId } = render(<CompareScreen products={[productA, productB]} />);
+      await act(async () => {
+        fireEvent.press(getByTestId('compare-share-button'));
+      });
+      // no crash — rejection handled gracefully
+    });
+
+    it('does not crash when Share.share is dismissed', async () => {
+      shareSpy.mockResolvedValueOnce({
+        action: Share.dismissedAction,
+        activityType: undefined,
+      });
+      const { getByTestId } = render(<CompareScreen products={[productA, productB]} />);
+      await act(async () => {
+        fireEvent.press(getByTestId('compare-share-button'));
+      });
+      // no crash
+    });
+
+    it('share button has accessible label', () => {
+      const { getByLabelText } = render(<CompareScreen products={[productA, productB]} />);
+      expect(getByLabelText('Share comparison')).toBeTruthy();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- **Progressive disclosure**: Comparison rows grouped into collapsible "Basic Info" (expanded by default) and "Details" (collapsed by default) sections with accessible toggle headers
- **Spec difference highlighting**: When values differ across compared products, rows get a subtle background tint and cells receive `diff-*` testIDs for testing
- **Color swatch visualization**: Fabrics row shows colored circular swatches mapped from `FABRICS` data instead of plain "N options" text, with fallback gray for unknown fabrics
- **Share to social**: Share button in header calls `Share.share` with formatted comparison text (product names, prices, ratings)

## Test plan
- [x] CompareScreen.test.tsx — 49 tests (18 new), all pass
- [x] Progressive disclosure: expand/collapse toggles, default states, accessibility labels
- [x] Diff highlighting: highlights differing cells, skips identical values, no highlighting for single product
- [x] Fabric swatches: correct count, accessible labels, fallback color, count label
- [x] Share: calls Share.share with all products, handles rejection/dismissal gracefully
- [x] Full suite: 395 passed, 2 skipped, 0 failures (62s)