### PR TITLE
fix(cf-qsxp): track longestStreak in useStreak — survives streak breaks

### DIFF
--- a/src/hooks/__tests__/useStreak.test.ts
+++ b/src/hooks/__tests__/useStreak.test.ts
@@ -72,7 +72,7 @@ describe('useStreak', () => {
     await act(async () => {});
     expect(mockSetItem).toHaveBeenCalledWith(
       '@carolina_futons_streak',
-      JSON.stringify({ lastVisit: TODAY, streak: 3 }),
+      JSON.stringify({ lastVisit: TODAY, streak: 3, longestStreak: 3 }),
     );
   });
 
@@ -168,5 +168,93 @@ describe('useStreak', () => {
     const { result } = renderHook(() => useStreak());
     await act(async () => {});
     expect(result.current.wasExtendedToday).toBe(false);
+  });
+
+  // ── longestStreak — cf-qsxp ─────────────────────────────────────────────
+
+  it('longestStreak equals current streak on first visit', async () => {
+    mockGetItem.mockResolvedValue(null);
+    const { result } = renderHook(() => useStreak());
+    await act(async () => {});
+    expect(result.current.longestStreak).toBe(1);
+  });
+
+  it('longestStreak updates when current streak exceeds it', async () => {
+    mockGetItem.mockResolvedValue(
+      JSON.stringify({ lastVisit: YESTERDAY, streak: 5, longestStreak: 5 }),
+    );
+    const { result } = renderHook(() => useStreak());
+    await act(async () => {});
+    expect(result.current.streak).toBe(6);
+    expect(result.current.longestStreak).toBe(6);
+  });
+
+  it('longestStreak preserved when streak resets after a break', async () => {
+    mockGetItem.mockResolvedValue(
+      JSON.stringify({ lastVisit: TWO_DAYS_AGO, streak: 10, longestStreak: 30 }),
+    );
+    const { result } = renderHook(() => useStreak());
+    await act(async () => {});
+    expect(result.current.streak).toBe(1);
+    expect(result.current.longestStreak).toBe(30);
+  });
+
+  it('longestStreak preserved when already visited today', async () => {
+    mockGetItem.mockResolvedValue(
+      JSON.stringify({ lastVisit: TODAY, streak: 3, longestStreak: 15 }),
+    );
+    const { result } = renderHook(() => useStreak());
+    await act(async () => {});
+    expect(result.current.streak).toBe(3);
+    expect(result.current.longestStreak).toBe(15);
+  });
+
+  it('persists longestStreak to AsyncStorage when streak extends', async () => {
+    mockGetItem.mockResolvedValue(
+      JSON.stringify({ lastVisit: YESTERDAY, streak: 7, longestStreak: 7 }),
+    );
+    renderHook(() => useStreak());
+    await act(async () => {});
+    expect(mockSetItem).toHaveBeenCalledWith(
+      '@carolina_futons_streak',
+      JSON.stringify({ lastVisit: TODAY, streak: 8, longestStreak: 8 }),
+    );
+  });
+
+  it('persists longestStreak to AsyncStorage when streak resets', async () => {
+    mockGetItem.mockResolvedValue(
+      JSON.stringify({ lastVisit: TWO_DAYS_AGO, streak: 5, longestStreak: 20 }),
+    );
+    renderHook(() => useStreak());
+    await act(async () => {});
+    expect(mockSetItem).toHaveBeenCalledWith(
+      '@carolina_futons_streak',
+      JSON.stringify({ lastVisit: TODAY, streak: 1, longestStreak: 20 }),
+    );
+  });
+
+  it('migrates legacy record without longestStreak field', async () => {
+    // Old records have no longestStreak — should default to current streak
+    mockGetItem.mockResolvedValue(JSON.stringify({ lastVisit: YESTERDAY, streak: 12 }));
+    const { result } = renderHook(() => useStreak());
+    await act(async () => {});
+    expect(result.current.streak).toBe(13);
+    expect(result.current.longestStreak).toBe(13);
+  });
+
+  it('migrates legacy record: longestStreak defaults to streak on reset', async () => {
+    mockGetItem.mockResolvedValue(JSON.stringify({ lastVisit: TWO_DAYS_AGO, streak: 8 }));
+    const { result } = renderHook(() => useStreak());
+    await act(async () => {});
+    expect(result.current.streak).toBe(1);
+    // Legacy record had no longestStreak — use the old streak as longest
+    expect(result.current.longestStreak).toBe(8);
+  });
+
+  it('longestStreak defaults to 1 on storage error', async () => {
+    mockGetItem.mockRejectedValue(new Error('Storage error'));
+    const { result } = renderHook(() => useStreak());
+    await act(async () => {});
+    expect(result.current.longestStreak).toBe(1);
   });
 });

--- a/src/hooks/useStreak.ts
+++ b/src/hooks/useStreak.ts
@@ -15,6 +15,7 @@ const STORAGE_KEY = '@carolina_futons_streak';
 interface StreakRecord {
   lastVisit: string; // ISO date string YYYY-MM-DD
   streak: number;
+  longestStreak?: number; // cf-qsxp: historical max streak (absent in legacy records)
 }
 
 function toDateString(timestamp: number): string {
@@ -31,10 +32,13 @@ export interface UseStreakResult {
   loading: boolean;
   /** True only when this session extended the streak (gap from last visit was exactly 1 day). */
   wasExtendedToday: boolean;
+  /** cf-qsxp: Historical best streak — survives streak breaks. */
+  longestStreak: number;
 }
 
 export function useStreak(): UseStreakResult {
   const [streak, setStreak] = useState(1);
+  const [longestStreak, setLongestStreak] = useState(1);
   const [loading, setLoading] = useState(true);
   const [wasExtendedToday, setWasExtendedToday] = useState(false);
 
@@ -50,29 +54,41 @@ export function useStreak(): UseStreakResult {
         if (!raw) {
           // First ever visit
           setStreak(1);
-          await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify({ lastVisit: today, streak: 1 }));
+          setLongestStreak(1);
+          await AsyncStorage.setItem(
+            STORAGE_KEY,
+            JSON.stringify({ lastVisit: today, streak: 1, longestStreak: 1 }),
+          );
           return;
         }
 
         const record: StreakRecord = JSON.parse(raw);
+        // cf-qsxp: migrate legacy records that lack longestStreak
+        const recordLongest = record.longestStreak ?? record.streak;
 
         if (record.lastVisit === today) {
           // Already counted today
           setStreak(record.streak);
+          setLongestStreak(recordLongest);
           return;
         }
 
         const gap = daysBetween(record.lastVisit, today);
         const newStreak = gap === 1 ? record.streak + 1 : 1;
+        const newLongest = Math.max(recordLongest, newStreak);
         if (gap === 1) setWasExtendedToday(true);
         setStreak(newStreak);
+        setLongestStreak(newLongest);
         await AsyncStorage.setItem(
           STORAGE_KEY,
-          JSON.stringify({ lastVisit: today, streak: newStreak }),
+          JSON.stringify({ lastVisit: today, streak: newStreak, longestStreak: newLongest }),
         );
       } catch {
         // Storage unavailable — fall back to streak of 1
-        if (!cancelled) setStreak(1);
+        if (!cancelled) {
+          setStreak(1);
+          setLongestStreak(1);
+        }
       } finally {
         if (!cancelled) setLoading(false);
       }
@@ -84,5 +100,5 @@ export function useStreak(): UseStreakResult {
     };
   }, []);
 
-  return { streak, loading, wasExtendedToday };
+  return { streak, loading, wasExtendedToday, longestStreak };
 }


### PR DESCRIPTION
## Summary
- Adds `longestStreak` to `StreakRecord` and `UseStreakResult` in `useStreak` hook
- On streak increment: `longestStreak = Math.max(existing, newStreak)`
- On streak reset (gap > 1 day): `longestStreak` preserved from record
- Legacy records without `longestStreak` field migrate by defaulting to current `streak` value
- Backwards compatible — existing consumers don't need changes

## Root Cause (cf-qsxp)
StreakTrackerWidget showed `longestStreak` but `useStreak` only tracked `{ lastVisit, streak }`. After a streak break (e.g. 30-day streak broken, now on day 2), the widget showed 2 instead of 30.

## Test Plan
- [x] 24 tests passing (14 existing + 10 new)
- [x] longestStreak equals current on first visit
- [x] longestStreak updates when current exceeds it
- [x] longestStreak preserved after streak break
- [x] longestStreak preserved on same-day revisit
- [x] Persisted to AsyncStorage on extend and reset
- [x] Legacy migration: records without longestStreak default correctly
- [x] Storage error fallback: longestStreak defaults to 1
- [x] TypeScript compiles clean (tsc --noEmit)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>