### PR TITLE
feat(cm-fvx): apply sanitizeInput at PromoCodeInput submit

### DIFF
--- a/src/components/PromoCodeInput.tsx
+++ b/src/components/PromoCodeInput.tsx
@@ -9,6 +9,7 @@ import {
 } from 'react-native';
 import { useTheme } from '@/theme';
 import { useOptionalWixClient } from '@/services/wix';
+import { sanitizeInput } from '@/utils/sanitizeInput';
 
 interface PromoCodeInputProps {
   cartTotal: number;
@@ -29,8 +30,8 @@ export function PromoCodeInput({ cartTotal, onDiscount }: PromoCodeInputProps) {
   const [appliedCode, setAppliedCode] = useState('');
 
   async function handleApply() {
-    const trimmed = code.trim().toUpperCase();
-    if (!trimmed) return;
+    const sanitized = sanitizeInput(code, PROMO_MAX_LENGTH).toUpperCase();
+    if (!sanitized) return;
     if (!client) {
       setState('error');
       setErrorMsg('Promo codes unavailable — please sign in to apply');
@@ -39,13 +40,13 @@ export function PromoCodeInput({ cartTotal, onDiscount }: PromoCodeInputProps) {
     setState('loading');
     try {
       const result = (await client.callFunction('/_functions/validatePromoCode', 'POST', {
-        code: trimmed,
+        code: sanitized,
         cartTotal,
       })) as { valid: boolean; discount: number; type: 'percent' | 'fixed'; error?: string };
 
       if (result.valid) {
         setState('success');
-        setAppliedCode(trimmed);
+        setAppliedCode(sanitized);
         onDiscount(result.discount, result.type);
       } else {
         setState('error');

--- a/src/components/__tests__/promoCodeInput.test.tsx
+++ b/src/components/__tests__/promoCodeInput.test.tsx
@@ -122,3 +122,62 @@ it('shows unavailable message when no wix client', async () => {
   fireEvent.press(getByTestId('promo-apply-btn'));
   await waitFor(() => expect(queryByText(/unavailable/i)).toBeTruthy());
 });
+
+describe('sanitization (cm-fvx)', () => {
+  it('strips html tags from submitted code', async () => {
+    mockValidate.mockResolvedValue({ valid: true, discount: 5, type: 'fixed' });
+    const { getByText, getByTestId } = render(
+      <PromoCodeInput cartTotal={199} onDiscount={jest.fn()} />,
+    );
+    fireEvent.press(getByText(/add promo code/i));
+    fireEvent.changeText(getByTestId('promo-input'), '<b>SAVE5</b>');
+    fireEvent.press(getByTestId('promo-apply-btn'));
+    await waitFor(() =>
+      expect(mockValidate).toHaveBeenCalledWith(
+        '/_functions/validatePromoCode',
+        'POST',
+        expect.objectContaining({ code: 'SAVE5' }),
+      ),
+    );
+  });
+
+  it('defangs SQL injection attempt in code', async () => {
+    mockValidate.mockResolvedValue({ valid: true, discount: 5, type: 'fixed' });
+    const { getByText, getByTestId } = render(
+      <PromoCodeInput cartTotal={199} onDiscount={jest.fn()} />,
+    );
+    fireEvent.press(getByText(/add promo code/i));
+    fireEvent.changeText(getByTestId('promo-input'), "SAVE5'; DROP TABLE promos; --");
+    fireEvent.press(getByTestId('promo-apply-btn'));
+    await waitFor(() => {
+      const callArg = mockValidate.mock.calls[0][2] as { code: string };
+      expect(callArg.code).not.toContain('DROP TABLE');
+      expect(callArg.code).not.toContain('--');
+    });
+  });
+
+  it('truncates overlong code to maxLength (30 chars, uppercased)', async () => {
+    mockValidate.mockResolvedValue({ valid: true, discount: 5, type: 'fixed' });
+    const { getByText, getByTestId } = render(
+      <PromoCodeInput cartTotal={199} onDiscount={jest.fn()} />,
+    );
+    fireEvent.press(getByText(/add promo code/i));
+    fireEvent.changeText(getByTestId('promo-input'), 'a'.repeat(100));
+    fireEvent.press(getByTestId('promo-apply-btn'));
+    await waitFor(() => {
+      const callArg = mockValidate.mock.calls[0][2] as { code: string };
+      expect(callArg.code.length).toBeLessThanOrEqual(30);
+      expect(callArg.code).toBe('A'.repeat(30));
+    });
+  });
+
+  it('does not submit when sanitizer reduces code to empty', () => {
+    const { getByText, getByTestId } = render(
+      <PromoCodeInput cartTotal={199} onDiscount={jest.fn()} />,
+    );
+    fireEvent.press(getByText(/add promo code/i));
+    fireEvent.changeText(getByTestId('promo-input'), '<script>evil()</script>');
+    fireEvent.press(getByTestId('promo-apply-btn'));
+    expect(mockValidate).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- Applies `sanitizeInput(code, 30)` at `PromoCodeInput.handleApply` before hitting the Wix `validatePromoCode` function
- Strips HTML/script tags, defangs SQL keyword combos (`DROP TABLE`, `--`, repeated quotes), truncates to 30 chars, uppercases

## Test plan
- [x] 4 new TDD tests under `describe('sanitization (cm-fvx)')`:
  - strips html tags (`<b>SAVE5</b>` → `SAVE5`)
  - defangs SQL injection (`SAVE5'; DROP TABLE promos; --` → no `DROP`/`--`)
  - truncates 100 chars → 30 uppercased
  - empty after sanitize → no submit
- [x] All 12 tests pass (8 existing + 4 new)
- [x] prettier + eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)