### PR TITLE
feat(hq-1jcj): useGamificationActions — AR try-on 5pts, room photo 25pts, review 10pts

### DIFF
--- a/src/hooks/__tests__/useGamificationActions.test.ts
+++ b/src/hooks/__tests__/useGamificationActions.test.ts
@@ -83,10 +83,7 @@ describe('useGamificationActions — awardForARTryOn', () => {
       }),
     ).resolves.toBeUndefined();
 
-    expect(spy).toHaveBeenCalledWith(
-      expect.stringContaining('[useGamificationActions]'),
-      boom,
-    );
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('[useGamificationActions]'), boom);
     spy.mockRestore();
   });
 });
@@ -135,10 +132,7 @@ describe('useGamificationActions — awardForRoomPhoto', () => {
       }),
     ).resolves.toBeUndefined();
 
-    expect(spy).toHaveBeenCalledWith(
-      expect.stringContaining('[useGamificationActions]'),
-      boom,
-    );
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('[useGamificationActions]'), boom);
     spy.mockRestore();
   });
 });
@@ -187,10 +181,7 @@ describe('useGamificationActions — awardForProductReview', () => {
       }),
     ).resolves.toBeUndefined();
 
-    expect(spy).toHaveBeenCalledWith(
-      expect.stringContaining('[useGamificationActions]'),
-      boom,
-    );
+    expect(spy).toHaveBeenCalledWith(expect.stringContaining('[useGamificationActions]'), boom);
     spy.mockRestore();
   });
 });

--- a/src/hooks/__tests__/useGamificationActions.test.ts
+++ b/src/hooks/__tests__/useGamificationActions.test.ts
@@ -1,0 +1,218 @@
+/**
+ * @module useGamificationActions tests — hq-1jcj
+ *
+ * TDD: tests written BEFORE implementation per CLAUDE.md mandate.
+ *
+ * Hook awards loyalty points for:
+ *   - AR try-on:        5 pts  (action: 'ar_try_on')
+ *   - Room photo upload: 25 pts (action: 'room_photo_upload')
+ *   - Product review:   10 pts  (action: 'product_review')
+ *
+ * All awards are best-effort — failures are logged and swallowed (non-fatal).
+ * Empty/missing IDs skip the award entirely.
+ */
+
+import { renderHook, act } from '@testing-library/react-native';
+import { useGamificationActions } from '../useGamificationActions';
+
+// ---------------------------------------------------------------------------
+// Mock useLoyalty — provides awardPoints for the hook to call
+// ---------------------------------------------------------------------------
+
+const mockAward = jest.fn();
+
+jest.mock('@/hooks/useLoyalty', () => ({
+  useLoyalty: () => ({ awardPoints: mockAward }),
+}));
+
+beforeEach(() => {
+  mockAward.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// awardForARTryOn — 5 pts
+// ---------------------------------------------------------------------------
+
+describe('useGamificationActions — awardForARTryOn', () => {
+  it('awards 5 points with correct action and productId', async () => {
+    mockAward.mockResolvedValue({ newTotal: 105 });
+    const { result } = renderHook(() => useGamificationActions());
+
+    await act(async () => {
+      await result.current.awardForARTryOn('product-123');
+    });
+
+    expect(mockAward).toHaveBeenCalledWith({
+      action: 'ar_try_on',
+      productId: 'product-123',
+      points: 5,
+    });
+    expect(mockAward).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call awardPoints when productId is empty string', async () => {
+    const { result } = renderHook(() => useGamificationActions());
+
+    await act(async () => {
+      await result.current.awardForARTryOn('');
+    });
+
+    expect(mockAward).not.toHaveBeenCalled();
+  });
+
+  it('does not call awardPoints when productId is whitespace only', async () => {
+    const { result } = renderHook(() => useGamificationActions());
+
+    await act(async () => {
+      await result.current.awardForARTryOn('   ');
+    });
+
+    expect(mockAward).not.toHaveBeenCalled();
+  });
+
+  it('swallows award failure — resolves undefined, logs error', async () => {
+    const boom = new Error('rate limited');
+    mockAward.mockRejectedValue(boom);
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useGamificationActions());
+
+    await expect(
+      act(async () => {
+        await result.current.awardForARTryOn('product-123');
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('[useGamificationActions]'),
+      boom,
+    );
+    spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// awardForRoomPhoto — 25 pts
+// ---------------------------------------------------------------------------
+
+describe('useGamificationActions — awardForRoomPhoto', () => {
+  it('awards 25 points with correct action and photoId', async () => {
+    mockAward.mockResolvedValue({ newTotal: 125 });
+    const { result } = renderHook(() => useGamificationActions());
+
+    await act(async () => {
+      await result.current.awardForRoomPhoto('photo-456');
+    });
+
+    expect(mockAward).toHaveBeenCalledWith({
+      action: 'room_photo_upload',
+      photoId: 'photo-456',
+      points: 25,
+    });
+    expect(mockAward).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call awardPoints when photoId is empty string', async () => {
+    const { result } = renderHook(() => useGamificationActions());
+
+    await act(async () => {
+      await result.current.awardForRoomPhoto('');
+    });
+
+    expect(mockAward).not.toHaveBeenCalled();
+  });
+
+  it('swallows award failure — resolves undefined, logs error', async () => {
+    const boom = new Error('network timeout');
+    mockAward.mockRejectedValue(boom);
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useGamificationActions());
+
+    await expect(
+      act(async () => {
+        await result.current.awardForRoomPhoto('photo-456');
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('[useGamificationActions]'),
+      boom,
+    );
+    spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// awardForProductReview — 10 pts
+// ---------------------------------------------------------------------------
+
+describe('useGamificationActions — awardForProductReview', () => {
+  it('awards 10 points with correct action and productId', async () => {
+    mockAward.mockResolvedValue({ newTotal: 110 });
+    const { result } = renderHook(() => useGamificationActions());
+
+    await act(async () => {
+      await result.current.awardForProductReview('product-789');
+    });
+
+    expect(mockAward).toHaveBeenCalledWith({
+      action: 'product_review',
+      productId: 'product-789',
+      points: 10,
+    });
+    expect(mockAward).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call awardPoints when productId is empty string', async () => {
+    const { result } = renderHook(() => useGamificationActions());
+
+    await act(async () => {
+      await result.current.awardForProductReview('');
+    });
+
+    expect(mockAward).not.toHaveBeenCalled();
+  });
+
+  it('swallows award failure — resolves undefined, logs error', async () => {
+    const boom = new Error('server error');
+    mockAward.mockRejectedValue(boom);
+    const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { result } = renderHook(() => useGamificationActions());
+
+    await expect(
+      act(async () => {
+        await result.current.awardForProductReview('product-789');
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.stringContaining('[useGamificationActions]'),
+      boom,
+    );
+    spy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Stability — award functions are stable across re-renders
+// ---------------------------------------------------------------------------
+
+describe('useGamificationActions — referential stability', () => {
+  it('returns the same function references across re-renders', () => {
+    const { result, rerender } = renderHook(() => useGamificationActions());
+
+    const first = {
+      arTryOn: result.current.awardForARTryOn,
+      roomPhoto: result.current.awardForRoomPhoto,
+      review: result.current.awardForProductReview,
+    };
+
+    rerender({});
+
+    expect(result.current.awardForARTryOn).toBe(first.arTryOn);
+    expect(result.current.awardForRoomPhoto).toBe(first.roomPhoto);
+    expect(result.current.awardForProductReview).toBe(first.review);
+  });
+});

--- a/src/hooks/useGamificationActions.ts
+++ b/src/hooks/useGamificationActions.ts
@@ -1,0 +1,92 @@
+/**
+ * @module useGamificationActions
+ *
+ * Awards loyalty points for high-value gamification actions. Each function is
+ * best-effort: failures are logged but never surfaced to the user (non-fatal).
+ * Empty/missing IDs skip the award entirely to prevent ghost records.
+ *
+ * Point values (from LoyaltyActions spec):
+ *   AR try-on:          5 pts  — low friction, high frequency
+ *   Room photo upload: 25 pts  — high-value UGC contribution
+ *   Product review:    10 pts  — social proof contribution
+ *
+ * hq-1jcj
+ */
+
+import { useCallback } from 'react';
+import { useLoyalty } from '@/hooks/useLoyalty';
+
+export interface UseGamificationActionsResult {
+  /**
+   * Award 5 points when a member uses AR try-on for a product.
+   * @param productId - Wix product ID. No-op if empty.
+   */
+  awardForARTryOn: (productId: string) => Promise<void>;
+
+  /**
+   * Award 25 points when a member uploads an approved room photo.
+   * @param photoId - Wix media/photo ID. No-op if empty.
+   */
+  awardForRoomPhoto: (photoId: string) => Promise<void>;
+
+  /**
+   * Award 10 points when a member submits a product review.
+   * @param productId - Wix product ID. No-op if empty.
+   */
+  awardForProductReview: (productId: string) => Promise<void>;
+}
+
+/**
+ * Returns stable action handlers for awarding gamification loyalty points.
+ * All handlers are memoized with useCallback — safe to pass as props or deps.
+ */
+export function useGamificationActions(): UseGamificationActionsResult {
+  const { awardPoints } = useLoyalty();
+
+  const awardForARTryOn = useCallback(
+    async (productId: string): Promise<void> => {
+      // Guard: skip award for blank IDs — prevents ghost LoyaltyActions records
+      if (!productId?.trim()) return;
+
+      try {
+        await awardPoints({ action: 'ar_try_on', productId, points: 5 });
+      } catch (err) {
+        // Non-fatal — points award should never block AR UX
+        console.error('[useGamificationActions] awardForARTryOn failed:', err);
+      }
+    },
+    [awardPoints],
+  );
+
+  const awardForRoomPhoto = useCallback(
+    async (photoId: string): Promise<void> => {
+      // Guard: skip award for blank IDs — prevents ghost LoyaltyActions records
+      if (!photoId?.trim()) return;
+
+      try {
+        await awardPoints({ action: 'room_photo_upload', photoId, points: 25 });
+      } catch (err) {
+        // Non-fatal — points award should never block photo upload confirmation
+        console.error('[useGamificationActions] awardForRoomPhoto failed:', err);
+      }
+    },
+    [awardPoints],
+  );
+
+  const awardForProductReview = useCallback(
+    async (productId: string): Promise<void> => {
+      // Guard: skip award for blank IDs — prevents ghost LoyaltyActions records
+      if (!productId?.trim()) return;
+
+      try {
+        await awardPoints({ action: 'product_review', productId, points: 10 });
+      } catch (err) {
+        // Non-fatal — points award should never block review submission
+        console.error('[useGamificationActions] awardForProductReview failed:', err);
+      }
+    },
+    [awardPoints],
+  );
+
+  return { awardForARTryOn, awardForRoomPhoto, awardForProductReview };
+}


### PR DESCRIPTION
## Summary

- New hook `src/hooks/useGamificationActions.ts` awarding loyalty points for three gamification actions:
  - `awardForARTryOn(productId)` — 5 pts (`action: 'ar_try_on'`)
  - `awardForRoomPhoto(photoId)` — 25 pts (`action: 'room_photo_upload'`)
  - `awardForProductReview(productId)` — 10 pts (`action: 'product_review'`)
- All handlers are `useCallback`-memoized (stable refs across re-renders)
- All awards are best-effort: failures logged `[useGamificationActions]` prefix, never surfaced to the user
- Empty/whitespace IDs are no-ops (prevents ghost LoyaltyActions records)
- JSDoc, try/catch, WHY-comments per Stilgar mandate

## Test plan

- [x] TDD: tests written first, watched red, implemented to green
- [x] 11 tests passing: happy path, empty/whitespace ID guard, error recovery, referential stability
- [x] Each action: correct points + payload shape verified
- [x] Error recovery: rejects → resolves undefined + console.error with `[useGamificationActions]` prefix
- [x] No console.error calls left unsuppressed in tests

Closes hq-1jcj

🤖 Generated with [Claude Code](https://claude.com/claude-code)