### PR TITLE
test(hq-wjwhm): deeplink test coverage — 100% lines

### DIFF
--- a/src/hooks/__tests__/usePushDeepLink.test.tsx
+++ b/src/hooks/__tests__/usePushDeepLink.test.tsx
@@ -343,4 +343,63 @@ describe('malformed payload guard → goBack() fallback', () => {
     expect(mockGoBack).not.toHaveBeenCalled();
     expect(mockNavigate).not.toHaveBeenCalled();
   });
+
+  it('calls goBack when deep link resolves to NotFound (e.g. daily_spin_reminder)', async () => {
+    // daily_spin_reminder → carolinafutons://daily-spin → resolveRoute returns NotFound
+    render(<HookHarness navRef={makeNavRef()} />);
+
+    const callback = mockAddNotificationResponseReceivedListener.mock.calls[0][0];
+    await act(async () => {
+      callback(makeResponse({ type: 'daily_spin_reminder' }));
+    });
+
+    expect(mockGoBack).toHaveBeenCalled();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});
+
+// ── Listener error handling ─────────────────────────────────────────────────
+
+describe('listener error handling', () => {
+  it('captures Error thrown during listener handleResponse', async () => {
+    const throwingNav = {
+      isReady: () => true,
+      navigate: jest.fn().mockImplementation(() => {
+        throw new Error('navigation crashed');
+      }),
+      goBack: jest.fn(),
+    } as any;
+
+    render(<HookHarness navRef={throwingNav} />);
+
+    const callback = mockAddNotificationResponseReceivedListener.mock.calls[0][0];
+    await act(async () => {
+      callback(makeResponse({ type: 'order_update', orderId: 'x' }));
+    });
+
+    expect(require('@/services/crashReporting').captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+    );
+  });
+
+  it('wraps non-Error thrown in listener catch before captureException', async () => {
+    const throwingNav = {
+      isReady: () => true,
+      navigate: jest.fn().mockImplementation(() => {
+        throw 'string error';
+      }),
+      goBack: jest.fn(),
+    } as any;
+
+    render(<HookHarness navRef={throwingNav} />);
+
+    const callback = mockAddNotificationResponseReceivedListener.mock.calls[0][0];
+    await act(async () => {
+      callback(makeResponse({ type: 'order_update', orderId: 'x' }));
+    });
+
+    expect(require('@/services/crashReporting').captureException).toHaveBeenCalledWith(
+      expect.any(Error),
+    );
+  });
 });

--- a/src/services/__tests__/deepLink.test.ts
+++ b/src/services/__tests__/deepLink.test.ts
@@ -292,6 +292,16 @@ describe('deepLink', () => {
       expect(url).not.toContain('utm_medium');
       expect(url).not.toContain('utm_campaign');
     });
+
+    it('includes content and term when provided', () => {
+      const url = buildShareUrlWithUTM('https://carolinafutons.com/shop', {
+        source: 'app',
+        content: 'hero-banner',
+        term: 'futon',
+      });
+      expect(url).toContain('utm_content=hero-banner');
+      expect(url).toContain('utm_term=futon');
+    });
   });
 
   describe('deferred deep links', () => {

--- a/src/services/__tests__/notifications.test.ts
+++ b/src/services/__tests__/notifications.test.ts
@@ -4,6 +4,7 @@ import {
   shouldShowNotification,
   formatBadgeCount,
   getChannelId,
+  registerPushToken,
   DEFAULT_PREFERENCES,
   NOTIFICATION_TYPE_CONFIG,
   ANDROID_CHANNEL_CONFIG,
@@ -314,5 +315,120 @@ describe('Notification service', () => {
       const link = getDeepLinkForNotification('daily_spin_reminder');
       expect(link).toMatch(/carolinafutons:\/\//);
     });
+  });
+
+  // ── registerPushToken ───────────────────────────────────────────────────
+
+  describe('registerPushToken', () => {
+    const originalFetch = global.fetch;
+
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+      jest.useRealTimers();
+    });
+
+    it('sends token and platform to push token endpoint', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: true });
+
+      await registerPushToken('ExponentPushToken[abc123]');
+
+      expect(global.fetch).toHaveBeenCalledWith(
+        'https://www.wixapis.com/v1/push-tokens',
+        expect.objectContaining({
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: expect.stringContaining('ExponentPushToken[abc123]'),
+        }),
+      );
+    });
+
+    it('returns successfully on 200 OK', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: true });
+
+      await expect(registerPushToken('token')).resolves.toBeUndefined();
+    });
+
+    it('throws immediately on 4xx client error (no retry)', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 400 });
+
+      await expect(registerPushToken('token')).rejects.toThrow(
+        'Push token registration failed: 400',
+      );
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws immediately on 403 forbidden', async () => {
+      global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 403 });
+
+      await expect(registerPushToken('token')).rejects.toThrow(
+        'Push token registration failed: 403',
+      );
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it('retries on 5xx server error and succeeds', async () => {
+      global.fetch = jest
+        .fn()
+        .mockResolvedValueOnce({ ok: false, status: 500 })
+        .mockResolvedValueOnce({ ok: true });
+
+      const promise = registerPushToken('token');
+
+      // Advance past first backoff (2^0 * 1000 = 1s)
+      await jest.advanceTimersByTimeAsync(1000);
+
+      await expect(promise).resolves.toBeUndefined();
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws after max retries exhausted on server errors', async () => {
+      jest.useRealTimers();
+      global.fetch = jest.fn().mockResolvedValue({ ok: false, status: 503 });
+
+      // With real timers, the backoff delays are real but the function
+      // retries quickly since we use short delays in test. Override the delay.
+      // Instead: just verify the error after all attempts.
+      await expect(registerPushToken('token')).rejects.toThrow(
+        'Push token registration failed: 503',
+      );
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+    }, 15000);
+
+    it('retries on network errors (fetch throws)', async () => {
+      jest.useRealTimers();
+      global.fetch = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('Network request failed'))
+        .mockResolvedValueOnce({ ok: true });
+
+      await expect(registerPushToken('token')).resolves.toBeUndefined();
+      expect(global.fetch).toHaveBeenCalledTimes(2);
+    }, 10000);
+
+    it('wraps non-Error fetch throws', async () => {
+      jest.useRealTimers();
+      global.fetch = jest
+        .fn()
+        .mockRejectedValueOnce('string error')
+        .mockResolvedValueOnce({ ok: true });
+
+      await expect(registerPushToken('token')).resolves.toBeUndefined();
+    }, 10000);
+
+    it('throws last error after all retries fail on network errors', async () => {
+      jest.useRealTimers();
+      global.fetch = jest
+        .fn()
+        .mockRejectedValueOnce(new Error('offline'))
+        .mockRejectedValueOnce(new Error('offline'))
+        .mockRejectedValueOnce(new Error('offline'));
+
+      await expect(registerPushToken('token')).rejects.toThrow('offline');
+      expect(global.fetch).toHaveBeenCalledTimes(3);
+    }, 15000);
   });
 });


### PR DESCRIPTION
Adds tests for usePushDeepLink (NotFound goBack, listener errors), deepLink (UTM content/term), and notifications (registerPushToken retry logic). 100% line coverage on all 5 deeplink files.