### PR TITLE
fix(8sq): guard invalidatePersonalizationCache + SommelierHeroCard null flavors

### DIFF
--- a/src/components/SommelierHeroCard.tsx
+++ b/src/components/SommelierHeroCard.tsx
@@ -75,7 +75,7 @@ export function SommelierHeroCard({ result, onSeePicks }: SommelierHeroCardProps
       </Text>
 
       <View style={{ flexDirection: 'row', flexWrap: 'wrap', marginBottom: spacing.md }}>
-        {result.flavors.map((f) => (
+        {(result.flavors ?? []).map((f) => (
           <View
             key={f}
             style={{

--- a/src/components/__tests__/SommelierHeroCard.test.tsx
+++ b/src/components/__tests__/SommelierHeroCard.test.tsx
@@ -86,3 +86,19 @@ it('dismiss button has accessibilityLabel', async () => {
   await waitFor(() => expect(getByTestId('sommelier-hero-dismiss')).toBeTruthy());
   expect(getByTestId('sommelier-hero-dismiss').props.accessibilityLabel).toBeTruthy();
 });
+
+it('renders without crashing when flavors is null', async () => {
+  const resultNullFlavors = { ...sampleResult, flavors: null as unknown as string[] };
+  const { getByTestId } = render(
+    <SommelierHeroCard result={resultNullFlavors} onSeePicks={mockOnSeePicks} />,
+  );
+  await waitFor(() => expect(getByTestId('sommelier-hero-card')).toBeTruthy());
+});
+
+it('renders without crashing when flavors is undefined', async () => {
+  const resultUndefinedFlavors = { ...sampleResult, flavors: undefined as unknown as string[] };
+  const { getByTestId } = render(
+    <SommelierHeroCard result={resultUndefinedFlavors} onSeePicks={mockOnSeePicks} />,
+  );
+  await waitFor(() => expect(getByTestId('sommelier-hero-card')).toBeTruthy());
+});

--- a/src/services/__tests__/personalizationCache.test.ts
+++ b/src/services/__tests__/personalizationCache.test.ts
@@ -117,3 +117,8 @@ it('does not throw when AsyncStorage fails', async () => {
   (AsyncStorage.getItem as jest.Mock).mockRejectedValue(new Error('storage error'));
   await expect(getCachedFitScore('prod-1', 'member-1')).resolves.toBeNull();
 });
+
+it('invalidatePersonalizationCache does not throw when AsyncStorage.removeItem fails', async () => {
+  (AsyncStorage.removeItem as jest.Mock).mockRejectedValue(new Error('remove failed'));
+  await expect(invalidatePersonalizationCache()).resolves.toBeUndefined();
+});

--- a/src/services/personalizationCache.ts
+++ b/src/services/personalizationCache.ts
@@ -85,8 +85,12 @@ export async function setCachedSommelierResult(
 }
 
 export async function invalidatePersonalizationCache(): Promise<void> {
-  await Promise.all([
-    AsyncStorage.removeItem(FIT_SCORE_KEY),
-    AsyncStorage.removeItem(SOMMELIER_KEY),
-  ]);
+  try {
+    await Promise.all([
+      AsyncStorage.removeItem(FIT_SCORE_KEY),
+      AsyncStorage.removeItem(SOMMELIER_KEY),
+    ]);
+  } catch (e) {
+    console.error('[personalizationCache] invalidate failed:', e);
+  }
 }


### PR DESCRIPTION
Fast-follow from bishop PR #374 review.\n\n- invalidatePersonalizationCache: try/catch around Promise.all prevents stale cache on AsyncStorage failure\n- SommelierHeroCard: (result.flavors ?? []).map() prevents crash on null/undefined flavors\n- 3 new tests, 20 total passing\n\n🤖 Generated with Claude Code