### PR TITLE
feat(cm-t6wl): wire arLayoutSync to Wix ARLayouts collection

### DIFF
--- a/src/hooks/useSavedARLayouts.ts
+++ b/src/hooks/useSavedARLayouts.ts
@@ -12,7 +12,8 @@
  */
 import { useState, useEffect, useCallback } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { pushLayouts } from '@/services/arLayoutSync';
+import { pushLayouts, pullLayouts } from '@/services/arLayoutSync';
+import type { SyncableARLayout } from '@/services/arLayoutSync';
 
 export const MAX_SAVED_LAYOUTS = 10;
 
@@ -58,7 +59,20 @@ async function persist(layouts: SavedARLayout[]): Promise<void> {
   await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(layouts));
 }
 
-export function useSavedARLayouts(): UseSavedARLayoutsReturn {
+/** Merge remote layouts into local: union by id, newer updatedAt wins. */
+function mergeLayouts(local: SavedARLayout[], remote: SyncableARLayout[]): SavedARLayout[] {
+  const byId = new Map<string, SavedARLayout>();
+  for (const l of local) byId.set(l.id, l);
+  for (const r of remote) {
+    const existing = byId.get(r.id);
+    if (!existing || r.updatedAt > existing.updatedAt) {
+      byId.set(r.id, r as SavedARLayout);
+    }
+  }
+  return Array.from(byId.values()).slice(0, MAX_SAVED_LAYOUTS);
+}
+
+export function useSavedARLayouts(memberId?: string): UseSavedARLayoutsReturn {
   const [layouts, setLayouts] = useState<SavedARLayout[]>([]);
   const [isLoading, setIsLoading] = useState(true);
   const [syncStatus, setSyncStatus] = useState<SyncStatus>('idle');
@@ -87,6 +101,24 @@ export function useSavedARLayouts(): UseSavedARLayoutsReturn {
       });
   }, []);
 
+  // Pull from cloud and merge when memberId becomes available
+  useEffect(() => {
+    if (!memberId) return;
+    pullLayouts(memberId)
+      .then((remote) => {
+        if (remote.length === 0) return;
+        setLayouts((current) => {
+          const merged = mergeLayouts(current, remote);
+          // Persist merged result best-effort (no await needed here)
+          persist(merged).catch(() => {});
+          return merged;
+        });
+      })
+      .catch(() => {
+        // best-effort — local data remains
+      });
+  }, [memberId]);
+
   const saveLayout = useCallback(
     async (
       name: string,
@@ -109,6 +141,9 @@ export function useSavedARLayouts(): UseSavedARLayoutsReturn {
       try {
         await persist(next);
         setLayouts(next);
+        if (memberId) {
+          pushLayouts(memberId, next).catch(() => {});
+        }
         return layout;
       } catch {
         return null;
@@ -157,13 +192,13 @@ export function useSavedARLayouts(): UseSavedARLayoutsReturn {
   const syncToCloud = useCallback(async (): Promise<void> => {
     setSyncStatus('syncing');
     try {
-      await pushLayouts(layouts);
+      await pushLayouts(memberId ?? '', layouts);
       setLastSyncedAt(new Date().toISOString());
       setSyncStatus('idle');
     } catch {
       setSyncStatus('error');
     }
-  }, [layouts]);
+  }, [layouts, memberId]);
 
   return {
     layouts,

--- a/src/services/__tests__/arLayoutSync.test.ts
+++ b/src/services/__tests__/arLayoutSync.test.ts
@@ -1,0 +1,214 @@
+/**
+ * TDD tests for arLayoutSync — cm-t6wl
+ *
+ * Covers: ARLayoutSyncService push/pull, validation, error paths,
+ * and standalone wrapper no-op behavior.
+ */
+import { ARLayoutSyncService, pushLayouts, pullLayouts } from '../arLayoutSync';
+import { WixClient, type WixClientConfig } from '../wix/wixClient';
+import { resetWixClientSingleton } from '../wix/wixClientSingleton';
+import type { SyncableARLayout } from '../arLayoutSync';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const TEST_CONFIG: WixClientConfig = {
+  apiKey: 'test-api-key',
+  siteId: 'test-site-id',
+};
+
+const MEMBER_ID = 'member-abc123';
+const SERVER_TIME = '2026-04-13T10:00:00.000Z';
+
+const LAYOUT_1: SyncableARLayout = {
+  id: 'ar-layout-1',
+  name: 'Living Room',
+  items: [{ modelId: 'asheville-full', fabricId: 'natural-linen' }],
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+const LAYOUT_2: SyncableARLayout = {
+  id: 'ar-layout-2',
+  name: 'Bedroom',
+  items: [{ modelId: 'blue-ridge-queen', fabricId: 'slate-gray' }],
+  createdAt: '2026-01-02T00:00:00Z',
+  updatedAt: '2026-01-02T00:00:00Z',
+};
+
+// ── Mock helpers ──────────────────────────────────────────────────────────────
+
+function mockQueryEmpty() {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve({ dataItems: [], pagingMetadata: { total: 0 } }),
+  });
+}
+
+function mockQueryWithDoc(layouts: SyncableARLayout[]) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: () =>
+      Promise.resolve({
+        dataItems: [
+          {
+            id: 'doc-1',
+            data: { memberId: MEMBER_ID, layouts },
+            _updatedDate: SERVER_TIME,
+          },
+        ],
+        pagingMetadata: { total: 1 },
+      }),
+  });
+}
+
+function mockInsertSuccess() {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: () =>
+      Promise.resolve({ dataItem: { id: 'doc-1', data: {}, _updatedDate: SERVER_TIME } }),
+  });
+}
+
+/** Mocks the two-step upsert (query → insert when no existing doc). */
+function mockUpsertNew() {
+  mockQueryEmpty();
+  mockInsertSuccess();
+}
+
+function mockNetworkError() {
+  mockFetch.mockRejectedValueOnce(new Error('Network request failed'));
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('ARLayoutSyncService', () => {
+  let client: WixClient;
+  let svc: ARLayoutSyncService;
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+    client = new WixClient(TEST_CONFIG);
+    svc = new ARLayoutSyncService(client);
+  });
+
+  // ── pushLayouts ────────────────────────────────────────────────────────────
+
+  describe('pushLayouts', () => {
+    it('throws when memberId is empty', async () => {
+      await expect(svc.pushLayouts('', [LAYOUT_1])).rejects.toThrow('memberId required');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('calls upsertDataItem on ARLayouts collection with memberId filter', async () => {
+      mockUpsertNew();
+      await svc.pushLayouts(MEMBER_ID, [LAYOUT_1]);
+
+      const [, opts] = mockFetch.mock.calls[0];
+      const body = JSON.parse(opts.body as string);
+      expect(body.dataCollectionId).toBe('ARLayouts');
+      expect(body.query.filter).toMatchObject({ memberId: { $eq: MEMBER_ID } });
+    });
+
+    it('resolves successfully when layouts are pushed', async () => {
+      mockUpsertNew();
+      await expect(svc.pushLayouts(MEMBER_ID, [LAYOUT_1, LAYOUT_2])).resolves.toBeUndefined();
+    });
+
+    it('propagates network errors', async () => {
+      // WixClient retries network errors (up to 2 retries). Queue enough failures.
+      mockNetworkError();
+      mockNetworkError();
+      mockNetworkError();
+      await expect(svc.pushLayouts(MEMBER_ID, [LAYOUT_1])).rejects.toThrow();
+    });
+  });
+
+  // ── pullLayouts ────────────────────────────────────────────────────────────
+
+  describe('pullLayouts', () => {
+    it('throws when memberId is empty', async () => {
+      await expect(svc.pullLayouts('')).rejects.toThrow('memberId required');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('returns empty array when no document exists for member', async () => {
+      mockQueryEmpty();
+      const result = await svc.pullLayouts(MEMBER_ID);
+      expect(result).toEqual([]);
+    });
+
+    it('returns layouts from the server document', async () => {
+      mockQueryWithDoc([LAYOUT_1, LAYOUT_2]);
+      const result = await svc.pullLayouts(MEMBER_ID);
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe('ar-layout-1');
+      expect(result[1].id).toBe('ar-layout-2');
+    });
+
+    it('queries ARLayouts collection with memberId filter', async () => {
+      mockQueryEmpty();
+      await svc.pullLayouts(MEMBER_ID);
+
+      const [, opts] = mockFetch.mock.calls[0];
+      const body = JSON.parse(opts.body as string);
+      expect(body.dataCollectionId).toBe('ARLayouts');
+      expect(body.query.filter).toMatchObject({ memberId: { $eq: MEMBER_ID } });
+    });
+
+    it('propagates network errors', async () => {
+      mockNetworkError();
+      mockNetworkError();
+      mockNetworkError();
+      await expect(svc.pullLayouts(MEMBER_ID)).rejects.toThrow();
+    });
+  });
+});
+
+// ── Standalone wrappers ───────────────────────────────────────────────────────
+
+describe('standalone pushLayouts', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    resetWixClientSingleton();
+  });
+
+  afterEach(() => {
+    resetWixClientSingleton();
+    delete process.env.EXPO_PUBLIC_WIX_API_KEY;
+    delete process.env.EXPO_PUBLIC_WIX_SITE_ID;
+  });
+
+  it('no-ops when memberId is empty string', async () => {
+    process.env.EXPO_PUBLIC_WIX_API_KEY = 'key';
+    process.env.EXPO_PUBLIC_WIX_SITE_ID = 'site';
+    await expect(pushLayouts('', [LAYOUT_1])).resolves.toBeUndefined();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when Wix is not configured', async () => {
+    await expect(pushLayouts(MEMBER_ID, [LAYOUT_1])).resolves.toBeUndefined();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});
+
+describe('standalone pullLayouts', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    resetWixClientSingleton();
+  });
+
+  afterEach(() => {
+    resetWixClientSingleton();
+  });
+
+  it('returns empty array when memberId is empty string', async () => {
+    await expect(pullLayouts('')).resolves.toEqual([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('returns empty array when Wix is not configured', async () => {
+    await expect(pullLayouts(MEMBER_ID)).resolves.toEqual([]);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+});

--- a/src/services/__tests__/arLayoutSync.test.ts
+++ b/src/services/__tests__/arLayoutSync.test.ts
@@ -65,8 +65,7 @@ function mockQueryWithDoc(layouts: SyncableARLayout[]) {
 function mockInsertSuccess() {
   mockFetch.mockResolvedValueOnce({
     ok: true,
-    json: () =>
-      Promise.resolve({ dataItem: { id: 'doc-1', data: {}, _updatedDate: SERVER_TIME } }),
+    json: () => Promise.resolve({ dataItem: { id: 'doc-1', data: {}, _updatedDate: SERVER_TIME } }),
   });
 }
 

--- a/src/services/arLayoutSync.ts
+++ b/src/services/arLayoutSync.ts
@@ -1,13 +1,22 @@
 /**
  * @module arLayoutSync
  *
- * Cloud sync stub for saved AR room layouts.
- * Pushes locally-saved layouts to the backend for cross-device access.
- * Currently a no-op stub — wire to a real API when the backend endpoint
- * is ready (see: carolinafutons.com/api/ar-layouts).
+ * Cloud sync for saved AR room layouts via Wix Data (ARLayouts collection).
+ * One document per member stores their full layout list.
  *
- * TODO(backend): Implement real push/pull once Wix Data API endpoint lands.
+ * Usage (injectable, for tests):
+ *   const svc = new ARLayoutSyncService(client);
+ *   await svc.pushLayouts(memberId, layouts);
+ *
+ * Usage (singleton, for app code):
+ *   await pushLayouts(memberId, layouts);
+ *   const remote = await pullLayouts(memberId);
  */
+import type { WixClient } from './wix/wixClient';
+import { getWixClientSingleton } from './wix/wixClientSingleton';
+
+const COLLECTION_ID = 'ARLayouts';
+
 /** Minimal layout shape used for push/pull — mirrors SavedARLayout in useSavedARLayouts. */
 export interface SyncableARLayout {
   id: string;
@@ -18,19 +27,64 @@ export interface SyncableARLayout {
   updatedAt: string;
 }
 
+interface ARLayoutDoc {
+  memberId: string;
+  layouts: SyncableARLayout[];
+}
+
+// ── Injectable service (testable) ────────────────────────────────────────────
+
+export class ARLayoutSyncService {
+  constructor(private readonly client: WixClient) {}
+
+  /**
+   * Upsert the member's full layout list to the ARLayouts collection.
+   * Creates a new document on first push; updates the existing one thereafter.
+   */
+  async pushLayouts(memberId: string, layouts: SyncableARLayout[]): Promise<void> {
+    if (!memberId) throw new Error('memberId required');
+    await this.client.upsertDataItem(
+      COLLECTION_ID,
+      { memberId: { $eq: memberId } },
+      { memberId, layouts },
+    );
+  }
+
+  /**
+   * Pull the member's layout list from the ARLayouts collection.
+   * Returns an empty array if no document exists yet.
+   */
+  async pullLayouts(memberId: string): Promise<SyncableARLayout[]> {
+    if (!memberId) throw new Error('memberId required');
+    const result = await this.client.queryData<ARLayoutDoc>(COLLECTION_ID, {
+      filter: { memberId: { $eq: memberId } },
+      limit: 1,
+    });
+    if (result.items.length === 0) return [];
+    return result.items[0].layouts ?? [];
+  }
+}
+
+// ── Singleton wrappers (used by useSavedARLayouts) ────────────────────────────
+
 /**
- * Push the user's layouts to the cloud backend.
- * Currently a no-op — resolves immediately.
+ * Push layouts to the cloud using the app's Wix singleton client.
+ * No-ops silently when memberId is empty or Wix is not configured.
  */
-export async function pushLayouts(_layouts: SyncableARLayout[]): Promise<void> {
-  // TODO: POST to /api/ar-layouts with user auth token
+export async function pushLayouts(memberId: string, layouts: SyncableARLayout[]): Promise<void> {
+  if (!memberId) return;
+  const client = getWixClientSingleton();
+  if (!client) return;
+  await new ARLayoutSyncService(client).pushLayouts(memberId, layouts);
 }
 
 /**
- * Pull layouts from the cloud backend for the current user.
- * Currently returns an empty array — no remote data available yet.
+ * Pull layouts from the cloud using the app's Wix singleton client.
+ * Returns an empty array when memberId is empty or Wix is not configured.
  */
-export async function pullLayouts(): Promise<SyncableARLayout[]> {
-  // TODO: GET /api/ar-layouts with user auth token
-  return [];
+export async function pullLayouts(memberId: string): Promise<SyncableARLayout[]> {
+  if (!memberId) return [];
+  const client = getWixClientSingleton();
+  if (!client) return [];
+  return new ARLayoutSyncService(client).pullLayouts(memberId);
 }


### PR DESCRIPTION
## Summary
- `ARLayoutSyncService`: real `pushLayouts`/`pullLayouts` via Wix Data `upsertDataItem`/`queryData` on `ARLayouts` collection (one doc per memberId, layouts stored as array field)
- Standalone `pushLayouts(memberId, layouts)` / `pullLayouts(memberId)` wrappers use singleton client; silently no-op when memberId empty or Wix unconfigured
- `useSavedARLayouts(memberId?)`: auto-pulls on memberId available and merges remote into local (newer `updatedAt` wins); auto-pushes after `saveLayout`
- `syncToCloud()` now forwards memberId to `pushLayouts`

## Test plan
- [x] 13 new tests: ARLayoutSyncService push/pull, validation, network error propagation, standalone no-ops
- [x] All 23 existing useSavedARLayouts tests pass unchanged
- [x] 36/36 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)