### PR TITLE
chore: add react-native-worklets Jest manual mock

### DIFF
--- a/__mocks__/react-native-worklets.js
+++ b/__mocks__/react-native-worklets.js
@@ -1,0 +1,6 @@
+// Stub for react-native-worklets (reanimated v4 dependency)
+// Native module unavailable in Jest — provide empty shim.
+module.exports = {
+  NativeWorklets: {},
+  WorkletsModule: { isAvailable: false },
+};


### PR DESCRIPTION
## Summary
- Adds `__mocks__/react-native-worklets.js` shim for Jest environments where `jest.setup.js` manual mock isn't loaded early enough
- Prevents native module errors in isolated test file runs

## Test plan
- [ ] `npx jest --no-coverage` — confirm no new failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)