### PR TITLE
fix(cf-ma6v): auto-refresh DailyQuestsCard on gamification action

### DIFF
--- a/src/hooks/__tests__/useDailyQuests.test.ts
+++ b/src/hooks/__tests__/useDailyQuests.test.ts
@@ -17,6 +17,12 @@ jest.mock('@react-native-async-storage/async-storage', () => ({
   removeItem: jest.fn().mockResolvedValue(undefined),
 }));
 
+// cf-ma6v: mock questRefreshBus so we can test subscription
+const mockOnQuestRefresh = jest.fn();
+jest.mock('@/services/questRefreshBus', () => ({
+  onQuestRefresh: (...args: unknown[]) => mockOnQuestRefresh(...args),
+}));
+
 const mockCallFunction = jest.fn();
 const mockUseOptionalWixClient = jest.fn();
 jest.mock('@/services/wix', () => ({
@@ -295,6 +301,49 @@ describe('useDailyQuests', () => {
     });
     expect(mockCallFunction).toHaveBeenCalledTimes(1);
     expect(result.current.quests[0].id).toBe('api-q1');
+  });
+
+  // ── questRefreshBus subscription (cf-ma6v) ──────────────────────────────
+
+  it('subscribes to questRefreshBus on mount', async () => {
+    mockGetItem.mockResolvedValue(null);
+    renderHook(() => useDailyQuests());
+    await act(async () => {});
+    expect(mockOnQuestRefresh).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('unsubscribes from questRefreshBus on unmount', async () => {
+    mockGetItem.mockResolvedValue(null);
+    const mockUnsub = jest.fn();
+    mockOnQuestRefresh.mockReturnValue(mockUnsub);
+    const { unmount } = renderHook(() => useDailyQuests());
+    await act(async () => {});
+    unmount();
+    expect(mockUnsub).toHaveBeenCalledTimes(1);
+  });
+
+  it('refresh() is called when questRefreshBus emits', async () => {
+    mockGetItem.mockResolvedValue(MOCK_QUESTS_JSON);
+    mockUseOptionalWixClient.mockReturnValue({ callFunction: mockCallFunction });
+    mockCallFunction.mockResolvedValue(API_QUESTS_TODAY);
+    // Capture the callback passed to onQuestRefresh
+    let busCallback: (() => void) | undefined;
+    mockOnQuestRefresh.mockImplementation((cb: () => void) => {
+      busCallback = cb;
+      return jest.fn();
+    });
+
+    renderHook(() => useDailyQuests());
+    await act(async () => {});
+    // Cache hit — API not called yet
+    expect(mockCallFunction).not.toHaveBeenCalled();
+
+    // Simulate bus emission (quest completed mid-session)
+    await act(async () => {
+      busCallback!();
+    });
+    // Bus-triggered refresh bypasses cache → calls API
+    expect(mockCallFunction).toHaveBeenCalledTimes(1);
   });
 
   it('API quest with action "referral" is preserved in mapped quest', async () => {

--- a/src/hooks/__tests__/useGamificationEvents.test.ts
+++ b/src/hooks/__tests__/useGamificationEvents.test.ts
@@ -37,6 +37,12 @@ jest.mock('@/services/analytics', () => ({
   trackEvent: jest.fn(),
 }));
 
+// cf-ma6v: mock questRefreshBus
+const mockEmitQuestRefresh = jest.fn();
+jest.mock('@/services/questRefreshBus', () => ({
+  emitQuestRefresh: () => mockEmitQuestRefresh(),
+}));
+
 beforeEach(() => {
   jest.clearAllMocks();
   mockSendGamificationEvent.mockResolvedValue({ success: true, newTotal: 100 });
@@ -299,6 +305,60 @@ describe('useGamificationEvents', () => {
         null,
         expect.objectContaining({ eventName: 'gamification_style_quiz_complete' }),
       );
+    });
+  });
+
+  // ── questRefreshBus emission (cf-ma6v) ───────────────────────────────────
+
+  describe('questRefreshBus', () => {
+    it('emits quest refresh after successful addToCart', async () => {
+      const { result } = renderHook(() => useGamificationEvents());
+      await result.current.addToCart('prod-1', 49.99);
+      expect(mockEmitQuestRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits quest refresh after successful submitReview', async () => {
+      const { result } = renderHook(() => useGamificationEvents());
+      await result.current.submitReview('prod-1', 5, false);
+      expect(mockEmitQuestRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits quest refresh after successful arUsed', async () => {
+      const { result } = renderHook(() => useGamificationEvents());
+      await result.current.arUsed('prod-1');
+      expect(mockEmitQuestRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits quest refresh after successful wishlistAdd', async () => {
+      const { result } = renderHook(() => useGamificationEvents());
+      await result.current.wishlistAdd('prod-1');
+      expect(mockEmitQuestRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits quest refresh after successful orderPlaced', async () => {
+      const { result } = renderHook(() => useGamificationEvents());
+      await result.current.orderPlaced('order-1', 299.99);
+      expect(mockEmitQuestRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('emits quest refresh after successful styleQuizComplete', async () => {
+      const { result } = renderHook(() => useGamificationEvents());
+      await result.current.styleQuizComplete('modern', 'full');
+      expect(mockEmitQuestRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT emit quest refresh when event fails', async () => {
+      mockSendGamificationEvent.mockResolvedValue({ success: false });
+      const { result } = renderHook(() => useGamificationEvents());
+      await result.current.addToCart('prod-1', 49.99);
+      expect(mockEmitQuestRefresh).not.toHaveBeenCalled();
+    });
+
+    it('does NOT emit quest refresh when event throws', async () => {
+      mockSendGamificationEvent.mockRejectedValue(new Error('network'));
+      const { result } = renderHook(() => useGamificationEvents());
+      await result.current.addToCart('prod-1', 49.99);
+      expect(mockEmitQuestRefresh).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/hooks/useDailyQuests.ts
+++ b/src/hooks/useDailyQuests.ts
@@ -11,9 +11,10 @@
  * cf-mz3
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { useOptionalWixClient } from '@/services/wix';
+import { onQuestRefresh } from '@/services/questRefreshBus';
 
 export type QuestAction =
   | 'purchase'
@@ -154,6 +155,14 @@ export function useDailyQuests(): UseDailyQuestsResult {
   const refresh = useCallback(() => {
     load(true);
   }, [load]);
+
+  // cf-ma6v: subscribe to questRefreshBus so quests re-fetch when a
+  // gamification action completes mid-session (e.g. addToCart, review).
+  const refreshRef = useRef(refresh);
+  refreshRef.current = refresh;
+  useEffect(() => {
+    return onQuestRefresh(() => refreshRef.current());
+  }, []);
 
   return { quests, loading, refresh };
 }

--- a/src/hooks/useGamificationEvents.ts
+++ b/src/hooks/useGamificationEvents.ts
@@ -23,6 +23,7 @@ import { useCallback } from 'react';
 import { useAuth } from '@/hooks/useAuth';
 import { useOptionalWixClient } from '@/services/wix';
 import { sendGamificationEvent, type GamificationEventResult } from '@/services/gamificationApi';
+import { emitQuestRefresh } from '@/services/questRefreshBus';
 
 export interface GamificationEvents {
   addToCart: (productId: string, price: number) => Promise<GamificationEventResult>;
@@ -44,6 +45,12 @@ export interface GamificationEvents {
 
 const FALLBACK: GamificationEventResult = { success: false };
 
+/** cf-ma6v: emit quest refresh after any successful gamification event. */
+function withQuestRefresh(result: GamificationEventResult): GamificationEventResult {
+  if (result.success) emitQuestRefresh();
+  return result;
+}
+
 export function useGamificationEvents(): GamificationEvents {
   const wixClient = useOptionalWixClient();
   const { user } = useAuth();
@@ -52,11 +59,11 @@ export function useGamificationEvents(): GamificationEvents {
   const addToCart = useCallback(
     async (productId: string, price: number): Promise<GamificationEventResult> => {
       try {
-        return await sendGamificationEvent(wixClient ?? null, {
+        return withQuestRefresh(await sendGamificationEvent(wixClient ?? null, {
           eventName: 'gamification_add_to_cart',
           memberId,
           payload: { product_id: productId, price },
-        });
+        }));
       } catch {
         return FALLBACK;
       }
@@ -71,11 +78,11 @@ export function useGamificationEvents(): GamificationEvents {
       hasPhoto: boolean,
     ): Promise<GamificationEventResult> => {
       try {
-        return await sendGamificationEvent(wixClient ?? null, {
+        return withQuestRefresh(await sendGamificationEvent(wixClient ?? null, {
           eventName: 'gamification_submit_review',
           memberId,
           payload: { product_id: productId, rating, has_photo: hasPhoto },
-        });
+        }));
       } catch {
         return FALLBACK;
       }
@@ -86,11 +93,11 @@ export function useGamificationEvents(): GamificationEvents {
   const referralShared = useCallback(
     async (code: string): Promise<GamificationEventResult> => {
       try {
-        return await sendGamificationEvent(wixClient ?? null, {
+        return withQuestRefresh(await sendGamificationEvent(wixClient ?? null, {
           eventName: 'gamification_referral_shared',
           memberId,
           payload: { referral_code: code },
-        });
+        }));
       } catch {
         return FALLBACK;
       }
@@ -101,11 +108,11 @@ export function useGamificationEvents(): GamificationEvents {
   const arUsed = useCallback(
     async (productId: string): Promise<GamificationEventResult> => {
       try {
-        return await sendGamificationEvent(wixClient ?? null, {
+        return withQuestRefresh(await sendGamificationEvent(wixClient ?? null, {
           eventName: 'gamification_ar_used',
           memberId,
           payload: { product_id: productId },
-        });
+        }));
       } catch {
         return FALLBACK;
       }
@@ -116,11 +123,11 @@ export function useGamificationEvents(): GamificationEvents {
   const wishlistAdd = useCallback(
     async (productId: string): Promise<GamificationEventResult> => {
       try {
-        return await sendGamificationEvent(wixClient ?? null, {
+        return withQuestRefresh(await sendGamificationEvent(wixClient ?? null, {
           eventName: 'gamification_wishlist_add',
           memberId,
           payload: { product_id: productId },
-        });
+        }));
       } catch {
         return FALLBACK;
       }
@@ -131,12 +138,12 @@ export function useGamificationEvents(): GamificationEvents {
   const orderPlaced = useCallback(
     async (orderId: string, orderTotal: number): Promise<GamificationEventResult> => {
       try {
-        return await sendGamificationEvent(wixClient ?? null, {
+        return withQuestRefresh(await sendGamificationEvent(wixClient ?? null, {
           eventName: 'gamification_order_placed',
           memberId,
           payload: { order_id: orderId, order_total: orderTotal },
           eventId: orderId,
-        });
+        }));
       } catch {
         return FALLBACK;
       }
@@ -147,11 +154,11 @@ export function useGamificationEvents(): GamificationEvents {
   const styleQuizComplete = useCallback(
     async (stylePreference: string, sizeNeeds: string): Promise<GamificationEventResult> => {
       try {
-        return await sendGamificationEvent(wixClient ?? null, {
+        return withQuestRefresh(await sendGamificationEvent(wixClient ?? null, {
           eventName: 'gamification_style_quiz_complete',
           memberId,
           payload: { style_preference: stylePreference, size_needs: sizeNeeds },
-        });
+        }));
       } catch {
         return FALLBACK;
       }

--- a/src/services/__tests__/questRefreshBus.test.ts
+++ b/src/services/__tests__/questRefreshBus.test.ts
@@ -1,0 +1,83 @@
+/**
+ * @module questRefreshBus.test
+ *
+ * TDD tests for questRefreshBus — lightweight in-app event emitter
+ * that signals DailyQuestsCard to refresh when a quest-relevant
+ * gamification action completes (e.g. addToCart, submitReview, arUsed).
+ *
+ * cf-ma6v
+ */
+
+import {
+  questRefreshBus,
+  onQuestRefresh,
+  emitQuestRefresh,
+} from '../questRefreshBus';
+
+describe('questRefreshBus', () => {
+  afterEach(() => {
+    // Clean up all listeners between tests
+    questRefreshBus.removeAllListeners();
+  });
+
+  it('emitQuestRefresh notifies all subscribers', () => {
+    const listener1 = jest.fn();
+    const listener2 = jest.fn();
+    onQuestRefresh(listener1);
+    onQuestRefresh(listener2);
+
+    emitQuestRefresh();
+
+    expect(listener1).toHaveBeenCalledTimes(1);
+    expect(listener2).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns unsubscribe function that removes only that listener', () => {
+    const listener1 = jest.fn();
+    const listener2 = jest.fn();
+    const unsub = onQuestRefresh(listener1);
+    onQuestRefresh(listener2);
+
+    unsub();
+    emitQuestRefresh();
+
+    expect(listener1).not.toHaveBeenCalled();
+    expect(listener2).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw when emitting with no listeners', () => {
+    expect(() => emitQuestRefresh()).not.toThrow();
+  });
+
+  it('listener is not called after unsubscribe even if emitted multiple times', () => {
+    const listener = jest.fn();
+    const unsub = onQuestRefresh(listener);
+
+    emitQuestRefresh();
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsub();
+    emitQuestRefresh();
+    emitQuestRefresh();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('double unsubscribe is safe (no-op)', () => {
+    const listener = jest.fn();
+    const unsub = onQuestRefresh(listener);
+
+    unsub();
+    expect(() => unsub()).not.toThrow();
+  });
+
+  it('removeAllListeners clears everything', () => {
+    const listener = jest.fn();
+    onQuestRefresh(listener);
+    onQuestRefresh(listener);
+
+    questRefreshBus.removeAllListeners();
+    emitQuestRefresh();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/questRefreshBus.ts
+++ b/src/services/questRefreshBus.ts
@@ -1,0 +1,47 @@
+/**
+ * @module questRefreshBus
+ *
+ * Lightweight in-app event bus that signals DailyQuestsCard to re-fetch
+ * when a quest-relevant gamification action completes mid-session.
+ *
+ * Usage:
+ *   - Producers (useGamificationEvents): call emitQuestRefresh() after
+ *     addToCart / submitReview / arUsed / etc.
+ *   - Consumers (useDailyQuests): subscribe via onQuestRefresh(callback)
+ *     and call refresh() when notified.
+ *
+ * cf-ma6v
+ */
+
+type Listener = () => void;
+
+class QuestRefreshBus {
+  private listeners = new Set<Listener>();
+
+  subscribe(listener: Listener): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  emit(): void {
+    for (const listener of this.listeners) {
+      listener();
+    }
+  }
+
+  removeAllListeners(): void {
+    this.listeners.clear();
+  }
+}
+
+export const questRefreshBus = new QuestRefreshBus();
+
+export function onQuestRefresh(listener: Listener): () => void {
+  return questRefreshBus.subscribe(listener);
+}
+
+export function emitQuestRefresh(): void {
+  questRefreshBus.emit();
+}


### PR DESCRIPTION
## Summary

- Adds `questRefreshBus` — lightweight in-app event emitter (Set-based pub/sub)
- `useDailyQuests` subscribes on mount, calls `refresh()` (cache-bust re-fetch) when notified
- `useGamificationEvents` emits quest refresh after any **successful** gamification action (addToCart, submitReview, arUsed, wishlistAdd, orderPlaced, styleQuizComplete)
- No emit on failure — prevents unnecessary API calls

## Acceptance Criteria (cf-ma6v)

- [x] Quest progress updates without page reload when action completes
- [x] Refresh triggered via gamification events (not polling)
- [x] No refresh on failed events
- [x] Clean subscribe/unsubscribe lifecycle (no memory leaks)

## Test Plan

- [x] questRefreshBus: 6 unit tests (emit, unsubscribe, double-unsub, removeAll, no-listeners)
- [x] useDailyQuests: 3 new tests (subscribes on mount, unsubscribes on unmount, refresh on bus emit)
- [x] useGamificationEvents: 8 new tests (emit on success for each action, no emit on failure/throw)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>