### PR TITLE
feat(cm-1we): MobileChallengeCompletions progress screen

### DIFF
--- a/src/hooks/__tests__/useMobileChallengeProgress.test.ts
+++ b/src/hooks/__tests__/useMobileChallengeProgress.test.ts
@@ -1,0 +1,254 @@
+/**
+ * @module useMobileChallengeProgress.test
+ *
+ * TDD tests for useMobileChallengeProgress — wraps getMobileChallengeProgress()
+ * and listens for crossRigEventReceiver push events to auto-refresh.
+ *
+ * cm-1we
+ */
+
+import { renderHook, act, waitFor } from '@testing-library/react-native';
+
+import { useMobileChallengeProgress } from '../useMobileChallengeProgress';
+
+// ── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockCallFunction = jest.fn();
+const mockWixClient = { callFunction: mockCallFunction };
+
+jest.mock('@/services/wix', () => ({
+  useOptionalWixClient: jest.fn(() => mockWixClient),
+}));
+
+const mockUseAuth = jest.fn((): { user: { id: string } | null } => ({
+  user: { id: 'member-1' },
+}));
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => mockUseAuth(),
+}));
+
+// Notification listener shim
+const listeners: ((n: any) => void)[] = [];
+const mockRemoveListener = jest.fn();
+jest.mock('expo-notifications', () => ({
+  addNotificationReceivedListener: jest.fn((cb: (n: any) => void) => {
+    listeners.push(cb);
+    return { remove: mockRemoveListener };
+  }),
+}));
+
+// Spy crossRigSync.syncMobilePoints to verify sync call on push-driven refresh
+jest.mock('@/services/crossRigSync', () => {
+  const actual = jest.requireActual('@/services/crossRigSync');
+  return {
+    ...actual,
+    syncMobilePoints: jest.fn(() => Promise.resolve()),
+  };
+});
+
+const { useOptionalWixClient } = require('@/services/wix');
+const crossRigSync = require('@/services/crossRigSync');
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const PROGRESS_RESPONSE = {
+  success: true,
+  counts: {
+    ar_discovery: 2,
+    quiz_completion: 5,
+    social_share: 1,
+  },
+};
+
+const EMPTY_RESPONSE = {
+  success: true,
+  counts: { ar_discovery: 0, quiz_completion: 0, social_share: 0 },
+};
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('useMobileChallengeProgress', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    listeners.length = 0;
+    (useOptionalWixClient as jest.Mock).mockReturnValue(mockWixClient);
+    mockUseAuth.mockReturnValue({ user: { id: 'member-1' } });
+    mockCallFunction.mockResolvedValue(PROGRESS_RESPONSE);
+  });
+
+  it('fetches progress on mount and exposes counts', async () => {
+    const { result } = renderHook(() => useMobileChallengeProgress());
+
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.counts).toEqual(PROGRESS_RESPONSE.counts);
+    expect(result.current.error).toBeNull();
+    expect(mockCallFunction).toHaveBeenCalledWith(
+      'getMobileChallengeProgress',
+      'GET',
+      expect.objectContaining({ memberId: 'member-1' }),
+    );
+  });
+
+  it('returns empty counts with loading=false when no wix client', async () => {
+    (useOptionalWixClient as jest.Mock).mockReturnValue(null);
+    const { result } = renderHook(() => useMobileChallengeProgress());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.counts).toEqual({
+      ar_discovery: 0,
+      quiz_completion: 0,
+      social_share: 0,
+    });
+  });
+
+  it('returns empty counts with loading=false when no authenticated user', async () => {
+    mockUseAuth.mockReturnValue({ user: null });
+    const { result } = renderHook(() => useMobileChallengeProgress());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockCallFunction).not.toHaveBeenCalled();
+    expect(result.current.counts.ar_discovery).toBe(0);
+  });
+
+  it('surfaces error string when callFunction rejects', async () => {
+    mockCallFunction.mockRejectedValueOnce(new Error('network'));
+    const { result } = renderHook(() => useMobileChallengeProgress());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toMatch(/unable to load/i);
+    expect(result.current.counts.ar_discovery).toBe(0);
+  });
+
+  it('refresh() re-fetches counts', async () => {
+    const { result } = renderHook(() => useMobileChallengeProgress());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockCallFunction).toHaveBeenCalledTimes(1);
+
+    mockCallFunction.mockResolvedValueOnce({
+      success: true,
+      counts: { ar_discovery: 9, quiz_completion: 9, social_share: 9 },
+    });
+
+    await act(async () => {
+      result.current.refresh();
+    });
+    await waitFor(() =>
+      expect(result.current.counts).toEqual({
+        ar_discovery: 9,
+        quiz_completion: 9,
+        social_share: 9,
+      }),
+    );
+    expect(mockCallFunction).toHaveBeenCalledTimes(2);
+  });
+
+  it('refreshes on push notification matching a challenge completion event', async () => {
+    const { result } = renderHook(() => useMobileChallengeProgress());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(listeners.length).toBe(1);
+    expect(mockCallFunction).toHaveBeenCalledTimes(1);
+
+    mockCallFunction.mockResolvedValueOnce({
+      success: true,
+      counts: { ar_discovery: 3, quiz_completion: 5, social_share: 1 },
+    });
+
+    await act(async () => {
+      listeners[0]({
+        request: {
+          content: {
+            data: { event: 'ar_discovery_completed', points: 75 },
+          },
+        },
+      });
+    });
+
+    await waitFor(() => expect(mockCallFunction).toHaveBeenCalledTimes(2));
+    expect(result.current.counts.ar_discovery).toBe(3);
+  });
+
+  it('calls syncMobilePoints when push event includes points', async () => {
+    renderHook(() => useMobileChallengeProgress());
+    await waitFor(() => expect(listeners.length).toBe(1));
+
+    await act(async () => {
+      listeners[0]({
+        request: {
+          content: {
+            data: { event: 'quiz_completed', points: 50 },
+          },
+        },
+      });
+    });
+
+    await waitFor(() =>
+      expect(crossRigSync.syncMobilePoints).toHaveBeenCalledWith(
+        mockWixClient,
+        'member-1',
+        50,
+        'quiz_completed',
+      ),
+    );
+  });
+
+  it('does not refresh on irrelevant push events', async () => {
+    renderHook(() => useMobileChallengeProgress());
+    await waitFor(() => expect(mockCallFunction).toHaveBeenCalledTimes(1));
+
+    await act(async () => {
+      listeners[0]({
+        request: { content: { data: { event: 'order_shipped' } } },
+      });
+    });
+
+    // Still only the initial mount call
+    expect(mockCallFunction).toHaveBeenCalledTimes(1);
+    expect(crossRigSync.syncMobilePoints).not.toHaveBeenCalled();
+  });
+
+  it('handles malformed notification payload without crashing', async () => {
+    renderHook(() => useMobileChallengeProgress());
+    await waitFor(() => expect(listeners.length).toBe(1));
+
+    await act(async () => {
+      listeners[0]({ request: { content: { data: null } } });
+      listeners[0]({ request: { content: {} } });
+      listeners[0]({});
+    });
+
+    // Only the mount call — all malformed events ignored
+    expect(mockCallFunction).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows syncMobilePoints failure without breaking refresh', async () => {
+    (crossRigSync.syncMobilePoints as jest.Mock).mockRejectedValueOnce(new Error('sync down'));
+    const { result } = renderHook(() => useMobileChallengeProgress());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    await act(async () => {
+      listeners[0]({
+        request: {
+          content: {
+            data: { event: 'social_share_completed', points: 100 },
+          },
+        },
+      });
+    });
+
+    // Refresh still fires even though sync throws
+    await waitFor(() => expect(mockCallFunction).toHaveBeenCalledTimes(2));
+    expect(result.current.error).toBeNull();
+  });
+
+  it('removes notification listener on unmount', async () => {
+    const { unmount } = renderHook(() => useMobileChallengeProgress());
+    await waitFor(() => expect(listeners.length).toBe(1));
+    unmount();
+    expect(mockRemoveListener).toHaveBeenCalled();
+  });
+
+  it('returns empty counts when API response success is false', async () => {
+    mockCallFunction.mockResolvedValueOnce({ success: false, counts: EMPTY_RESPONSE.counts });
+    const { result } = renderHook(() => useMobileChallengeProgress());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.error).toMatch(/unable to load/i);
+  });
+});

--- a/src/hooks/useMobileChallengeProgress.ts
+++ b/src/hooks/useMobileChallengeProgress.ts
@@ -1,0 +1,138 @@
+/**
+ * @module useMobileChallengeProgress
+ *
+ * Fetches MobileChallengeCompletions progress counts for the authenticated
+ * member via `getMobileChallengeProgress` and keeps them in sync with incoming
+ * cross-rig completion push events (ar_discovery_completed, quiz_completed,
+ * social_share_completed).
+ *
+ * When a push arrives carrying `points`, also calls {@link syncMobilePoints}
+ * so the web-side loyalty ledger stays in lockstep with mobile completions.
+ *
+ * cm-1we
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import * as Notifications from 'expo-notifications';
+import { useOptionalWixClient } from '@/services/wix';
+import { useAuth } from '@/hooks/useAuth';
+import {
+  getMobileChallengeProgress,
+  syncMobilePoints,
+  type CrossRigEventType,
+  type MobileChallengeProgress,
+} from '@/services/crossRigSync';
+
+export type ChallengeCounts = MobileChallengeProgress['counts'];
+
+export interface UseMobileChallengeProgressResult {
+  counts: ChallengeCounts;
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+const EMPTY_COUNTS: ChallengeCounts = {
+  ar_discovery: 0,
+  quiz_completion: 0,
+  social_share: 0,
+};
+
+/** Cross-rig completion events that should trigger a progress re-fetch. */
+const COMPLETION_EVENTS: ReadonlySet<CrossRigEventType> = new Set<CrossRigEventType>([
+  'ar_discovery_completed',
+  'quiz_completed',
+  'social_share_completed',
+]);
+
+function isCompletionEvent(value: unknown): value is CrossRigEventType {
+  return typeof value === 'string' && COMPLETION_EVENTS.has(value as CrossRigEventType);
+}
+
+export function useMobileChallengeProgress(): UseMobileChallengeProgressResult {
+  const wixClient = useOptionalWixClient();
+  const { user } = useAuth();
+  const memberId = user?.id ?? '';
+
+  const [counts, setCounts] = useState<ChallengeCounts>(EMPTY_COUNTS);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshToken, setRefreshToken] = useState(0);
+
+  // Latest client/member captured for the notification listener closure
+  const ctxRef = useRef({ wixClient, memberId });
+  ctxRef.current = { wixClient, memberId };
+
+  const refresh = useCallback(() => {
+    setRefreshToken((t) => t + 1);
+  }, []);
+
+  // Fetch on mount + on refresh token change
+  useEffect(() => {
+    if (!wixClient || !memberId) {
+      setCounts(EMPTY_COUNTS);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+    setLoading(true);
+    setError(null);
+
+    getMobileChallengeProgress(wixClient, memberId)
+      .then((res) => {
+        if (cancelled) return;
+        if (!res?.success) {
+          setCounts(EMPTY_COUNTS);
+          setError('Unable to load challenge progress.');
+          setLoading(false);
+          return;
+        }
+        setCounts(res.counts ?? EMPTY_COUNTS);
+        setLoading(false);
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setCounts(EMPTY_COUNTS);
+        setError('Unable to load challenge progress.');
+        setLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [wixClient, memberId, refreshToken]);
+
+  // Wire push notifications → refresh (+ ledger sync when points present)
+  useEffect(() => {
+    const subscription = Notifications.addNotificationReceivedListener((n) => {
+      const data = n?.request?.content?.data as Record<string, unknown> | null | undefined;
+      if (!data) return;
+
+      const event = data.event;
+      if (!isCompletionEvent(event)) return;
+
+      const { wixClient: client, memberId: mid } = ctxRef.current;
+      const rawPoints = data.points;
+      const points = typeof rawPoints === 'number' && rawPoints >= 0 ? rawPoints : null;
+
+      if (client && mid && points !== null) {
+        // Fire-and-forget; don't let a sync failure prevent refresh.
+        Promise.resolve()
+          .then(() => syncMobilePoints(client, mid, points, event))
+          .catch(() => {
+            // Intentionally swallowed — progress refresh below is the user-visible path.
+          });
+      }
+
+      refresh();
+    });
+
+    return () => {
+      subscription.remove();
+    };
+  }, [refresh]);
+
+  return { counts, loading, error, refresh };
+}

--- a/src/screens/MobileChallengeProgressScreen.tsx
+++ b/src/screens/MobileChallengeProgressScreen.tsx
@@ -1,0 +1,194 @@
+/**
+ * @module MobileChallengeProgressScreen
+ *
+ * Displays the authenticated member's MobileChallengeCompletions progress —
+ * completion counts per challenge type (AR Discovery, Quiz Completion,
+ * Social Share) plus a derived total-points tally.
+ *
+ * Counts are fetched via {@link useMobileChallengeProgress}, which also
+ * listens for cross-rig completion push events and auto-refreshes the view
+ * while the screen is mounted.
+ *
+ * cm-1we
+ */
+
+import React from 'react';
+import {
+  ActivityIndicator,
+  RefreshControl,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from 'react-native';
+import { useTheme } from '@/theme';
+import {
+  useMobileChallengeProgress,
+  type ChallengeCounts,
+} from '@/hooks/useMobileChallengeProgress';
+import { MOBILE_CHALLENGE_TYPES, type MobileChallengeType } from '@/services/crossRigSync';
+
+interface TypeDisplay {
+  key: MobileChallengeType;
+  label: string;
+  icon: string;
+}
+
+const TYPE_DISPLAY: readonly TypeDisplay[] = [
+  { key: 'ar_discovery', label: 'AR Discovery', icon: '📷' },
+  { key: 'quiz_completion', label: 'Quiz Completion', icon: '🎯' },
+  { key: 'social_share', label: 'Social Share', icon: '🔗' },
+];
+
+function computeTotalPoints(counts: ChallengeCounts): number {
+  return (
+    counts.ar_discovery * MOBILE_CHALLENGE_TYPES.ar_discovery.points +
+    counts.quiz_completion * MOBILE_CHALLENGE_TYPES.quiz_completion.points +
+    counts.social_share * MOBILE_CHALLENGE_TYPES.social_share.points
+  );
+}
+
+export function MobileChallengeProgressScreen() {
+  const { colors, typography, spacing } = useTheme();
+  const { counts, loading, error, refresh } = useMobileChallengeProgress();
+
+  if (loading) {
+    return (
+      <View style={styles.centered} testID="mcp-loading">
+        <ActivityIndicator size="large" color={colors.mountainBlue} />
+      </View>
+    );
+  }
+
+  if (error) {
+    return (
+      <View style={styles.centered} testID="mcp-error">
+        <Text
+          style={[styles.errorText, { color: colors.espresso, fontFamily: typography.bodyFamily }]}
+        >
+          {error}
+        </Text>
+        <TouchableOpacity
+          testID="mcp-retry"
+          onPress={refresh}
+          style={[styles.retryButton, { backgroundColor: colors.mountainBlue }]}
+          accessibilityRole="button"
+          accessibilityLabel="Retry loading challenge progress"
+        >
+          <Text style={[styles.retryText, { fontFamily: typography.bodyFamilyBold }]}>Retry</Text>
+        </TouchableOpacity>
+      </View>
+    );
+  }
+
+  const totalPoints = computeTotalPoints(counts);
+
+  return (
+    <ScrollView
+      testID="mcp-scroll"
+      contentContainerStyle={[styles.container, { padding: spacing.lg }]}
+      refreshControl={<RefreshControl refreshing={false} onRefresh={refresh} />}
+    >
+      <Text
+        style={[
+          styles.title,
+          {
+            color: colors.espresso,
+            fontFamily: typography.headingFamily ?? typography.bodyFamilyBold,
+          },
+        ]}
+      >
+        Challenge Progress
+      </Text>
+      <View
+        style={[
+          styles.summary,
+          { backgroundColor: colors.sandDark, marginTop: spacing.md, padding: spacing.md },
+        ]}
+      >
+        <Text
+          style={[
+            styles.summaryLabel,
+            { color: colors.espressoLight, fontFamily: typography.bodyFamily },
+          ]}
+        >
+          Total points earned
+        </Text>
+        <Text
+          testID="mcp-total-points"
+          style={[
+            styles.summaryValue,
+            { color: colors.mountainBlue, fontFamily: typography.bodyFamilyBold },
+          ]}
+        >
+          {totalPoints}
+        </Text>
+      </View>
+
+      <View style={{ marginTop: spacing.lg }}>
+        {TYPE_DISPLAY.map(({ key, label, icon }) => (
+          <View
+            key={key}
+            testID={`mcp-card-${key}`}
+            style={[
+              styles.card,
+              {
+                backgroundColor: colors.sandDark,
+                marginBottom: spacing.md,
+                padding: spacing.md,
+              },
+            ]}
+          >
+            <Text style={styles.cardIcon}>{icon}</Text>
+            <View style={styles.cardBody}>
+              <Text
+                style={[
+                  styles.cardLabel,
+                  { color: colors.espresso, fontFamily: typography.bodyFamilyBold },
+                ]}
+              >
+                {label}
+              </Text>
+              <Text
+                style={[
+                  styles.cardSubLabel,
+                  { color: colors.espressoLight, fontFamily: typography.bodyFamily },
+                ]}
+              >
+                {MOBILE_CHALLENGE_TYPES[key].points} pts each
+              </Text>
+            </View>
+            <Text
+              testID={`mcp-count-${key}`}
+              style={[
+                styles.cardCount,
+                { color: colors.mountainBlue, fontFamily: typography.bodyFamilyBold },
+              ]}
+            >
+              {counts[key]}
+            </Text>
+          </View>
+        ))}
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flexGrow: 1 },
+  centered: { flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 },
+  errorText: { fontSize: 16, textAlign: 'center', marginBottom: 16 },
+  retryButton: { paddingVertical: 12, paddingHorizontal: 24, borderRadius: 8 },
+  retryText: { color: '#fff', fontSize: 16 },
+  title: { fontSize: 24 },
+  summary: { borderRadius: 12, alignItems: 'center' },
+  summaryLabel: { fontSize: 14 },
+  summaryValue: { fontSize: 32, marginTop: 4 },
+  card: { flexDirection: 'row', alignItems: 'center', borderRadius: 12 },
+  cardIcon: { fontSize: 28, marginRight: 12 },
+  cardBody: { flex: 1 },
+  cardLabel: { fontSize: 16 },
+  cardSubLabel: { fontSize: 12, marginTop: 2 },
+  cardCount: { fontSize: 28, marginLeft: 12, minWidth: 40, textAlign: 'right' },
+});

--- a/src/screens/__tests__/mobileChallengeProgressScreen.test.tsx
+++ b/src/screens/__tests__/mobileChallengeProgressScreen.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * @module mobileChallengeProgressScreen.test
+ *
+ * TDD tests for MobileChallengeProgressScreen — renders completion counts
+ * per challenge type from useMobileChallengeProgress.
+ *
+ * cm-1we
+ */
+
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+
+import { ThemeProvider } from '@/theme/ThemeProvider';
+import { MobileChallengeProgressScreen } from '../MobileChallengeProgressScreen';
+
+const mockRefresh = jest.fn();
+const mockState: {
+  counts: { ar_discovery: number; quiz_completion: number; social_share: number };
+  loading: boolean;
+  error: string | null;
+  refresh: jest.Mock;
+} = {
+  counts: { ar_discovery: 0, quiz_completion: 0, social_share: 0 },
+  loading: false,
+  error: null,
+  refresh: mockRefresh,
+};
+
+jest.mock('@/hooks/useMobileChallengeProgress', () => ({
+  useMobileChallengeProgress: () => mockState,
+}));
+
+function renderScreen() {
+  return render(
+    <ThemeProvider>
+      <MobileChallengeProgressScreen />
+    </ThemeProvider>,
+  );
+}
+
+beforeEach(() => {
+  mockRefresh.mockClear();
+  mockState.counts = { ar_discovery: 0, quiz_completion: 0, social_share: 0 };
+  mockState.loading = false;
+  mockState.error = null;
+  mockState.refresh = mockRefresh;
+});
+
+describe('MobileChallengeProgressScreen', () => {
+  it('renders loading indicator when hook is loading', () => {
+    mockState.loading = true;
+    const { getByTestId } = renderScreen();
+    expect(getByTestId('mcp-loading')).toBeTruthy();
+  });
+
+  it('renders error message with retry when hook returns an error', () => {
+    mockState.error = 'Unable to load challenge progress.';
+    const { getByTestId, getByText } = renderScreen();
+    expect(getByTestId('mcp-error')).toBeTruthy();
+    expect(getByText('Unable to load challenge progress.')).toBeTruthy();
+    fireEvent.press(getByTestId('mcp-retry'));
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+
+  it('renders all three challenge type cards with their counts', () => {
+    mockState.counts = { ar_discovery: 3, quiz_completion: 7, social_share: 2 };
+    const { getByTestId } = renderScreen();
+    expect(getByTestId('mcp-card-ar_discovery')).toBeTruthy();
+    expect(getByTestId('mcp-count-ar_discovery').props.children).toBe(3);
+    expect(getByTestId('mcp-count-quiz_completion').props.children).toBe(7);
+    expect(getByTestId('mcp-count-social_share').props.children).toBe(2);
+  });
+
+  it('renders zero counts cleanly for empty state', () => {
+    const { getByTestId } = renderScreen();
+    expect(getByTestId('mcp-count-ar_discovery').props.children).toBe(0);
+    expect(getByTestId('mcp-count-quiz_completion').props.children).toBe(0);
+    expect(getByTestId('mcp-count-social_share').props.children).toBe(0);
+  });
+
+  it('renders a human-readable label for each challenge type', () => {
+    const { getByText } = renderScreen();
+    expect(getByText('AR Discovery')).toBeTruthy();
+    expect(getByText('Quiz Completion')).toBeTruthy();
+    expect(getByText('Social Share')).toBeTruthy();
+  });
+
+  it('total points reflects completion counts × per-type point values', () => {
+    // points map: ar_discovery=75, quiz_completion=50, social_share=100
+    mockState.counts = { ar_discovery: 2, quiz_completion: 3, social_share: 1 };
+    const { getByTestId } = renderScreen();
+    // 2*75 + 3*50 + 1*100 = 150 + 150 + 100 = 400
+    expect(getByTestId('mcp-total-points').props.children).toBe(400);
+  });
+
+  it('pull-to-refresh (refresh control) triggers hook refresh', () => {
+    const { getByTestId } = renderScreen();
+    const scrollView = getByTestId('mcp-scroll');
+    const refreshControl = scrollView.props.refreshControl;
+    refreshControl.props.onRefresh();
+    expect(mockRefresh).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
Adds `useMobileChallengeProgress` hook + `MobileChallengeProgressScreen` for the authenticated member's mobile challenge completion counts.

## Hook — `useMobileChallengeProgress`
- Fetches `getMobileChallengeProgress(memberId)` via `useOptionalWixClient`
- Subscribes to `Notifications.addNotificationReceivedListener` — refreshes counts when `data.event` is one of `ar_discovery_completed`, `quiz_completed`, `social_share_completed`
- Calls `syncMobilePoints(client, memberId, points, event)` when the push payload includes `points`, keeping the web loyalty ledger in lockstep
- Sync failures are swallowed; the progress refresh is the user-visible path
- Guards: no client / no auth user → empty counts with no network call
- `success: false` response surfaces "Unable to load" error
- Cleans up the notification listener on unmount

## Screen — `MobileChallengeProgressScreen`
- Three type cards (AR Discovery, Quiz Completion, Social Share) with per-type point value + completion count
- Derived total-points tally (counts × `MOBILE_CHALLENGE_TYPES` points)
- Loading (ActivityIndicator), error with Retry, pull-to-refresh via `RefreshControl`

## Test plan
- [x] `npx jest --ci src/hooks/__tests__/useMobileChallengeProgress.test.ts` — 12/12 pass
- [x] `npx jest --ci src/screens/__tests__/mobileChallengeProgressScreen.test.tsx` — 7/7 pass
- [x] `npx prettier --check` clean; `npx eslint` zero errors (warnings match existing repo pattern)
- [x] `npx tsc --noEmit` clean
- [x] Pure Jest, Mac-safe — no device dependencies

Closes cm-1we.

🤖 Generated with [Claude Code](https://claude.com/claude-code)