### PR TITLE
fix(cm-zo1): drop stale expo-av references in ResourcesSection

### DIFF
--- a/src/components/ResourcesSection.tsx
+++ b/src/components/ResourcesSection.tsx
@@ -9,7 +9,7 @@
  * PDF taps: expo-sharing (native share sheet on mobile); falls back to
  * expo-web-browser if sharing is unavailable.
  * Policy links: expo-web-browser (in-app browser).
- * Video: expo-av Video component, lazy-loaded (mounted only when expanded).
+ * Video: expo-web-browser — taps open the video URL in the in-app browser.
  */
 
 import React, { memo, useState, useCallback } from 'react';

--- a/src/components/__tests__/ResourcesSection.test.tsx
+++ b/src/components/__tests__/ResourcesSection.test.tsx
@@ -13,7 +13,6 @@ import * as Sharing from 'expo-sharing';
 import * as WebBrowser from 'expo-web-browser';
 
 // expo-sharing is auto-mocked via __mocks__/expo-sharing.js
-// expo-av is auto-mocked via __mocks__/expo-av.js
 
 jest.mock('expo-web-browser', () => ({
   openBrowserAsync: jest.fn(() => Promise.resolve({ type: 'cancel' })),
@@ -155,6 +154,16 @@ describe('ResourcesSection', () => {
     it('does not render video player when videoUrl is absent', () => {
       const { queryByTestId } = openResources({ specSheetUrl: MOCK_RESOURCES.specSheetUrl });
       expect(queryByTestId('resources-video-player')).toBeNull();
+    });
+
+    // cm-zo1: expo-av was imported but never used. Video taps go through
+    // expo-web-browser. Lock that behavior in so the dead import can't creep back.
+    it('tapping the video player opens the video URL in the in-app browser', async () => {
+      const { getByTestId } = openResources({ videoUrl: MOCK_RESOURCES.videoUrl });
+      await act(async () => {
+        fireEvent.press(getByTestId('resources-video-player'));
+      });
+      expect(WebBrowser.openBrowserAsync).toHaveBeenCalledWith(MOCK_RESOURCES.videoUrl);
     });
   });
 


### PR DESCRIPTION
## Summary
The broken `expo-av` import was already removed upstream, but stale references lingered:
- JSDoc header still said video used `expo-av Video component`
- Test file comment mentioned a non-existent `__mocks__/expo-av.js`

Cleans both up and adds a TDD test locking the real behavior (video tap → `WebBrowser.openBrowserAsync`) so the dead import can't creep back.

## Test plan
- [x] 31 tests pass (30 existing + 1 new: \"tapping the video player opens the video URL in the in-app browser\")
- [x] No code behavior change — doc/comment hygiene + regression guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)