### PR TITLE
fix(ci): resolve screen-refactor-hooks test + prettier errors

### DIFF
--- a/src/components/MiniCartDrawer.tsx
+++ b/src/components/MiniCartDrawer.tsx
@@ -16,7 +16,13 @@
 import React, { useCallback } from 'react';
 import { StyleSheet, View, Text, TouchableOpacity, Pressable, ScrollView } from 'react-native';
 import { Image } from 'expo-image';
-import Animated, { SlideInDown, SlideOutDown, FadeIn, FadeOut, runOnJS } from 'react-native-reanimated';
+import Animated, {
+  SlideInDown,
+  SlideOutDown,
+  FadeIn,
+  FadeOut,
+  runOnJS,
+} from 'react-native-reanimated';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 import { useTheme } from '@/theme';
 import { useCart, type CartItem } from '@/hooks/useCart';

--- a/src/components/__tests__/TierCelebrationModal.test.tsx
+++ b/src/components/__tests__/TierCelebrationModal.test.tsx
@@ -98,9 +98,7 @@ describe('TierCelebrationModal', () => {
       jest.spyOn(AccessibilityInfo, 'isReduceMotionEnabled').mockResolvedValue(true);
       const { queryByTestId } = renderModal('gold');
       // Wait for the async isReduceMotionEnabled to resolve and state to update
-      await waitFor(() =>
-        expect(queryByTestId('tier-celebration-confetti')).toBeNull(),
-      );
+      await waitFor(() => expect(queryByTestId('tier-celebration-confetti')).toBeNull());
       jest.restoreAllMocks();
     });
   });

--- a/src/screens/CartScreen.tsx
+++ b/src/screens/CartScreen.tsx
@@ -76,7 +76,16 @@ interface Props {
  */
 export function CartScreen({ onCheckout, onContinueShopping, testID }: Props) {
   const { colors, spacing, borderRadius, shadows, typography } = useTheme();
-  const { items, itemCount, subtotal, removeItem, updateQuantity, clearCart, syncError, clearSyncError } = useCart();
+  const {
+    items,
+    itemCount,
+    subtotal,
+    removeItem,
+    updateQuantity,
+    clearCart,
+    syncError,
+    clearSyncError,
+  } = useCart();
   const { isAuthenticated } = useAuth();
   const promo = usePromoCode();
   const { points } = useLoyalty();

--- a/src/screens/OrderHistoryScreen.tsx
+++ b/src/screens/OrderHistoryScreen.tsx
@@ -17,7 +17,7 @@ import { MountainSkyline } from '@/components/MountainSkyline';
 import { SkeletonOrderList } from '@/components/SkeletonOrderCard';
 import { useOrders, ORDER_STATUS_CONFIG, type Order } from '@/hooks/useOrders';
 import { useCart } from '@/hooks/useCart';
-import { FUTON_MODELS, FABRICS } from '@/data/futons';
+import { useFutonModels } from '@/hooks/useFutonModels';
 import {
   MountainRefreshControl,
   MountainRefreshIndicator,
@@ -42,6 +42,7 @@ export function OrderHistoryScreen({
   const [refreshing, setRefreshing] = useState(false);
   const { orders: hookOrders, isLoading, error: hookError, refresh: hookRefresh } = useOrders();
   const { addItem } = useCart();
+  const { getModel, getFabric } = useFutonModels();
 
   // Use prop orders or fall back to hook data (already sorted newest-first)
   const orders = ordersProp
@@ -68,14 +69,14 @@ export function OrderHistoryScreen({
   const handleReorder = useCallback(
     (order: Order) => {
       for (const lineItem of order.items) {
-        const model = FUTON_MODELS.find((m) => m.id === lineItem.modelId);
-        const fabric = FABRICS.find((f) => f.id === lineItem.fabricId);
+        const model = getModel(lineItem.modelId);
+        const fabric = getFabric(lineItem.fabricId);
         if (model && fabric) {
           addItem(model, fabric, lineItem.quantity);
         }
       }
     },
-    [addItem],
+    [addItem, getModel, getFabric],
   );
 
   const renderOrder = useCallback(

--- a/src/screens/__tests__/CartScreen.sync-error.test.tsx
+++ b/src/screens/__tests__/CartScreen.sync-error.test.tsx
@@ -35,8 +35,13 @@ jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
   const { View } = require('react-native');
   const MockSwipeable = React.forwardRef(
     ({ children, onSwipeableOpen, testID, renderRightActions }: any, _ref: any) => (
-      <View testID={testID} onSwipeableOpen={() => onSwipeableOpen?.('right', { close: jest.fn() })}>
-        {renderRightActions ? renderRightActions({ value: 1 }, { value: -100 }, { close: jest.fn() }) : null}
+      <View
+        testID={testID}
+        onSwipeableOpen={() => onSwipeableOpen?.('right', { close: jest.fn() })}
+      >
+        {renderRightActions
+          ? renderRightActions({ value: 1 }, { value: -100 }, { close: jest.fn() })
+          : null}
         {children}
       </View>
     ),
@@ -128,9 +133,7 @@ describe('CartScreen — sync error recovery (cm-vjz)', () => {
 
       // Wait for rollback — item disappears after rejection propagates
       await waitFor(() => {
-        expect(
-          queryByTestId(`cart-item-${asheville.id}:${naturalLinen.id}`),
-        ).toBeNull();
+        expect(queryByTestId(`cart-item-${asheville.id}:${naturalLinen.id}`)).toBeNull();
       });
     });
 

--- a/src/screens/__tests__/HomeScreen.test.tsx
+++ b/src/screens/__tests__/HomeScreen.test.tsx
@@ -12,7 +12,11 @@ jest.mock('@/components/LivingSkyBackground', () => {
 jest.mock('@/components/WildlifeLayer', () => {
   const { View } = require('react-native');
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  return { WildlifeLayer: ({ skyState }: any) => <View testID="wildlife-layer" accessibilityLabel={`birdOpacity:${skyState.birdOpacity}`} /> };
+  return {
+    WildlifeLayer: ({ skyState }: any) => (
+      <View testID="wildlife-layer" accessibilityLabel={`birdOpacity:${skyState.birdOpacity}`} />
+    ),
+  };
 });
 
 jest.mock('react-native-reanimated', () => {

--- a/src/screens/__tests__/OrderHistoryScreen.test.tsx
+++ b/src/screens/__tests__/OrderHistoryScreen.test.tsx
@@ -13,6 +13,40 @@ jest.mock('@/hooks/useOrders', () => ({
   useOrders: () => mockUseOrders(),
 }));
 
+jest.mock('@/hooks/useCart', () => ({
+  ...jest.requireActual('@/hooks/useCart'),
+  useCart: () => ({
+    addItem: jest.fn(),
+    items: [],
+    itemCount: 0,
+    subtotal: 0,
+    syncing: false,
+    removeItem: jest.fn(),
+    updateQuantity: jest.fn(),
+    clearCart: jest.fn(),
+    pendingSync: 0,
+    isSyncing: false,
+    loadItems: jest.fn(),
+    syncError: null,
+    clearSyncError: jest.fn(),
+  }),
+}));
+
+jest.mock('@/hooks/useFutonModels', () => ({
+  ...jest.requireActual('@/hooks/useFutonModels'),
+  useFutonModels: () => ({
+    models: [],
+    fabrics: [],
+    isLoading: false,
+    error: null,
+    getModel: jest.fn((id: string) => ({ id, name: `Model ${id}`, basePrice: 349 })),
+    getModelById: jest.fn((id: string) => ({ id, name: `Model ${id}`, basePrice: 349 })),
+    getFabric: jest.fn((id: string) => ({ id, name: `Fabric ${id}`, price: 0 })),
+    getModelForProduct: jest.fn(),
+    refresh: jest.fn(),
+  }),
+}));
+
 function renderOrderHistory(props: Partial<React.ComponentProps<typeof OrderHistoryScreen>> = {}) {
   return render(
     <ThemeProvider>

--- a/src/screens/__tests__/ShopScreen.recently-viewed.test.tsx
+++ b/src/screens/__tests__/ShopScreen.recently-viewed.test.tsx
@@ -45,7 +45,12 @@ describe('ShopScreen — recently viewed rail', () => {
   });
 
   it('does not show recently viewed rail when no products viewed', () => {
-    spy.mockReturnValue({ recentProducts: [], addViewed: jest.fn(), clearAll: jest.fn(), count: 0 });
+    spy.mockReturnValue({
+      recentProducts: [],
+      addViewed: jest.fn(),
+      clearAll: jest.fn(),
+      count: 0,
+    });
     const { queryByTestId } = renderShop();
     expect(queryByTestId('shop-recently-viewed-rail')).toBeNull();
   });


### PR DESCRIPTION
## Summary
- Refactored `OrderHistoryScreen` to use `useFutonModels` hook instead of direct `@/data/futons` import (architecture rule violation)
- Added `useCart` + `useFutonModels` mocks to `OrderHistoryScreen.test.tsx` (30 tests were failing)
- Fixed prettier formatting in 6 files (8 errors blocking CI lint job)

## Test plan
- [x] `screen-refactor-hooks.test.ts` — 12/12 pass (was 1 failing)
- [x] `OrderHistoryScreen.test.tsx` — 30/30 pass (was 30 failing)
- [x] `OrderHistoryScreen.reorder.test.tsx` — 10/10 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)