### PR TITLE
feat(cm-1r1): CategoryScreen error recovery — skeleton + NetworkErrorState + retry

### DIFF
--- a/src/screens/CategoryScreen.tsx
+++ b/src/screens/CategoryScreen.tsx
@@ -19,6 +19,8 @@ import { SortPicker } from '@/components/SortPicker';
 import { FilterButton } from '@/components/FilterButton';
 import { FilterModal } from '@/components/FilterModal';
 import { EmptyState } from '@/components/EmptyState';
+import { NetworkErrorState } from '@/components/NetworkErrorState';
+import { SkeletonProductGrid } from '@/components/SkeletonProductCard';
 
 /** Estimated height (px) of a single product-grid row (two-column layout). */
 const ESTIMATED_PRODUCT_ROW_HEIGHT = 262;
@@ -70,6 +72,7 @@ export function CategoryScreen({
     activeFilterCount,
     availableFabrics,
     priceExtent,
+    isInitialLoading,
     fetchError,
     setSortBy,
     setFilters,
@@ -138,18 +141,6 @@ export function CategoryScreen({
             {products.length} {products.length === 1 ? 'product' : 'products'}
           </Text>
         </View>
-        {/* Fetch error banner */}
-        {fetchError && (
-          <View
-            style={[styles.errorBanner, { backgroundColor: colors.sunsetCoralLight ?? '#FEE2E2' }]}
-            testID="category-fetch-error"
-            accessibilityRole="alert"
-          >
-            <Text style={[styles.errorText, { color: colors.sunsetCoralDark ?? '#991B1B' }]}>
-              Unable to load products. Pull to refresh.
-            </Text>
-          </View>
-        )}
         <SortPicker
           value={sortBy}
           onChange={setSortBy}
@@ -160,17 +151,7 @@ export function CategoryScreen({
         />
       </View>
     ),
-    [
-      title,
-      products.length,
-      sortBy,
-      activeFilterCount,
-      fetchError,
-      colors,
-      spacing,
-      onBack,
-      setSortBy,
-    ],
+    [title, products.length, sortBy, activeFilterCount, colors, spacing, onBack, setSortBy],
   );
 
   const renderEmpty = useCallback(
@@ -185,6 +166,20 @@ export function CategoryScreen({
     ),
     [title, onBack],
   );
+
+  if (isInitialLoading) {
+    return <SkeletonProductGrid count={4} testID="skeleton-category-grid" />;
+  }
+
+  if (fetchError) {
+    return (
+      <NetworkErrorState
+        message={fetchError.message}
+        onRetry={refresh}
+        testID="network-error-state"
+      />
+    );
+  }
 
   return (
     <View
@@ -265,17 +260,5 @@ const styles = StyleSheet.create({
   },
   row: {
     paddingHorizontal: 10,
-  },
-  errorBanner: {
-    marginHorizontal: 16,
-    marginBottom: 8,
-    paddingVertical: 10,
-    paddingHorizontal: 14,
-    borderRadius: 8,
-  },
-  errorText: {
-    fontSize: 13,
-    fontWeight: '600',
-    textAlign: 'center',
   },
 });

--- a/src/screens/__tests__/CategoryScreen.error.test.tsx
+++ b/src/screens/__tests__/CategoryScreen.error.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * CategoryScreen — error recovery
+ *
+ * Tests for the isLoading → skeleton and fetchError → NetworkErrorState → retry cycle.
+ * Kept separate from CategoryScreen.test.tsx which uses real hook data.
+ */
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import { CategoryScreen } from '../CategoryScreen';
+import { ThemeProvider } from '@/theme/ThemeProvider';
+import { WishlistProvider } from '@/hooks/useWishlist';
+import { CompareProvider } from '@/contexts/CompareContext';
+import * as useProductsModule from '@/hooks/useProducts';
+import type { ProductCategory, ProductFilters } from '@/hooks/useProducts';
+
+const EMPTY_FILTERS: ProductFilters = {
+  sizes: [],
+  fabrics: [],
+  colorFamilies: [],
+  priceRange: null,
+};
+
+const BASE = {
+  products: [],
+  categories: [],
+  searchQuery: '',
+  selectedCategory: null as ProductCategory | null,
+  sortBy: 'featured' as const,
+  filters: EMPTY_FILTERS,
+  activeFilterCount: 0,
+  availableFabrics: [],
+  priceExtent: [0, 1000] as [number, number],
+  isLoading: false,
+  isInitialLoading: false,
+  hasMore: false,
+  suggestions: [],
+  isFromCache: true,
+  fetchError: null as Error | null,
+  setSearchQuery: jest.fn(),
+  setSelectedCategory: jest.fn(),
+  setSortBy: jest.fn(),
+  setFilters: jest.fn(),
+  loadMore: jest.fn(),
+  refresh: jest.fn(),
+};
+
+function renderCategory() {
+  return render(
+    <ThemeProvider>
+      <WishlistProvider>
+        <CompareProvider>
+          <CategoryScreen onProductPress={jest.fn()} onBack={jest.fn()} />
+        </CompareProvider>
+      </WishlistProvider>
+    </ThemeProvider>,
+  );
+}
+
+describe('CategoryScreen — error recovery', () => {
+  let spy: jest.SpyInstance;
+
+  beforeEach(() => {
+    spy = jest.spyOn(useProductsModule, 'useProducts').mockReturnValue(BASE);
+  });
+
+  afterEach(() => {
+    spy.mockRestore();
+    jest.clearAllMocks();
+  });
+
+  describe('skeleton loading', () => {
+    it('shows skeleton when isInitialLoading is true', () => {
+      spy.mockReturnValue({ ...BASE, isInitialLoading: true });
+      const { getByTestId } = renderCategory();
+      expect(getByTestId('skeleton-category-grid')).toBeTruthy();
+    });
+
+    it('does not show skeleton when not loading', () => {
+      spy.mockReturnValue({ ...BASE, isInitialLoading: false });
+      const { queryByTestId } = renderCategory();
+      expect(queryByTestId('skeleton-category-grid')).toBeNull();
+    });
+  });
+
+  describe('error state', () => {
+    it('shows error state when fetchError is set and not loading', () => {
+      spy.mockReturnValue({
+        ...BASE,
+        fetchError: new Error('Wix catalog unavailable'),
+      });
+      const { getByTestId } = renderCategory();
+      expect(getByTestId('network-error-state')).toBeTruthy();
+    });
+
+    it('shows retry button when fetchError is set', () => {
+      spy.mockReturnValue({
+        ...BASE,
+        fetchError: new Error('Network timeout'),
+      });
+      const { getByTestId } = renderCategory();
+      expect(getByTestId('network-error-retry')).toBeTruthy();
+    });
+
+    it('calls refresh when retry button is pressed', () => {
+      const mockRefresh = jest.fn();
+      spy.mockReturnValue({
+        ...BASE,
+        fetchError: new Error('Network timeout'),
+        refresh: mockRefresh,
+      });
+      const { getByTestId } = renderCategory();
+      fireEvent.press(getByTestId('network-error-retry'));
+      expect(mockRefresh).toHaveBeenCalledTimes(1);
+    });
+
+    it('shows skeleton not error while initially loading even if fetchError set', () => {
+      spy.mockReturnValue({
+        ...BASE,
+        isInitialLoading: true,
+        fetchError: new Error('race condition'),
+      });
+      const { queryByTestId, getByTestId } = renderCategory();
+      expect(queryByTestId('network-error-state')).toBeNull();
+      expect(getByTestId('skeleton-category-grid')).toBeTruthy();
+    });
+
+    it('does not show error state when fetchError is null', () => {
+      spy.mockReturnValue({ ...BASE, fetchError: null });
+      const { queryByTestId } = renderCategory();
+      expect(queryByTestId('network-error-state')).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Completes the cm-1r1 error recovery pass for CategoryScreen — the last major data-loading screen missing consistent skeleton→error→retry states.

- **Skeleton**: `isInitialLoading` → `SkeletonProductGrid` (testID: `skeleton-category-grid`)
- **Error state**: `fetchError` → `NetworkErrorState` full-screen (testID: `network-error-state`) replacing the old inline error banner
- **Retry**: button calls `refresh()` from `useProducts` (testID: `network-error-retry`)
- Consistent with ShopScreen, SearchScreen, CollectionsScreen error recovery pattern
- Removed now-redundant `errorBanner`/`errorText` styles

## Test plan

- [x] 7 new tests in `CategoryScreen.error.test.tsx`: skeleton shows on initial load, error state shows on fetchError, retry calls refresh, skeleton wins over error during initial load, null error = no error state
- [x] Existing 20 CategoryScreen tests still pass (27 total)
- [x] Full suite: 7343 passing (3 pre-existing failures from cm-7ot/OrderHistoryScreen unrelated to this change)

Generated with Claude Code