### PR TITLE
feat(cm-3fd): sanitizeInput + secureStorage — CFM leg of security convoy hq-cv-f1ilb

### DIFF
--- a/docs/plans/2026-04-13-cfm-feature-roadmap-s33-s34.md
+++ b/docs/plans/2026-04-13-cfm-feature-roadmap-s33-s34.md
@@ -8,7 +8,25 @@
 
 **Tech Stack:** React Native (Expo 55), TypeScript, Wix Data SDK (`wixClient.queryData` / `upsertDataItem`), AsyncStorage, expo-secure-store, Jest + `@testing-library/react-native`, expo-haptics, expo-image-picker, Stripe (payments, mobile-only).
 
-**Living document:** Crew and PM input solicited 2026-04-13 — this document will be updated as responses arrive from bishop, ripley, hicks, and melania.
+**Living document:** Updated 2026-04-13 with crew input from bishop, ripley, hicks. Melania response pending (ConsultationBookings schema blocker).
+
+---
+
+## Crew Input Summary (2026-04-13 21:15 MDT)
+
+**bishop:** cm-xw4 price alerts already shipped under cm-pda (PR #424) — drop from roadmap. Bead hygiene broken (duplicates accumulating). Worktree pre-commit hook gap causing repeated prettier-only commits. Starting cm-3fd security now.
+
+**hicks:** AR skeleton/loading feedback missing on 6 screens. cm-b3b cloud sync top pick. No perf telemetry — flying blind on real-device TTI/jank. Offline AR retry queue not wired.
+
+**ripley:** P0 gap: no unified Image wrapper (caching/placeholder/retry). P1: no shared EmptyState or Skeleton primitives — every screen rolls its own. P2: no OfflineBanner — offline feature has no visible proof. These unblock multiple downstream features.
+
+**New beads filed from crew input:**
+- `cm-48e` P1 — Image wrapper (ripley, after hq-bzb) ← **P0 unblocked by ripley**
+- `cm-2ts` P1 — EmptyState component (ripley queue)
+- `cm-sxj` P1 — Skeleton primitives (hicks, after cm-b3b)
+- `cm-049` P2 — OfflineBanner + queue status hook
+- `cm-ox9` P2 — Perf telemetry + FlatList memo audit (hicks queue)
+- `cm-2s8` P2 — Bead hygiene audit + worktree pre-commit fix (bishop)
 
 ---
 
@@ -966,8 +984,15 @@ git commit -m "feat(cm-3fd): sanitizeInput + secureStorage — CFM leg of securi
 
 Priority order based on conversion impact and crew availability:
 
-### Task 2.1: Price Drop Push Notifications
-**Bead:** `cm-xw4` | **Owner:** bishop
+### ~~Task 2.1: Price Drop Push Notifications~~ ✓ ALREADY SHIPPED
+**Bead:** `cm-xw4` CLOSED | **Shipped as:** `cm-pda` PR #424 (PriceAlertButton, usePriceAlertSubscription, 51 tests)
+
+> **bishop confirmed 2026-04-13:** Feature complete. Track 2.1 dropped from roadmap. Bishop capacity reallocated to cm-3fd + cm-48e Image wrapper.
+
+---
+
+### Task 2.1b: Unified Image Wrapper *(new — from ripley P0)*
+**Bead:** `cm-48e` | **Owner:** ripley (after hq-bzb)
 
 **Files:**
 - Create: `src/components/PriceAlertButton.tsx`
@@ -1302,10 +1327,18 @@ Per Stilgar mandate — every PR must demonstrate:
 
 ---
 
-## Open Questions (Pending Input)
+## Open Questions
 
-- **melania:** ConsultationBookings schema for cm-4yk — blocking
+- **melania:** ConsultationBookings schema for cm-4yk — still blocking (requested 2026-04-13)
 - **melania:** Priority ranking on Phase 2 ports — which converts best on web?
-- **bishop:** Technical debt assessment — what is blocking new work most?
-- **ripley:** UI gaps — what components are missing that multiple features need?
-- **hicks:** Performance gaps — any loading state or AR issues to address?
+- **melania:** Is cm-to0 NPS a duplicate of cm-5cp/hq-9dq already shipped? (bishop flag — bead hygiene audit cm-2s8)
+
+## Crew Assignments — Updated
+
+| Crew | Now (S33) | Next | Queue |
+|------|-----------|------|-------|
+| bishop | cm-3fd security | cm-2s8 bead hygiene | cm-4yk (blocked on melania) |
+| ripley | hq-bzb ProductRec | cm-48e Image wrapper | cm-2ts EmptyState, cm-nw8 UGC |
+| nux | cm-0q4 CompleteTheLook | cm-qa Product Q&A | — |
+| burke | cm-to0 NPS survey | cm-vid Video Reviews | cm-049 OfflineBanner |
+| hicks | cm-b3b AR sync | cm-sxj Skeleton primitives | cm-ox9 Perf telemetry |

--- a/src/services/__tests__/secureStorage.test.ts
+++ b/src/services/__tests__/secureStorage.test.ts
@@ -1,0 +1,138 @@
+import * as SecureStore from 'expo-secure-store';
+import {
+  saveSecure,
+  loadSecure,
+  deleteSecure,
+  migrateFromAsyncStorage,
+  SECURE_KEYS,
+} from '../secureStorage';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+jest.mock('expo-secure-store');
+jest.mock('@react-native-async-storage/async-storage');
+
+const mockSet = SecureStore.setItemAsync as jest.Mock;
+const mockGet = SecureStore.getItemAsync as jest.Mock;
+const mockDel = SecureStore.deleteItemAsync as jest.Mock;
+const mockAsyncGet = AsyncStorage.getItem as jest.Mock;
+const mockAsyncRemove = AsyncStorage.removeItem as jest.Mock;
+
+describe('secureStorage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('saveSecure', () => {
+    it('saves via SecureStore.setItemAsync', async () => {
+      mockSet.mockResolvedValue(undefined);
+      await saveSecure('auth_token', 'tok123');
+      expect(mockSet).toHaveBeenCalledWith('auth_token', 'tok123');
+    });
+
+    it('swallows and logs errors (no throw)', async () => {
+      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      mockSet.mockRejectedValue(new Error('keychain locked'));
+      await expect(saveSecure('k', 'v')).resolves.toBeUndefined();
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining('[secureStorage]'),
+        expect.anything(),
+      );
+      spy.mockRestore();
+    });
+
+    it('rejects empty key to prevent accidental global storage', async () => {
+      await expect(saveSecure('', 'v')).rejects.toThrow(/key/i);
+      expect(mockSet).not.toHaveBeenCalled();
+    });
+
+    it('coerces undefined value to empty string rather than calling store', async () => {
+      await saveSecure('k', undefined as unknown as string);
+      expect(mockSet).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('loadSecure', () => {
+    it('loads via SecureStore.getItemAsync', async () => {
+      mockGet.mockResolvedValue('tok123');
+      expect(await loadSecure('auth_token')).toBe('tok123');
+    });
+
+    it('returns null when key not found', async () => {
+      mockGet.mockResolvedValue(null);
+      expect(await loadSecure('missing')).toBeNull();
+    });
+
+    it('logs and returns null on read error', async () => {
+      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      mockGet.mockRejectedValue(new Error('keychain'));
+      expect(await loadSecure('key')).toBeNull();
+      expect(spy).toHaveBeenCalledWith(
+        expect.stringContaining('[secureStorage]'),
+        expect.anything(),
+      );
+      spy.mockRestore();
+    });
+
+    it('rejects empty key', async () => {
+      await expect(loadSecure('')).rejects.toThrow(/key/i);
+    });
+  });
+
+  describe('deleteSecure', () => {
+    it('removes the key', async () => {
+      mockDel.mockResolvedValue(undefined);
+      await deleteSecure('auth_token');
+      expect(mockDel).toHaveBeenCalledWith('auth_token');
+    });
+
+    it('swallows and logs errors', async () => {
+      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      mockDel.mockRejectedValue(new Error('fail'));
+      await expect(deleteSecure('k')).resolves.toBeUndefined();
+      expect(spy).toHaveBeenCalled();
+      spy.mockRestore();
+    });
+  });
+
+  describe('SECURE_KEYS registry', () => {
+    it('exposes canonical keys for sensitive data', () => {
+      expect(SECURE_KEYS.AUTH_TOKEN).toBe('auth_token');
+      expect(SECURE_KEYS.MEMBER_ID).toBe('member_id');
+      expect(SECURE_KEYS.SESSION_ID).toBe('session_id');
+      expect(SECURE_KEYS.REFRESH_TOKEN).toBe('refresh_token');
+    });
+  });
+
+  describe('migrateFromAsyncStorage', () => {
+    it('moves a value from AsyncStorage to SecureStore and removes the legacy key', async () => {
+      mockAsyncGet.mockResolvedValue('legacy-token');
+      mockSet.mockResolvedValue(undefined);
+      mockAsyncRemove.mockResolvedValue(undefined);
+
+      const migrated = await migrateFromAsyncStorage('auth_token');
+
+      expect(migrated).toBe(true);
+      expect(mockAsyncGet).toHaveBeenCalledWith('auth_token');
+      expect(mockSet).toHaveBeenCalledWith('auth_token', 'legacy-token');
+      expect(mockAsyncRemove).toHaveBeenCalledWith('auth_token');
+    });
+
+    it('is a no-op when no legacy value exists', async () => {
+      mockAsyncGet.mockResolvedValue(null);
+      const migrated = await migrateFromAsyncStorage('auth_token');
+      expect(migrated).toBe(false);
+      expect(mockSet).not.toHaveBeenCalled();
+      expect(mockAsyncRemove).not.toHaveBeenCalled();
+    });
+
+    it('does not remove legacy key if secure save fails', async () => {
+      const spy = jest.spyOn(console, 'error').mockImplementation(() => {});
+      mockAsyncGet.mockResolvedValue('legacy-token');
+      mockSet.mockRejectedValue(new Error('keychain fail'));
+      const migrated = await migrateFromAsyncStorage('auth_token');
+      expect(migrated).toBe(false);
+      expect(mockAsyncRemove).not.toHaveBeenCalled();
+      spy.mockRestore();
+    });
+  });
+});

--- a/src/services/secureStorage.ts
+++ b/src/services/secureStorage.ts
@@ -1,0 +1,75 @@
+/**
+ * @module secureStorage
+ *
+ * Thin wrapper around expo-secure-store for sensitive key/value data.
+ * Use for tokens, member/session identifiers, anything the keychain should hold.
+ * Do NOT use for large payloads, UI preferences, or cache — use AsyncStorage.
+ *
+ * Errors are logged and swallowed so auth flows degrade gracefully if the
+ * keychain is unavailable; callers receive `null` on read failure.
+ */
+
+import * as SecureStore from 'expo-secure-store';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export const SECURE_KEYS = {
+  AUTH_TOKEN: 'auth_token',
+  REFRESH_TOKEN: 'refresh_token',
+  MEMBER_ID: 'member_id',
+  SESSION_ID: 'session_id',
+} as const;
+
+function requireKey(key: string): void {
+  if (!key || typeof key !== 'string') {
+    throw new Error('secureStorage: key must be a non-empty string');
+  }
+}
+
+export async function saveSecure(key: string, value: string): Promise<void> {
+  requireKey(key);
+  if (value == null) return;
+  try {
+    await SecureStore.setItemAsync(key, value);
+  } catch (error) {
+    console.error('[secureStorage] saveSecure failed:', error);
+  }
+}
+
+export async function loadSecure(key: string): Promise<string | null> {
+  requireKey(key);
+  try {
+    return await SecureStore.getItemAsync(key);
+  } catch (error) {
+    console.error('[secureStorage] loadSecure failed:', error);
+    return null;
+  }
+}
+
+export async function deleteSecure(key: string): Promise<void> {
+  requireKey(key);
+  try {
+    await SecureStore.deleteItemAsync(key);
+  } catch (error) {
+    console.error('[secureStorage] deleteSecure failed:', error);
+  }
+}
+
+/**
+ * Migrate a value previously stored in AsyncStorage into SecureStore.
+ * Returns true if a value was migrated, false otherwise. Only removes the
+ * legacy AsyncStorage entry if the secure save succeeded, so we never lose
+ * the value on keychain failure.
+ */
+export async function migrateFromAsyncStorage(key: string): Promise<boolean> {
+  requireKey(key);
+  const legacy = await AsyncStorage.getItem(key);
+  if (legacy == null) return false;
+  try {
+    await SecureStore.setItemAsync(key, legacy);
+  } catch (error) {
+    console.error('[secureStorage] migration save failed:', error);
+    return false;
+  }
+  await AsyncStorage.removeItem(key);
+  return true;
+}

--- a/src/utils/__tests__/sanitizeInput.test.ts
+++ b/src/utils/__tests__/sanitizeInput.test.ts
@@ -1,0 +1,138 @@
+import { sanitizeInput } from '../sanitizeInput';
+
+describe('sanitizeInput', () => {
+  describe('XSS / HTML', () => {
+    it('strips script tags with content', () => {
+      expect(sanitizeInput('<script>alert(1)</script>hello')).toBe('hello');
+    });
+
+    it('strips style tags with content', () => {
+      expect(sanitizeInput('a<style>body{}</style>b')).toBe('ab');
+    });
+
+    it('strips generic html tags', () => {
+      expect(sanitizeInput('<b>bold</b>')).toBe('bold');
+    });
+
+    it('strips mixed-case script tags', () => {
+      expect(sanitizeInput('x<ScRiPt>evil()</ScRiPt>y')).toBe('xy');
+    });
+
+    it('strips img tags (common XSS vector)', () => {
+      expect(sanitizeInput('<img src=x onerror=alert(1)>safe')).toBe('safe');
+    });
+
+    it('strips iframe tags', () => {
+      expect(sanitizeInput('<iframe src="evil.com"></iframe>ok')).toBe('ok');
+    });
+  });
+
+  describe('SQL injection patterns', () => {
+    it('rejects classic DROP TABLE injection', () => {
+      expect(sanitizeInput("'; DROP TABLE users; --")).not.toContain('DROP TABLE');
+    });
+
+    it('rejects UNION SELECT injection', () => {
+      const result = sanitizeInput("1' UNION SELECT * FROM secrets--");
+      expect(result).not.toContain('UNION SELECT');
+    });
+
+    it('rejects DELETE FROM injection', () => {
+      expect(sanitizeInput("x'; DELETE FROM orders;")).not.toContain('DELETE FROM');
+    });
+
+    it('strips SQL comment markers', () => {
+      expect(sanitizeInput('safe text -- dropped')).not.toContain('--');
+    });
+
+    it('strips runs of quote/semicolon injection boilerplate', () => {
+      const result = sanitizeInput(`name'';;`);
+      expect(result).not.toMatch(/['";]{2,}/);
+    });
+  });
+
+  describe('normal text passthrough', () => {
+    it('allows normal product review text unchanged', () => {
+      expect(sanitizeInput('Nice sofa! 5 stars.')).toBe('Nice sofa! 5 stars.');
+    });
+
+    it('allows apostrophes in everyday words', () => {
+      expect(sanitizeInput("It's comfy")).toBe("It's comfy");
+    });
+
+    it('allows numerals, punctuation, emoji', () => {
+      expect(sanitizeInput('Got it on 4/12 for $499 — worth it 👍')).toBe(
+        'Got it on 4/12 for $499 — worth it 👍',
+      );
+    });
+
+    it('preserves internal whitespace', () => {
+      expect(sanitizeInput('hello  world')).toBe('hello  world');
+    });
+  });
+
+  describe('whitespace and boundary handling', () => {
+    it('trims leading whitespace', () => {
+      expect(sanitizeInput('   hello')).toBe('hello');
+    });
+
+    it('trims trailing whitespace', () => {
+      expect(sanitizeInput('hello   ')).toBe('hello');
+    });
+
+    it('trims both sides', () => {
+      expect(sanitizeInput('  hello  ')).toBe('hello');
+    });
+
+    it('returns empty string for null', () => {
+      expect(sanitizeInput(null as unknown as string)).toBe('');
+    });
+
+    it('returns empty string for undefined', () => {
+      expect(sanitizeInput(undefined as unknown as string)).toBe('');
+    });
+
+    it('returns empty string for empty input', () => {
+      expect(sanitizeInput('')).toBe('');
+    });
+
+    it('returns empty string for whitespace-only input', () => {
+      expect(sanitizeInput('     ')).toBe('');
+    });
+
+    it('handles very long input without throwing', () => {
+      const long = 'a'.repeat(100_000);
+      expect(() => sanitizeInput(long)).not.toThrow();
+      expect(sanitizeInput(long)).toHaveLength(100_000);
+    });
+  });
+
+  describe('maxLength truncation', () => {
+    it('truncates to maxLength when provided', () => {
+      expect(sanitizeInput('hello world', 5)).toBe('hello');
+    });
+
+    it('does not truncate when input is under maxLength', () => {
+      expect(sanitizeInput('hi', 10)).toBe('hi');
+    });
+
+    it('maxLength of 0 returns empty string', () => {
+      expect(sanitizeInput('hello', 0)).toBe('');
+    });
+
+    it('truncates AFTER sanitization (not before)', () => {
+      // raw input with tags is 20 chars; real content after strip is "hello world" (11)
+      expect(sanitizeInput('<b>hello world</b>', 5)).toBe('hello');
+    });
+  });
+
+  describe('non-string defensive input', () => {
+    it('coerces number to string', () => {
+      expect(sanitizeInput(42 as unknown as string)).toBe('42');
+    });
+
+    it('returns empty string for objects', () => {
+      expect(sanitizeInput({} as unknown as string)).toBe('');
+    });
+  });
+});

--- a/src/utils/sanitizeInput.ts
+++ b/src/utils/sanitizeInput.ts
@@ -1,0 +1,36 @@
+/**
+ * @module sanitizeInput
+ *
+ * Hardened user-input sanitizer for forms, search queries, reviews, comments.
+ * Strips XSS vectors (HTML/script/style), defangs common SQL injection
+ * signatures, trims whitespace, and optionally truncates.
+ *
+ * For legacy caption/QA content that only needs tag stripping, use `sanitizeText`.
+ */
+
+import { sanitizeText } from './sanitizeText';
+
+const SQL_KEYWORD_COMBOS =
+  /\b(DROP|DELETE|TRUNCATE|ALTER|EXEC|UNION|INSERT|UPDATE|CREATE)\s+(TABLE|FROM|INTO|DATABASE|SELECT|VIEW|INDEX)\b/gi;
+
+export function sanitizeInput(value: string | null | undefined, maxLength?: number): string {
+  if (value == null) return '';
+
+  let raw: string;
+  if (typeof value === 'string') {
+    raw = value;
+  } else if (typeof value === 'number' || typeof value === 'boolean') {
+    raw = String(value);
+  } else {
+    return '';
+  }
+
+  let clean = sanitizeText(raw)
+    .replace(SQL_KEYWORD_COMBOS, '')
+    .replace(/--+/g, '')
+    .replace(/['";]{2,}/g, '')
+    .trim();
+
+  if (maxLength !== undefined) clean = clean.slice(0, maxLength);
+  return clean;
+}


### PR DESCRIPTION
## Summary
- Adds `src/utils/sanitizeInput.ts` — hardened input sanitizer composing over existing `sanitizeText`. Adds SQL keyword-combo stripping (DROP/DELETE/TRUNCATE × TABLE/FROM/…), SQL comment defang (`--`), quote/semicolon run collapse, null/undefined safety, and optional `maxLength` truncation.
- Adds `src/services/secureStorage.ts` — thin wrapper around `expo-secure-store` with a `SECURE_KEYS` registry (AUTH_TOKEN, REFRESH_TOKEN, MEMBER_ID, SESSION_ID) and a `migrateFromAsyncStorage` helper that only removes the legacy key after the secure save succeeds. Empty-key guard; errors logged and swallowed so auth degrades gracefully.

## TDD
Tests written before implementation per PM directive. 43 tests total, all passing:
- `sanitizeInput.test.ts` — 29 tests: XSS (script/style/img/iframe), SQL injection (DROP TABLE, UNION SELECT, DELETE FROM, `--`, `''`), passthrough (apostrophes, emoji, whitespace), boundaries (null/undefined/empty/whitespace-only/100k input), maxLength (truncates after sanitization, 0 = empty), defensive coercion (number/object).
- `secureStorage.test.ts` — 14 tests: save/load/delete happy + error paths, empty-key rejection, SECURE_KEYS registry, migration (happy path, no-op, failure keeps legacy key).

## Audit findings (bead scope)
- **Token storage already hardened.** Wix auth tokens (`tokenStorage.ts`) and session UUID (`sessionToken.ts`) already on SecureStore. No AsyncStorage migration needed for the big three (tokens, memberId, session).
- **High-risk user input already sanitized.** `sanitizeText` is applied in ReviewForm, NPSSurveyModal, useUGCPhotos, useProductQA, useQAAnswers, useRecentSearches.
- **No hardcoded credentials** in `src/` — all API keys are env-var driven (`EXPO_PUBLIC_*`) or test fixtures.

## Convoy
CFM leg of `hq-cv-f1ilb` (security hardening convoy). Bead: cm-3fd.

## Test plan
- [x] `npx jest src/utils/__tests__/sanitizeInput.test.ts src/services/__tests__/secureStorage.test.ts` — 43 passing
- [x] Full `src/utils` + `src/services/__tests__/secureStorage.test.ts` — 346 passing, no regressions
- [x] `npx prettier --write` on new files
- [x] `npx eslint` on new files — clean
- [x] `npx tsc --noEmit` — no type errors in new files

## Follow-up (out of scope, file if desired)
- Apply `sanitizeInput(code, 30)` at `PromoCodeInput` submit.
- Apply `sanitizeInput` at `SearchBar` submit (currently sanitized only at persistence layer).