### PR TITLE
feat(bnpl): Prominent BNPL hero surface on PDP + Cart

### DIFF
--- a/src/components/BNPLHeroSurface.tsx
+++ b/src/components/BNPLHeroSurface.tsx
@@ -1,0 +1,178 @@
+/**
+ * BNPLHeroSurface — Prominent buy-now-pay-later callout for PDP and Cart.
+ *
+ * Surfaces Affirm/Klarna monthly payment prominently in the price section.
+ * Tap opens the BNPLModal payment calculator.
+ *
+ * Two variants:
+ * - `pdp` (default): Full-width card below the price on ProductDetailScreen
+ * - `cart`: Compact card below the cart total on CartScreen
+ */
+import React from 'react';
+import { StyleSheet, View, Text, TouchableOpacity } from 'react-native';
+import { useTheme } from '@/theme';
+import { isFinancingEligible, getFinancingTerms } from '@/utils/financing';
+import { formatPrice } from '@/utils';
+
+interface Props {
+  price: number;
+  variant?: 'pdp' | 'cart';
+  onPress?: () => void;
+  testID?: string;
+}
+
+export function BNPLHeroSurface({ price, variant = 'pdp', onPress, testID = 'bnpl-hero' }: Props) {
+  const { colors, borderRadius, spacing } = useTheme();
+
+  if (!isFinancingEligible(price) || !isFinite(price)) return null;
+
+  const terms = getFinancingTerms(price);
+  if (terms.length === 0) return null;
+
+  const lowestTerm = terms[terms.length - 1];
+  const monthlyDisplay = formatPrice(lowestTerm.monthlyPayment);
+
+  const content = (
+    <View
+      style={[
+        styles.container,
+        variant === 'cart' && styles.containerCart,
+        {
+          backgroundColor: `${colors.mountainBlue}0D`,
+          borderColor: `${colors.mountainBlue}40`,
+          borderRadius: borderRadius.lg,
+        },
+      ]}
+    >
+      <View style={styles.header}>
+        <Text
+          style={[styles.monthlyLabel, { color: colors.textSecondary }]}
+        >
+          Pay as low as
+        </Text>
+        <Text
+          testID={`${testID}-monthly`}
+          style={[
+            styles.monthlyAmount,
+            variant === 'cart' && styles.monthlyAmountCart,
+            { color: colors.mountainBlue },
+          ]}
+        >
+          {monthlyDisplay}/mo
+        </Text>
+      </View>
+
+      <View style={styles.providerRow}>
+        <View style={[styles.providerPill, { backgroundColor: `${colors.mountainBlue}1A` }]}>
+          <Text style={[styles.providerText, { color: colors.mountainBlue }]}>Affirm</Text>
+        </View>
+        <View style={[styles.providerPill, { backgroundColor: `${colors.mountainBlue}1A` }]}>
+          <Text style={[styles.providerText, { color: colors.mountainBlue }]}>Klarna</Text>
+        </View>
+      </View>
+
+      {variant === 'pdp' && (
+        <View style={styles.termsRow}>
+          {terms.map((term) => (
+            <Text
+              key={term.months}
+              style={[styles.termOption, { color: colors.textSecondary }]}
+            >
+              {term.months}mo: {formatPrice(term.monthlyPayment)}
+            </Text>
+          ))}
+        </View>
+      )}
+
+      <Text style={[styles.cta, { color: colors.mountainBlue }]}>
+        See payment options →
+      </Text>
+    </View>
+  );
+
+  const a11yLabel = `Pay as low as ${monthlyDisplay} per month with Affirm or Klarna. Tap to see payment options.`;
+
+  if (onPress) {
+    return (
+      <TouchableOpacity
+        onPress={onPress}
+        testID={testID}
+        accessibilityRole="button"
+        accessibilityLabel={a11yLabel}
+        activeOpacity={0.7}
+        style={{ marginTop: spacing.sm }}
+      >
+        {content}
+      </TouchableOpacity>
+    );
+  }
+
+  return (
+    <View
+      testID={testID}
+      accessibilityRole="button"
+      accessibilityLabel={a11yLabel}
+      style={{ marginTop: spacing.sm }}
+    >
+      {content}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    borderWidth: 1,
+    padding: 16,
+    gap: 8,
+  },
+  containerCart: {
+    padding: 12,
+    gap: 6,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'baseline',
+    gap: 6,
+    flexWrap: 'wrap',
+  },
+  monthlyLabel: {
+    fontSize: 14,
+    fontWeight: '500',
+  },
+  monthlyAmount: {
+    fontSize: 22,
+    fontWeight: '800',
+    letterSpacing: -0.3,
+  },
+  monthlyAmountCart: {
+    fontSize: 18,
+  },
+  providerRow: {
+    flexDirection: 'row',
+    gap: 8,
+  },
+  providerPill: {
+    paddingHorizontal: 10,
+    paddingVertical: 3,
+    borderRadius: 12,
+  },
+  providerText: {
+    fontSize: 12,
+    fontWeight: '700',
+    letterSpacing: 0.3,
+  },
+  termsRow: {
+    flexDirection: 'row',
+    gap: 12,
+    flexWrap: 'wrap',
+  },
+  termOption: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  cta: {
+    fontSize: 13,
+    fontWeight: '700',
+    marginTop: 2,
+  },
+});

--- a/src/components/__tests__/BNPLHeroSurface.test.tsx
+++ b/src/components/__tests__/BNPLHeroSurface.test.tsx
@@ -1,0 +1,149 @@
+/**
+ * BNPLHeroSurface — Tests for the prominent BNPL callout component.
+ *
+ * Surfaces Affirm/Afterpay messaging prominently on PDP price section
+ * and cart total. Tap opens payment calculator (BNPLModal).
+ *
+ * TDD: Tests written before implementation per PM quality gate.
+ */
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { ThemeProvider } from '@/theme/ThemeProvider';
+import { BNPLHeroSurface } from '../BNPLHeroSurface';
+
+// --- Test helpers ---
+
+function renderHero(props: Partial<React.ComponentProps<typeof BNPLHeroSurface>> = {}) {
+  const defaultProps = {
+    price: 899,
+    onPress: jest.fn(),
+    ...props,
+  };
+  return {
+    ...render(
+      <ThemeProvider>
+        <BNPLHeroSurface {...defaultProps} />
+      </ThemeProvider>,
+    ),
+    onPress: defaultProps.onPress,
+  };
+}
+
+// --- Rendering ---
+
+describe('BNPLHeroSurface', () => {
+  describe('Rendering — eligible price', () => {
+    it('renders the hero surface when price is financing-eligible', () => {
+      const { getByTestId } = renderHero({ price: 899 });
+      expect(getByTestId('bnpl-hero')).toBeTruthy();
+    });
+
+    it('shows monthly payment amount', () => {
+      const { getByTestId } = renderHero({ price: 899 });
+      const children = getByTestId('bnpl-hero-monthly').props.children;
+      // children may be array or string — flatten and check for dollar amount
+      const text = Array.isArray(children) ? children.join('') : String(children);
+      expect(text).toMatch(/\$\d+/);
+    });
+
+    it('shows provider names (Affirm and Klarna)', () => {
+      const { getByText } = renderHero({ price: 899 });
+      expect(getByText(/Affirm/)).toBeTruthy();
+      expect(getByText(/Klarna/)).toBeTruthy();
+    });
+
+    it('shows "See payment options" call-to-action', () => {
+      const { getByText } = renderHero({ price: 899 });
+      expect(getByText(/payment options/i)).toBeTruthy();
+    });
+
+    it('renders with pdp variant by default', () => {
+      const { getByTestId } = renderHero({ price: 899 });
+      expect(getByTestId('bnpl-hero')).toBeTruthy();
+    });
+
+    it('renders cart variant when specified', () => {
+      const { getByTestId } = renderHero({ price: 899, variant: 'cart' });
+      expect(getByTestId('bnpl-hero')).toBeTruthy();
+    });
+  });
+
+  describe('Rendering — ineligible price', () => {
+    it('returns null when price is below financing threshold ($299)', () => {
+      const { queryByTestId } = renderHero({ price: 199 });
+      expect(queryByTestId('bnpl-hero')).toBeNull();
+    });
+
+    it('returns null when price is zero', () => {
+      const { queryByTestId } = renderHero({ price: 0 });
+      expect(queryByTestId('bnpl-hero')).toBeNull();
+    });
+
+    it('returns null when price is negative', () => {
+      const { queryByTestId } = renderHero({ price: -100 });
+      expect(queryByTestId('bnpl-hero')).toBeNull();
+    });
+
+    it('returns null when price is NaN', () => {
+      const { queryByTestId } = renderHero({ price: NaN });
+      expect(queryByTestId('bnpl-hero')).toBeNull();
+    });
+  });
+
+  describe('Interaction', () => {
+    it('calls onPress when tapped', () => {
+      const { getByTestId, onPress } = renderHero({ price: 899 });
+      fireEvent.press(getByTestId('bnpl-hero'));
+      expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not crash when onPress is not provided', () => {
+      expect(() => {
+        renderHero({ price: 899, onPress: undefined });
+      }).not.toThrow();
+    });
+  });
+
+  describe('Accessibility', () => {
+    it('has button accessibility role', () => {
+      const { getByTestId } = renderHero({ price: 899 });
+      expect(getByTestId('bnpl-hero').props.accessibilityRole).toBe('button');
+    });
+
+    it('has descriptive accessibility label mentioning monthly payment', () => {
+      const { getByTestId } = renderHero({ price: 899 });
+      const label = getByTestId('bnpl-hero').props.accessibilityLabel;
+      expect(label).toMatch(/\$\d+/);
+      expect(label).toMatch(/month/i);
+    });
+
+    it('has descriptive accessibility label mentioning providers', () => {
+      const { getByTestId } = renderHero({ price: 899 });
+      const label = getByTestId('bnpl-hero').props.accessibilityLabel;
+      expect(label).toMatch(/Affirm|Klarna/i);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('handles price at exact threshold ($299) — not eligible', () => {
+      // Threshold is $299, must be OVER $299 to qualify
+      const { queryByTestId } = renderHero({ price: 299 });
+      expect(queryByTestId('bnpl-hero')).toBeNull();
+    });
+
+    it('handles price just above threshold ($300)', () => {
+      const { getByTestId } = renderHero({ price: 300 });
+      expect(getByTestId('bnpl-hero')).toBeTruthy();
+    });
+
+    it('handles very large price ($99999)', () => {
+      const { getByTestId } = renderHero({ price: 99999 });
+      expect(getByTestId('bnpl-hero')).toBeTruthy();
+    });
+
+    it('accepts custom testID', () => {
+      const { getByTestId } = renderHero({ price: 899, testID: 'custom-bnpl' });
+      expect(getByTestId('custom-bnpl')).toBeTruthy();
+    });
+  });
+});

--- a/src/screens/CartScreen.tsx
+++ b/src/screens/CartScreen.tsx
@@ -36,6 +36,7 @@ import * as Haptics from 'expo-haptics';
 import { useTheme } from '@/theme';
 import { darkPalette } from '@/theme/tokens';
 import { BNPLModal } from '@/components/BNPLModal';
+import { BNPLHeroSurface } from '@/components/BNPLHeroSurface';
 import { BrandedSpinner } from '@/components/BrandedSpinner';
 import { CartItemDeliveryEstimate } from '@/components/CartItemDeliveryEstimate';
 import { EmptyState } from '@/components/EmptyState';
@@ -406,27 +407,15 @@ export function CartScreen({ onCheckout, onContinueShopping, testID }: Props) {
           </View>
         </View>
 
-        {/* BNPL teaser — tap to open installment breakdown modal */}
-        <TouchableOpacity
-          style={[
-            styles.bnplTeaser,
-            {
-              backgroundColor: colors.mountainBlueLight,
-              borderRadius: borderRadius.md,
-              marginHorizontal: spacing.lg,
-            },
-          ]}
-          onPress={() => setBnplModalVisible(true)}
-          testID="bnpl-teaser"
-          accessibilityRole="button"
-          accessibilityLabel="View payment options — pay over time with Klarna or Affirm"
-          activeOpacity={0.7}
-        >
-          <Text style={[styles.bnplText, { color: colors.mountainBlueDark }]}>
-            Or 4 interest-free payments of{' '}
-            <Text style={styles.bnplAmount}>{formatPrice(total / 4)}</Text> with Klarna or Affirm
-          </Text>
-        </TouchableOpacity>
+        {/* BNPL hero — prominent installment messaging */}
+        <View style={{ paddingHorizontal: spacing.lg }}>
+          <BNPLHeroSurface
+            price={total}
+            variant="cart"
+            onPress={() => setBnplModalVisible(true)}
+            testID="bnpl-hero-cart"
+          />
+        </View>
 
         {/* Checkout button */}
         <View style={{ paddingHorizontal: spacing.lg, paddingBottom: spacing.xxl }}>

--- a/src/screens/ProductDetailScreen.tsx
+++ b/src/screens/ProductDetailScreen.tsx
@@ -74,6 +74,7 @@ import { ImageGalleryModal } from '@/components/ImageGalleryModal';
 import { useRecentlyViewed } from '@/hooks/useRecentlyViewed';
 import { usePremium } from '@/hooks/usePremium';
 import { FinancingBadge } from '@/components/FinancingBadge';
+import { BNPLHeroSurface } from '@/components/BNPLHeroSurface';
 import { BNPLModal } from '@/components/BNPLModal';
 import { useBackInStockSubscription } from '@/hooks/useBackInStockSubscription';
 import { getStockStatus } from '@/hooks/useProducts';
@@ -800,11 +801,11 @@ export function ProductDetailScreen({
             isAuthenticated={isAuthenticated}
             testID="pdp-points-chip"
           />
-          <FinancingBadge
+          <BNPLHeroSurface
             price={totalPrice}
-            variant="detail"
+            variant="pdp"
             onPress={() => setBnplModalVisible(true)}
-            testID="product-detail-financing-badge"
+            testID="bnpl-hero-pdp"
           />
           {showInlineRating && (
             <TouchableOpacity

--- a/src/screens/__tests__/CartScreen.test.tsx
+++ b/src/screens/__tests__/CartScreen.test.tsx
@@ -231,7 +231,7 @@ describe('CartScreen', () => {
     it('shows BNPL teaser', () => {
       const seed = [{ model: asheville, fabric: naturalLinen, qty: 1 }];
       const { getByTestId } = renderCartScreen({}, seed);
-      expect(getByTestId('bnpl-teaser')).toBeTruthy();
+      expect(getByTestId('bnpl-hero-cart')).toBeTruthy();
     });
   });
 
@@ -463,7 +463,7 @@ describe('CartScreen', () => {
 
     it('BNPL teaser is shown when cart has items', () => {
       const { getByTestId } = renderCartScreen({}, seed);
-      expect(getByTestId('bnpl-teaser')).toBeTruthy();
+      expect(getByTestId('bnpl-hero-cart')).toBeTruthy();
     });
 
     it('BNPL modal is not visible initially', () => {
@@ -473,33 +473,33 @@ describe('CartScreen', () => {
 
     it('tapping BNPL teaser opens the modal', () => {
       const { getByTestId } = renderCartScreen({}, seed);
-      fireEvent.press(getByTestId('bnpl-teaser'));
+      fireEvent.press(getByTestId('bnpl-hero-cart'));
       expect(getByTestId('bnpl-modal')).toBeTruthy();
     });
 
     it('modal shows installment breakdown after teaser tap', () => {
       const { getByTestId, getByText } = renderCartScreen({}, seed);
-      fireEvent.press(getByTestId('bnpl-teaser'));
+      fireEvent.press(getByTestId('bnpl-hero-cart'));
       expect(getByText('Pay over time')).toBeTruthy();
       expect(getByText('Today')).toBeTruthy();
     });
 
     it('modal shows Klarna tab by default', () => {
       const { getByTestId, getByText } = renderCartScreen({}, seed);
-      fireEvent.press(getByTestId('bnpl-teaser'));
+      fireEvent.press(getByTestId('bnpl-hero-cart'));
       expect(getByText('Continue with Klarna')).toBeTruthy();
     });
 
     it('modal closes when close button pressed', () => {
       const { getByTestId, queryByTestId } = renderCartScreen({}, seed);
-      fireEvent.press(getByTestId('bnpl-teaser'));
+      fireEvent.press(getByTestId('bnpl-hero-cart'));
       fireEvent.press(getByTestId('bnpl-modal-close'));
       expect(queryByTestId('bnpl-continue-btn')).toBeNull();
     });
 
     it('modal closes when overlay pressed', () => {
       const { getByTestId, queryByTestId } = renderCartScreen({}, seed);
-      fireEvent.press(getByTestId('bnpl-teaser'));
+      fireEvent.press(getByTestId('bnpl-hero-cart'));
       fireEvent.press(getByTestId('bnpl-modal-overlay'));
       expect(queryByTestId('bnpl-continue-btn')).toBeNull();
     });

--- a/src/screens/__tests__/ProductDetailScreen.test.tsx
+++ b/src/screens/__tests__/ProductDetailScreen.test.tsx
@@ -1607,7 +1607,7 @@ describe('ProductDetailScreen', () => {
     it('inline rating is positioned after the financing badge', () => {
       const { getByTestId } = renderDetail({ productId: 'asheville-full' });
       // FinancingBadge and inline rating must both be present
-      expect(getByTestId('product-detail-financing-badge')).toBeTruthy();
+      expect(getByTestId('bnpl-hero-pdp')).toBeTruthy();
       expect(getByTestId('price-inline-rating')).toBeTruthy();
     });
 
@@ -1666,39 +1666,39 @@ describe('ProductDetailScreen', () => {
 
     it('tapping financing badge opens BNPL modal', () => {
       const { getByTestId } = renderDetail({ productId: 'asheville-full' });
-      fireEvent.press(getByTestId('product-detail-financing-badge'));
+      fireEvent.press(getByTestId('bnpl-hero-pdp'));
       expect(getByTestId('bnpl-modal')).toBeTruthy();
     });
 
     it('BNPL modal shows installment breakdown after badge tap', () => {
       const { getByTestId, getByText } = renderDetail({ productId: 'asheville-full' });
-      fireEvent.press(getByTestId('product-detail-financing-badge'));
+      fireEvent.press(getByTestId('bnpl-hero-pdp'));
       expect(getByText('Today')).toBeTruthy();
       expect(getByText('In 2 weeks')).toBeTruthy();
     });
 
     it('BNPL modal shows "Pay over time" header', () => {
       const { getByTestId, getByText } = renderDetail({ productId: 'asheville-full' });
-      fireEvent.press(getByTestId('product-detail-financing-badge'));
+      fireEvent.press(getByTestId('bnpl-hero-pdp'));
       expect(getByText('Pay over time')).toBeTruthy();
     });
 
     it('BNPL modal shows Klarna tab by default', () => {
       const { getByTestId, getByText } = renderDetail({ productId: 'asheville-full' });
-      fireEvent.press(getByTestId('product-detail-financing-badge'));
+      fireEvent.press(getByTestId('bnpl-hero-pdp'));
       expect(getByText('Continue with Klarna')).toBeTruthy();
     });
 
     it('BNPL modal closes when close button pressed', () => {
       const { getByTestId, queryByTestId } = renderDetail({ productId: 'asheville-full' });
-      fireEvent.press(getByTestId('product-detail-financing-badge'));
+      fireEvent.press(getByTestId('bnpl-hero-pdp'));
       fireEvent.press(getByTestId('bnpl-modal-close'));
       expect(queryByTestId('bnpl-continue-btn')).toBeNull();
     });
 
     it('BNPL modal closes when overlay pressed', () => {
       const { getByTestId, queryByTestId } = renderDetail({ productId: 'asheville-full' });
-      fireEvent.press(getByTestId('product-detail-financing-badge'));
+      fireEvent.press(getByTestId('bnpl-hero-pdp'));
       fireEvent.press(getByTestId('bnpl-modal-overlay'));
       expect(queryByTestId('bnpl-continue-btn')).toBeNull();
     });


### PR DESCRIPTION
## Summary
- New `BNPLHeroSurface` component surfaces Affirm/Klarna monthly payment prominently in PDP price section and cart total area
- Two variants: `pdp` (full term breakdown with 3/6/12mo options) and `cart` (compact)
- Tap opens existing `BNPLModal` payment calculator
- Replaces smaller `FinancingBadge` (detail) on PDP and inline BNPL teaser on Cart

## Test plan
- [x] 19 new BNPLHeroSurface component tests (rendering, ineligible prices, interaction, accessibility, edge cases)
- [x] Updated PDP tests for new testID (bnpl-hero-pdp)
- [x] Updated Cart tests for new testID (bnpl-hero-cart)
- [x] All 260 related tests passing (259 passed, 1 pre-existing skip)
- [ ] Manual: verify hero renders on PDP below price
- [ ] Manual: verify hero renders on Cart below total
- [ ] Manual: verify tap opens BNPLModal calculator

Bead: cfutons_mobile-vud