### PR TITLE
feat(cm-sxj): Skeleton primitives — Row, Card, Grid

### DIFF
--- a/src/components/Skeleton.tsx
+++ b/src/components/Skeleton.tsx
@@ -1,0 +1,149 @@
+import React, { useEffect, useMemo } from 'react';
+import { View, StyleSheet, ViewStyle, StyleProp } from 'react-native';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withRepeat,
+  withTiming,
+  Easing,
+} from 'react-native-reanimated';
+import { useTheme } from '@/theme';
+import { useReducedMotion } from '@/hooks/useReducedMotion';
+
+interface SkeletonRowProps {
+  width?: number | string;
+  height?: number;
+  borderRadius?: number;
+  animated?: boolean;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+export function SkeletonRow({
+  width = '100%',
+  height = 12,
+  borderRadius = 4,
+  animated = true,
+  style,
+  testID,
+}: SkeletonRowProps) {
+  const { colors } = useTheme();
+  const reduceMotion = useReducedMotion();
+  const shimmer = useSharedValue(0.4);
+
+  useEffect(() => {
+    if (!animated || reduceMotion) {
+      shimmer.value = 0.6;
+      return;
+    }
+    shimmer.value = withRepeat(
+      withTiming(1, { duration: 900, easing: Easing.inOut(Easing.ease) }),
+      -1,
+      true,
+    );
+  }, [shimmer, animated, reduceMotion]);
+
+  const animatedStyle = useAnimatedStyle(() => ({ opacity: shimmer.value }));
+
+  return (
+    <Animated.View
+      testID={testID}
+      accessibilityLabel="Loading"
+      style={[
+        { width, height, borderRadius, backgroundColor: colors.sandBase },
+        animatedStyle,
+        style,
+      ]}
+    />
+  );
+}
+
+interface SkeletonCardProps {
+  width?: number | string;
+  header?: boolean;
+  lines?: number;
+  animated?: boolean;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+export function SkeletonCard({
+  width = '100%',
+  header = false,
+  lines = 1,
+  animated = true,
+  style,
+  testID,
+}: SkeletonCardProps) {
+  const { colors, spacing, borderRadius } = useTheme();
+  const s = useMemo(
+    () =>
+      StyleSheet.create({
+        card: {
+          width: width as ViewStyle['width'],
+          padding: spacing.md,
+          borderRadius: borderRadius.md,
+          backgroundColor: colors.sandDark,
+          gap: spacing.sm,
+        },
+      }),
+    [width, spacing, borderRadius, colors.sandDark],
+  );
+
+  return (
+    <View testID={testID} style={[s.card, style]}>
+      {header ? (
+        <SkeletonRow testID={`${testID ?? 'sk-card'}-header`} height={20} animated={animated} />
+      ) : null}
+      {Array.from({ length: lines }).map((_, i) => (
+        <SkeletonRow
+          key={i}
+          testID={`${testID ?? 'sk-card'}-line`}
+          height={12}
+          animated={animated}
+        />
+      ))}
+    </View>
+  );
+}
+
+interface SkeletonGridProps {
+  rows?: number;
+  columns?: number;
+  animated?: boolean;
+  cardHeader?: boolean;
+  cardLines?: number;
+  style?: StyleProp<ViewStyle>;
+  testID?: string;
+}
+
+export function SkeletonGrid({
+  rows = 1,
+  columns = 1,
+  animated = true,
+  cardHeader = false,
+  cardLines = 1,
+  style,
+  testID,
+}: SkeletonGridProps) {
+  const { spacing } = useTheme();
+  const total = rows * columns;
+
+  return (
+    <View
+      testID={testID}
+      style={[{ flexDirection: 'row', flexWrap: 'wrap', gap: spacing.sm }, style]}
+    >
+      {Array.from({ length: total }).map((_, i) => (
+        <View key={i} style={{ flexBasis: `${100 / columns}%`, padding: spacing.xs / 2 }}>
+          <SkeletonCard
+            testID={`${testID ?? 'sk-grid'}-card`}
+            header={cardHeader}
+            lines={cardLines}
+            animated={animated}
+          />
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/src/components/__tests__/skeleton.test.tsx
+++ b/src/components/__tests__/skeleton.test.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+
+import { SkeletonRow, SkeletonCard, SkeletonGrid } from '../Skeleton';
+
+jest.mock('@/theme', () => ({
+  useTheme: () => ({
+    colors: {
+      sandBase: '#E8D5B7',
+      espresso: '#3A2518',
+      sandDark: '#D4BC96',
+    },
+    spacing: { xs: 4, sm: 8, md: 16 },
+    borderRadius: { sm: 4, md: 8 },
+  }),
+}));
+
+jest.mock('@/hooks/useReducedMotion', () => ({
+  useReducedMotion: () => false,
+}));
+
+describe('SkeletonRow', () => {
+  it('renders with default dimensions', () => {
+    const { getByTestId } = render(<SkeletonRow testID="sk-row" />);
+    expect(getByTestId('sk-row')).toBeTruthy();
+  });
+
+  it('passes width and height props through to style', () => {
+    const { getByTestId } = render(<SkeletonRow testID="sk-row" width={200} height={24} />);
+    const el = getByTestId('sk-row');
+    const style = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style)
+      : el.props.style;
+    expect(style.width).toBe(200);
+    expect(style.height).toBe(24);
+  });
+
+  it('honors borderRadius prop', () => {
+    const { getByTestId } = render(<SkeletonRow testID="sk-row" borderRadius={12} />);
+    const el = getByTestId('sk-row');
+    const style = Array.isArray(el.props.style)
+      ? Object.assign({}, ...el.props.style)
+      : el.props.style;
+    expect(style.borderRadius).toBe(12);
+  });
+
+  it('does not animate when animated={false}', () => {
+    const { getByTestId } = render(<SkeletonRow testID="sk-row" animated={false} />);
+    expect(getByTestId('sk-row')).toBeTruthy();
+  });
+});
+
+describe('SkeletonCard', () => {
+  it('renders body lines based on lines prop', () => {
+    const { getAllByTestId } = render(<SkeletonCard testID="sk-card" lines={3} />);
+    expect(getAllByTestId('sk-card-line').length).toBe(3);
+  });
+
+  it('renders header placeholder when header={true}', () => {
+    const { getByTestId } = render(<SkeletonCard testID="sk-card" header lines={2} />);
+    expect(getByTestId('sk-card-header')).toBeTruthy();
+  });
+
+  it('omits header when header={false}', () => {
+    const { queryByTestId } = render(<SkeletonCard testID="sk-card" lines={2} />);
+    expect(queryByTestId('sk-card-header')).toBeNull();
+  });
+
+  it('defaults to one line when lines not specified', () => {
+    const { getAllByTestId } = render(<SkeletonCard testID="sk-card" />);
+    expect(getAllByTestId('sk-card-line').length).toBe(1);
+  });
+});
+
+describe('SkeletonGrid', () => {
+  it('renders rows × columns cards', () => {
+    const { getAllByTestId } = render(<SkeletonGrid testID="sk-grid" rows={2} columns={3} />);
+    expect(getAllByTestId('sk-grid-card').length).toBe(6);
+  });
+
+  it('renders zero cards when rows=0', () => {
+    const { queryAllByTestId } = render(<SkeletonGrid testID="sk-grid" rows={0} columns={3} />);
+    expect(queryAllByTestId('sk-grid-card').length).toBe(0);
+  });
+
+  it('defaults to 1×1 when no dims given', () => {
+    const { getAllByTestId } = render(<SkeletonGrid testID="sk-grid" />);
+    expect(getAllByTestId('sk-grid-card').length).toBe(1);
+  });
+});


### PR DESCRIPTION
## Summary
- `SkeletonRow` — single-line placeholder. Props: `width`, `height`, `borderRadius`, `animated`, `style`.
- `SkeletonCard` — rectangular card with optional `header` + N body `lines`.
- `SkeletonGrid` — `rows × columns` grid of `SkeletonCard`.
- Reanimated shimmer (opacity pulse), respects `useReducedMotion` and `animated={false}`.
- SAND base color per brand tokens.

## Test plan
- [x] 11 TDD tests (render, width/height/borderRadius passthrough, animated off, lines count, header toggle, grid dims, zero rows, defaults)
- [x] prettier + eslint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)