### PR TITLE
fix(daily-quests): suppress loading flash during refresh

### DIFF
--- a/src/hooks/__tests__/useDailyQuests.test.ts
+++ b/src/hooks/__tests__/useDailyQuests.test.ts
@@ -183,6 +183,23 @@ describe('useDailyQuests', () => {
     expect(result.current.quests).toHaveLength(3);
   });
 
+  it('does not flash quests to empty during refresh', async () => {
+    mockGetItem.mockResolvedValue(MOCK_QUESTS_JSON);
+    const { result } = renderHook(() => useDailyQuests());
+    await act(async () => {});
+    expect(result.current.quests).toHaveLength(3);
+    expect(result.current.loading).toBe(false);
+
+    // Trigger refresh synchronously — before the async fetch resolves,
+    // loading must NOT go true (which would flash the skeleton over existing quests)
+    act(() => {
+      result.current.refresh();
+    });
+
+    expect(result.current.loading).toBe(false);
+    expect(result.current.quests).toHaveLength(3);
+  });
+
   // ── Quest shape ─────────────────────────────────────────────────────────
 
   it('returned quests have id, title, action, pointReward, completed fields', async () => {

--- a/src/hooks/useDailyQuests.ts
+++ b/src/hooks/useDailyQuests.ts
@@ -106,7 +106,8 @@ export function useDailyQuests(): UseDailyQuestsResult {
 
   const load = useCallback(
     async (bustCache = false) => {
-      setLoading(true);
+      const isInitialLoad = quests.length === 0;
+      if (isInitialLoad) setLoading(true);
       try {
         const today = todayDateString();
 
@@ -145,7 +146,7 @@ export function useDailyQuests(): UseDailyQuestsResult {
         setLoading(false);
       }
     },
-    [wixClient],
+    [wixClient, quests.length],
   );
 
   useEffect(() => {


### PR DESCRIPTION
## Summary

- `useDailyQuests.load()` was calling `setLoading(true)` unconditionally, causing DailyQuestsCard to flash skeleton over existing quests on every refresh
- Fix: only set `loading=true` when `quests.length === 0` (initial load); refreshes keep existing quests visible
- Added `quests.length` to `useCallback` deps

## Test Plan

- [ ] New test: `does not flash quests to empty during refresh` — checks loading stays false when quests already populated at refresh time
- [ ] All 24 `useDailyQuests` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)