### PR TITLE
fix(cm-7ot): OrderHistoryScreen — add useCart mock to test suite

### DIFF
--- a/src/screens/__tests__/OrderHistoryScreen.test.tsx
+++ b/src/screens/__tests__/OrderHistoryScreen.test.tsx
@@ -13,6 +13,25 @@ jest.mock('@/hooks/useOrders', () => ({
   useOrders: () => mockUseOrders(),
 }));
 
+jest.mock('@/hooks/useCart', () => ({
+  ...jest.requireActual('@/hooks/useCart'),
+  useCart: () => ({
+    addItem: jest.fn(),
+    items: [],
+    itemCount: 0,
+    subtotal: 0,
+    syncing: false,
+    removeItem: jest.fn(),
+    updateQuantity: jest.fn(),
+    clearCart: jest.fn(),
+    pendingSync: 0,
+    isSyncing: false,
+    loadItems: jest.fn(),
+    syncError: null,
+    clearSyncError: jest.fn(),
+  }),
+}));
+
 function renderOrderHistory(props: Partial<React.ComponentProps<typeof OrderHistoryScreen>> = {}) {
   return render(
     <ThemeProvider>


### PR DESCRIPTION
## Summary

- `OrderHistoryScreen` and `useOrders` hook were already fully implemented (screen, hook, 101 tests)
- All 30 tests in `OrderHistoryScreen.test.tsx` were failing because the screen calls `useCart` for the Reorder CTA, but the test wrapper only provided `ThemeProvider` — triggering `useCart must be used within a CartProvider`
- Fix: added a `useCart` module mock (matching the pattern in `OrderHistoryScreen.reorder.test.tsx`) — no `CartProvider` needed in the wrapper

## Test plan

- [x] `OrderHistoryScreen.test.tsx`: 30 tests — all pass
- [x] `OrderHistoryScreen.reorder.test.tsx`: 21 tests — all pass  
- [x] `useOrders.test.ts`: 50 tests — all pass
- [x] Total: 101/101 pass

## Bead spec coverage

| Requirement | Status |
|-------------|--------|
| Past orders list with status badges | ✅ |
| Order number, date, items summary, total per row | ✅ |
| Status badges: Pending/Processing/Shipped/Delivered/Cancelled | ✅ |
| Tap → OrderDetailScreen | ✅ wired via `onSelectOrder` |
| Reorder CTA per row | ✅ adds all line items to cart |
| Empty state | ✅ `orders-empty-state` + Start Shopping CTA |
| Loading skeleton | ✅ `SkeletonOrderList` shown while `isLoading` |
| Error state + retry | ✅ branded MountainSkyline + retry button |
| TDD | ✅ comprehensive test suite pre-existed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)