### PR TITLE
feat(hq-8p0y8): visual search catalog export service

### DIFF
--- a/src/services/__tests__/visualSearch.test.ts
+++ b/src/services/__tests__/visualSearch.test.ts
@@ -202,6 +202,37 @@ describe('fetchCatalogExport', () => {
     expect(result.error).toContain('Too many requests');
   });
 
+  // ── Timeout ─────────────────────────────────────────────────────────
+
+  it('times out on slow first export (post-cache-clear)', async () => {
+    const client: WixClientLike = {
+      callFunction: jest.fn(() => new Promise((resolve) => setTimeout(resolve, 60_000))),
+    };
+
+    const result = await fetchCatalogExport(client, { timeoutMs: 50 });
+
+    expect(result.success).toBe(false);
+    expect(result.error).toBe('Export request timed out');
+  });
+
+  it('returns stale cache on timeout when cache exists', async () => {
+    const cachedData = {
+      products: sampleProducts,
+      staleMinutes: 0,
+      cachedAt: Date.now() - 120_000,
+    };
+    await AsyncStorage.setItem('@cf_visual_search_catalog', JSON.stringify(cachedData));
+
+    const client: WixClientLike = {
+      callFunction: jest.fn(() => new Promise((resolve) => setTimeout(resolve, 60_000))),
+    };
+
+    const result = await fetchCatalogExport(client, { timeoutMs: 50 });
+
+    expect(result.success).toBe(true);
+    expect(result.fromCache).toBe(true);
+  });
+
   // ── Caching ────────────────────────────────────────────────────────────
 
   it('caches API response to AsyncStorage', async () => {

--- a/src/services/visualSearch.ts
+++ b/src/services/visualSearch.ts
@@ -53,6 +53,8 @@ interface WixClientLike {
 
 const WIX_FN = 'visualSearchExport';
 const CACHE_KEY = '@cf_visual_search_catalog';
+/** First post-cache-clear export runs a full Wix Products query and can be slow. */
+const FETCH_TIMEOUT_MS = 45_000;
 
 // ── Cache ─────────────────────────────────────────────────────────────────────
 
@@ -96,7 +98,7 @@ function isCacheFresh(cached: CachedExport): boolean {
  */
 export async function fetchCatalogExport(
   client: WixClientLike | null,
-  options: { clientId?: string; forceRefresh?: boolean } = {},
+  options: { clientId?: string; forceRefresh?: boolean; timeoutMs?: number } = {},
 ): Promise<CatalogExportResult> {
   const empty: CatalogExportResult = { success: false, products: [] };
 
@@ -131,7 +133,13 @@ export async function fetchCatalogExport(
     const body: Record<string, unknown> = {};
     if (options.clientId) body.clientId = options.clientId;
 
-    const response = await client.callFunction(WIX_FN, 'POST', body);
+    const timeout = options.timeoutMs ?? FETCH_TIMEOUT_MS;
+    const response = await Promise.race([
+      client.callFunction(WIX_FN, 'POST', body),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error('Export request timed out')), timeout),
+      ),
+    ]);
 
     if (!response || typeof response !== 'object') {
       return { ...empty, error: 'Malformed API response' };


### PR DESCRIPTION
## Summary

Adds `src/services/visualSearch.ts` — fetches product catalog from Wix visual search batch export API (cf-juq6) and caches locally for downstream embedding generation (hq-r1251).

- Fetch from Wix Web Method `getExportData(clientId)` (no auth, rate-limited 10 req/60s)
- Handles rate limit errors, staleMinutes freshness, network failures
- Supabase embedding storage stubbed pending hq-r1251
- 14 TDD tests: happy path, rate limit, API error, network timeout, empty results, cache freshness

**Note:** Endpoint URL needs confirmation from melania — currently using assumed path, will update once staging CMS collection is confirmed.

## Test plan

- [x] 14 unit tests passing
- [x] Rate limit handling tested
- [x] Supabase layer stubbed (not wired)
- [ ] Integration test against staging (blocked: CMS collection setup pending)

🤖 Generated with [Claude Code](https://claude.com/claude-code)