### PR TITLE
feat(cm-1r1): ScreenDataState — consistent skeleton→error→retry UX

### DIFF
--- a/src/components/ScreenDataState.tsx
+++ b/src/components/ScreenDataState.tsx
@@ -1,0 +1,65 @@
+/**
+ * @module ScreenDataState
+ *
+ * Composable wrapper for the skeleton → error → content state machine.
+ *
+ * Usage:
+ *   <ScreenDataState
+ *     isLoading={isLoading}
+ *     hasData={data.length > 0}
+ *     error={error}
+ *     onRetry={refresh}
+ *     skeleton={<SkeletonMyList />}
+ *   >
+ *     <MyList />
+ *   </ScreenDataState>
+ *
+ * State machine:
+ *   isLoading && !hasData   → skeleton (or null if no skeleton provided)
+ *   error && !isLoading     → NetworkErrorState with retry button
+ *   otherwise               → children
+ *
+ * cm-1r1: error recovery UX — consistent skeleton→error→retry across screens
+ */
+import React from 'react';
+import { View } from 'react-native';
+import { NetworkErrorState } from './NetworkErrorState';
+
+interface Props {
+  isLoading: boolean;
+  error: string | null | undefined;
+  onRetry: () => void;
+  /** When true, renders children even while reloading (avoids skeleton flash on refresh) */
+  hasData?: boolean;
+  /** Skeleton element to show during initial load */
+  skeleton?: React.ReactElement;
+  children?: React.ReactNode;
+  testID?: string;
+}
+
+export function ScreenDataState({
+  isLoading,
+  error,
+  onRetry,
+  hasData = false,
+  skeleton,
+  children,
+  testID,
+}: Props) {
+  // Initial load: show skeleton (or nothing)
+  if (isLoading && !hasData) {
+    return skeleton ?? null;
+  }
+
+  // Data fetch failed: show inline error + retry
+  if (error && !isLoading) {
+    return <NetworkErrorState message={error} onRetry={onRetry} testID="network-error-state" />;
+  }
+
+  // Success or reload: show children
+  if (testID) {
+    return <View testID={testID}>{children}</View>;
+  }
+
+  return <>{children}</>;
+}

--- a/src/components/__tests__/ScreenDataState.test.tsx
+++ b/src/components/__tests__/ScreenDataState.test.tsx
@@ -1,0 +1,138 @@
+/**
+ * @module ScreenDataState tests — cm-1r1
+ *
+ * Covers:
+ * - Shows skeleton when loading (isLoading=true, no error)
+ * - Shows NetworkErrorState when error + not loading
+ * - Shows children when not loading and no error
+ * - Shows children when loading but already has data (reload scenario)
+ * - Error includes retry callback wired to onRetry
+ * - Shows nothing (null) when loading with no skeleton provided
+ * - testID forwarded to container
+ */
+import React from 'react';
+import { Text } from 'react-native';
+import { render, fireEvent } from '@testing-library/react-native';
+
+import { ScreenDataState } from '../ScreenDataState';
+
+jest.mock('@/theme', () => ({
+  useTheme: () => ({
+    colors: {
+      sunsetCoral: '#E8845C',
+      espresso: '#3A2518',
+      espressoLight: '#7B5E4E',
+      sandLight: '#FAF7F2',
+      mountainBlue: '#5B8FA8',
+    },
+    spacing: { sm: 8, md: 16, lg: 24 },
+    borderRadius: { button: 8 },
+  }),
+}));
+
+const Skeleton = () => <Text testID="skeleton">Loading skeleton</Text>;
+const Content = () => <Text testID="content">My content</Text>;
+
+describe('ScreenDataState', () => {
+  it('shows skeleton when loading with no data', () => {
+    const { getByTestId, queryByTestId } = render(
+      <ScreenDataState isLoading error={null} onRetry={jest.fn()} skeleton={<Skeleton />}>
+        <Content />
+      </ScreenDataState>,
+    );
+    expect(getByTestId('skeleton')).toBeTruthy();
+    expect(queryByTestId('content')).toBeNull();
+    expect(queryByTestId('network-error-state')).toBeNull();
+  });
+
+  it('shows children (not skeleton) when loading but hasData', () => {
+    const { getByTestId, queryByTestId } = render(
+      <ScreenDataState isLoading hasData error={null} onRetry={jest.fn()} skeleton={<Skeleton />}>
+        <Content />
+      </ScreenDataState>,
+    );
+    expect(getByTestId('content')).toBeTruthy();
+    expect(queryByTestId('skeleton')).toBeNull();
+  });
+
+  it('shows error state when error and not loading', () => {
+    const { getByTestId, queryByTestId } = render(
+      <ScreenDataState
+        isLoading={false}
+        error="Network request failed"
+        onRetry={jest.fn()}
+        skeleton={<Skeleton />}
+      >
+        <Content />
+      </ScreenDataState>,
+    );
+    expect(getByTestId('network-error-state')).toBeTruthy();
+    expect(queryByTestId('content')).toBeNull();
+    expect(queryByTestId('skeleton')).toBeNull();
+  });
+
+  it('calls onRetry when retry button pressed', () => {
+    const onRetry = jest.fn();
+    const { getByTestId } = render(
+      <ScreenDataState isLoading={false} error="Oops" onRetry={onRetry} skeleton={<Skeleton />}>
+        <Content />
+      </ScreenDataState>,
+    );
+    fireEvent.press(getByTestId('network-error-retry'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows custom error message', () => {
+    const { getByText } = render(
+      <ScreenDataState
+        isLoading={false}
+        error="Could not load challenges"
+        onRetry={jest.fn()}
+        skeleton={<Skeleton />}
+      >
+        <Content />
+      </ScreenDataState>,
+    );
+    expect(getByText('Could not load challenges')).toBeTruthy();
+  });
+
+  it('shows children when not loading and no error', () => {
+    const { getByTestId, queryByTestId } = render(
+      <ScreenDataState isLoading={false} error={null} onRetry={jest.fn()} skeleton={<Skeleton />}>
+        <Content />
+      </ScreenDataState>,
+    );
+    expect(getByTestId('content')).toBeTruthy();
+    expect(queryByTestId('skeleton')).toBeNull();
+    expect(queryByTestId('network-error-state')).toBeNull();
+  });
+
+  it('shows nothing when loading with no skeleton', () => {
+    const { queryByTestId } = render(
+      <ScreenDataState isLoading error={null} onRetry={jest.fn()}>
+        <Content />
+      </ScreenDataState>,
+    );
+    expect(queryByTestId('skeleton')).toBeNull();
+    expect(queryByTestId('content')).toBeNull();
+  });
+
+  it('forwards testID', () => {
+    const { getByTestId } = render(
+      <ScreenDataState isLoading={false} error={null} onRetry={jest.fn()} testID="my-data-state">
+        <Content />
+      </ScreenDataState>,
+    );
+    expect(getByTestId('my-data-state')).toBeTruthy();
+  });
+
+  it('prioritizes loading over error (skeleton wins when both isLoading + error)', () => {
+    const { getByTestId, queryByTestId } = render(
+      <ScreenDataState isLoading error="Some error" onRetry={jest.fn()} skeleton={<Skeleton />}>
+        <Content />
+      </ScreenDataState>,
+    );
+    expect(getByTestId('skeleton')).toBeTruthy();
+    expect(queryByTestId('network-error-state')).toBeNull();
+  });
+});

--- a/src/hooks/__tests__/useCollections.test.ts
+++ b/src/hooks/__tests__/useCollections.test.ts
@@ -132,4 +132,21 @@ describe('useCollection', () => {
     expect(result.current.products.length).toBeGreaterThan(0);
     expect(result.current.products[0].id).toContain('prod-');
   });
+
+  it('exposes a refresh function for retry', async () => {
+    const { result } = renderHook(() => useCollection('mountain-lodge-living'));
+    await act(async () => {});
+    expect(typeof result.current.refresh).toBe('function');
+  });
+
+  it('re-fetches products when refresh is called', async () => {
+    const { result } = renderHook(() => useCollection('mountain-lodge-living'));
+    await act(async () => {});
+    const callCount = mockQueryProducts.mock.calls.length;
+    await act(async () => {
+      result.current.refresh();
+    });
+    await act(async () => {});
+    expect(mockQueryProducts.mock.calls.length).toBeGreaterThan(callCount);
+  });
 });

--- a/src/hooks/useCollections.ts
+++ b/src/hooks/useCollections.ts
@@ -98,6 +98,7 @@ export function useCollection(slug: string): {
   collection: EditorialCollection | undefined;
   products: Product[];
   isLoading: boolean;
+  refresh: () => void;
 } {
   const { collections } = useCollections();
   const client = useOptionalWixClient();
@@ -128,7 +129,7 @@ export function useCollection(slug: string): {
       .filter((p): p is Product => p !== undefined);
   }, [collection, client]);
 
-  const { data, isLoading } = useDataCache<Product[]>(
+  const { data, isLoading, refresh } = useDataCache<Product[]>(
     `collection-products-${slug}`,
     productFetcher,
     { maxAge: COLLECTION_CACHE_MAX_AGE },
@@ -139,7 +140,8 @@ export function useCollection(slug: string): {
       collection,
       products: data ?? [],
       isLoading,
+      refresh,
     }),
-    [collection, data, isLoading],
+    [collection, data, isLoading, refresh],
   );
 }

--- a/src/screens/CollectionsScreen.tsx
+++ b/src/screens/CollectionsScreen.tsx
@@ -8,7 +8,7 @@
  */
 
 import React, { useCallback } from 'react';
-import { Alert, FlatList, StyleSheet, Text, TouchableOpacity, View } from 'react-native';
+import { Alert, FlatList, StyleSheet, Text, View } from 'react-native';
 import { useNavigation } from '@react-navigation/native';
 import type { NativeStackNavigationProp } from '@react-navigation/native-stack';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -21,6 +21,7 @@ import { CollectionCard } from '@/components/CollectionCard';
 import { PremiumBadge } from '@/components/PremiumBadge';
 import { Header } from '@/components/Header';
 import { SkeletonCollectionCard } from '@/components/SkeletonCollectionCard';
+import { ScreenDataState } from '@/components/ScreenDataState';
 import { useScrollPerformance } from '@/hooks/useScrollPerformance';
 import type { RootStackParamList } from '@/navigation/AppNavigator';
 import type { EditorialCollection } from '@/data/collections';
@@ -116,44 +117,26 @@ export function CollectionsScreen() {
     [colors, spacing, typography],
   );
 
-  const renderContent = () => {
-    if (isLoading) {
-      return (
-        <View
-          testID="collections-skeleton"
-          style={{ paddingHorizontal: spacing.pagePadding, paddingTop: spacing.lg }}
-        >
-          {[0, 1, 2, 3].map((i) => (
-            <SkeletonCollectionCard key={i} testID={`skeleton-collection-card-${i}`} />
-          ))}
-        </View>
-      );
-    }
+  const skeleton = (
+    <View
+      testID="collections-skeleton"
+      style={{ paddingHorizontal: spacing.pagePadding, paddingTop: spacing.lg }}
+    >
+      {[0, 1, 2, 3].map((i) => (
+        <SkeletonCollectionCard key={i} testID={`skeleton-collection-card-${i}`} />
+      ))}
+    </View>
+  );
 
-    if (error) {
-      return (
-        <View testID="collections-error" style={styles.centerContent}>
-          <Text
-            testID="collections-error-message"
-            style={[typography.body, { color: colors.espressoLight, textAlign: 'center' }]}
-          >
-            Something went wrong loading collections.
-          </Text>
-          <TouchableOpacity
-            testID="collections-retry-btn"
-            onPress={refresh}
-            style={[styles.retryBtn, { backgroundColor: colors.espresso }]}
-          >
-            <Text style={[typography.body, { color: colors.white, fontWeight: '600' }]}>
-              Try Again
-            </Text>
-          </TouchableOpacity>
-        </View>
-      );
-    }
-
-    if (collections.length === 0) {
-      return (
+  const renderContent = () => (
+    <ScreenDataState
+      isLoading={isLoading}
+      hasData={collections.length > 0}
+      error={error ? error.message || 'Something went wrong loading collections.' : null}
+      onRetry={refresh}
+      skeleton={skeleton}
+    >
+      {collections.length === 0 ? (
         <View testID="collections-empty" style={styles.centerContent}>
           <Text
             testID="collections-empty-message"
@@ -162,35 +145,33 @@ export function CollectionsScreen() {
             No collections available right now.
           </Text>
         </View>
-      );
-    }
-
-    return (
-      <FlatList
-        testID="collections-list"
-        data={collections}
-        keyExtractor={keyExtractor}
-        renderItem={renderItem}
-        ItemSeparatorComponent={renderSeparator}
-        ListHeaderComponent={renderHeader}
-        contentContainerStyle={{
-          paddingTop: spacing.lg,
-          paddingBottom: insets.bottom + spacing.xl,
-        }}
-        showsVerticalScrollIndicator={false}
-        windowSize={5}
-        maxToRenderPerBatch={6}
-        removeClippedSubviews
-        getItemLayout={(_data, index) => ({
-          length: ESTIMATED_COLLECTION_CARD_HEIGHT,
-          offset: ESTIMATED_COLLECTION_CARD_HEIGHT * index,
-          index,
-        })}
-        onScrollBeginDrag={scrollPerf.onScrollBeginDrag}
-        onScrollEndDrag={scrollPerf.onScrollEndDrag}
-      />
-    );
-  };
+      ) : (
+        <FlatList
+          testID="collections-list"
+          data={collections}
+          keyExtractor={keyExtractor}
+          renderItem={renderItem}
+          ItemSeparatorComponent={renderSeparator}
+          ListHeaderComponent={renderHeader}
+          contentContainerStyle={{
+            paddingTop: spacing.lg,
+            paddingBottom: insets.bottom + spacing.xl,
+          }}
+          showsVerticalScrollIndicator={false}
+          windowSize={5}
+          maxToRenderPerBatch={6}
+          removeClippedSubviews
+          getItemLayout={(_data, index) => ({
+            length: ESTIMATED_COLLECTION_CARD_HEIGHT,
+            offset: ESTIMATED_COLLECTION_CARD_HEIGHT * index,
+            index,
+          })}
+          onScrollBeginDrag={scrollPerf.onScrollBeginDrag}
+          onScrollEndDrag={scrollPerf.onScrollEndDrag}
+        />
+      )}
+    </ScreenDataState>
+  );
 
   return (
     <View
@@ -219,12 +200,6 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     padding: 32,
     gap: 16,
-  },
-  retryBtn: {
-    paddingHorizontal: 24,
-    paddingVertical: 10,
-    borderRadius: 8,
-    marginTop: 8,
   },
   earlyAccessOverlay: {
     flexDirection: 'row',

--- a/src/screens/__tests__/CollectionsScreen.test.tsx
+++ b/src/screens/__tests__/CollectionsScreen.test.tsx
@@ -166,7 +166,7 @@ describe('CollectionsScreen — skeleton loading', () => {
       isLoading: true,
     });
     const { queryByTestId } = renderCollectionsScreen();
-    expect(queryByTestId('collections-error')).toBeNull();
+    expect(queryByTestId('network-error-state')).toBeNull();
   });
 
   it('does not show empty state while loading', () => {
@@ -191,7 +191,7 @@ describe('CollectionsScreen — error state', () => {
       error: new Error('Network error'),
     });
     const { getByTestId } = renderCollectionsScreen();
-    expect(getByTestId('collections-error')).toBeTruthy();
+    expect(getByTestId('network-error-state')).toBeTruthy();
   });
 
   it('shows error message text', () => {
@@ -201,8 +201,8 @@ describe('CollectionsScreen — error state', () => {
       isLoading: false,
       error: new Error('Network error'),
     });
-    const { getByTestId } = renderCollectionsScreen();
-    expect(getByTestId('collections-error-message')).toBeTruthy();
+    const { getByText } = renderCollectionsScreen();
+    expect(getByText('Network error')).toBeTruthy();
   });
 
   it('shows retry button on error', () => {
@@ -213,7 +213,7 @@ describe('CollectionsScreen — error state', () => {
       error: new Error('Network error'),
     });
     const { getByTestId } = renderCollectionsScreen();
-    expect(getByTestId('collections-retry-btn')).toBeTruthy();
+    expect(getByTestId('network-error-retry')).toBeTruthy();
   });
 
   it('calls refresh when retry button is pressed', () => {
@@ -226,7 +226,7 @@ describe('CollectionsScreen — error state', () => {
       refresh: mockRefresh,
     });
     const { getByTestId } = renderCollectionsScreen();
-    fireEvent.press(getByTestId('collections-retry-btn'));
+    fireEvent.press(getByTestId('network-error-retry'));
     expect(mockRefresh).toHaveBeenCalledTimes(1);
   });
 
@@ -277,7 +277,7 @@ describe('CollectionsScreen — empty state', () => {
     });
     const { queryByTestId } = renderCollectionsScreen();
     expect(queryByTestId('collections-skeleton')).toBeNull();
-    expect(queryByTestId('collections-error')).toBeNull();
+    expect(queryByTestId('network-error-state')).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

- **New `ScreenDataState` component**: composable wrapper for the skeleton→error→retry state machine. Eliminates repeated inline if/else loading/error blocks across screens.
- **`useCollection(slug)` exposes `refresh()`**: callers can trigger retry on product hydration failure.
- **`CollectionsScreen` refactored**: replaced custom inline error/skeleton/retry blocks with `ScreenDataState`. Error button now uses the branded `NetworkErrorState`.
- **Tests updated**: `CollectionsScreen` tests use `network-error-state` / `network-error-retry` testIDs from `NetworkErrorState`.

## Test plan

- [x] 8 `ScreenDataState` unit tests
- [x] 2 `useCollection` refresh tests
- [x] `CollectionsScreen` error/skeleton/retry/empty tests — all pass
- [x] 40/40 tests pass on Linux

Closes cm-1r1

🤖 Generated with [Claude Code](https://claude.com/claude-code)