### PR TITLE
fix(lint): prettier formatting across loyalty/gamification files

### DIFF
--- a/src/hooks/__tests__/useProductRecommendations.test.ts
+++ b/src/hooks/__tests__/useProductRecommendations.test.ts
@@ -31,6 +31,8 @@ import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { useProductRecommendations, clearRecommendationsCache } from '../useProductRecommendations';
 import { PRODUCTS } from '@/data/products';
 
+import { useOptionalWixClient } from '@/services/wix/wixProvider';
+
 // ── Mock Wix provider ──────────────────────────────────────────────────────────
 
 const mockQueryData = jest.fn();
@@ -39,8 +41,6 @@ const mockWixClient = { queryData: mockQueryData };
 jest.mock('@/services/wix/wixProvider', () => ({
   useOptionalWixClient: jest.fn(),
 }));
-
-import { useOptionalWixClient } from '@/services/wix/wixProvider';
 const mockUseOptionalWixClient = useOptionalWixClient as jest.Mock;
 
 // ── Mock crashReporting ───────────────────────────────────────────────────────

--- a/src/hooks/__tests__/useRealRoomPhotos.test.ts
+++ b/src/hooks/__tests__/useRealRoomPhotos.test.ts
@@ -47,6 +47,8 @@
 import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { useRealRoomPhotos } from '../useRealRoomPhotos';
 
+import { useOptionalWixClient } from '@/services/wix/wixProvider';
+
 // ── Mock Wix client ───────────────────────────────────────────────────────────
 
 const mockQueryData = jest.fn();
@@ -55,8 +57,6 @@ const mockWixClient = { queryData: mockQueryData };
 jest.mock('@/services/wix/wixProvider', () => ({
   useOptionalWixClient: jest.fn(),
 }));
-
-import { useOptionalWixClient } from '@/services/wix/wixProvider';
 
 const mockUseOptionalWixClient = useOptionalWixClient as jest.Mock;
 

--- a/src/hooks/__tests__/useSavedARLayouts.test.ts
+++ b/src/hooks/__tests__/useSavedARLayouts.test.ts
@@ -9,6 +9,8 @@ import { renderHook, act, waitFor } from '@testing-library/react-native';
 import { useSavedARLayouts, MAX_SAVED_LAYOUTS } from '../useSavedARLayouts';
 import { pushLayouts, pullLayouts } from '@/services/arLayoutSync';
 
+import { useOptionalWixClient } from '@/services/wix/wixProvider';
+
 // ── AsyncStorage mock ─────────────────────────────────────────────────────────
 const mockSetItem: jest.Mock = jest.fn(() => Promise.resolve());
 const mockGetItem: jest.Mock = jest.fn(() => Promise.resolve(null));
@@ -35,8 +37,6 @@ const mockWixClient = {
 jest.mock('@/services/wix/wixProvider', () => ({
   useOptionalWixClient: jest.fn(() => null),
 }));
-
-import { useOptionalWixClient } from '@/services/wix/wixProvider';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 const ITEM_A = { modelId: 'asheville-full', fabricId: 'natural-linen' };

--- a/src/hooks/__tests__/useTierPerks.test.ts
+++ b/src/hooks/__tests__/useTierPerks.test.ts
@@ -66,7 +66,11 @@ describe('useTierPerks — happy path', () => {
     mockGetTierPerks.mockResolvedValue({
       perks: [
         makeDelivery({ perkType: 'FREE_WHITE_GLOVE', tier: 'Summit Master' }),
-        makeDelivery({ perkType: 'STYLING_CALL', tier: 'Summit Master', bookingUrl: 'https://calendly.com/test' }),
+        makeDelivery({
+          perkType: 'STYLING_CALL',
+          tier: 'Summit Master',
+          bookingUrl: 'https://calendly.com/test',
+        }),
         makeDelivery({ perkType: 'EARLY_ACCESS', tier: 'Blue Ridge Legend' }),
       ],
     });

--- a/src/screens/LoyaltyScreen.tsx
+++ b/src/screens/LoyaltyScreen.tsx
@@ -230,13 +230,19 @@ export function LoyaltyScreen({ testID, onClose: _onClose }: Props) {
               testID={`loyalty-perk-${perk.perkType}`}
             >
               <Text
-                style={[styles.perkLabel, { color: colors.espresso, fontFamily: typography.bodyFamily }]}
+                style={[
+                  styles.perkLabel,
+                  { color: colors.espresso, fontFamily: typography.bodyFamily },
+                ]}
               >
                 {perkLabel(perk.perkType)}
               </Text>
               {perk.couponCode ? (
                 <Text
-                  style={[styles.perkCode, { color: colors.mountainBlue, fontFamily: typography.bodyFamilySemiBold }]}
+                  style={[
+                    styles.perkCode,
+                    { color: colors.mountainBlue, fontFamily: typography.bodyFamilySemiBold },
+                  ]}
                   testID={`loyalty-perk-coupon-${perk.perkType}`}
                 >
                   {perk.couponCode}
@@ -244,7 +250,10 @@ export function LoyaltyScreen({ testID, onClose: _onClose }: Props) {
               ) : null}
               {perk.bookingUrl ? (
                 <Text
-                  style={[styles.perkCode, { color: colors.sunsetCoral, fontFamily: typography.bodyFamilySemiBold }]}
+                  style={[
+                    styles.perkCode,
+                    { color: colors.sunsetCoral, fontFamily: typography.bodyFamilySemiBold },
+                  ]}
                   testID={`loyalty-perk-booking-${perk.perkType}`}
                 >
                   Book now
@@ -275,7 +284,10 @@ export function LoyaltyScreen({ testID, onClose: _onClose }: Props) {
       ) : activityError ? (
         <View style={styles.emptyTx} testID="loyalty-activity-error">
           <Text
-            style={[styles.emptyText, { color: colors.espressoLight, fontFamily: typography.bodyFamily }]}
+            style={[
+              styles.emptyText,
+              { color: colors.espressoLight, fontFamily: typography.bodyFamily },
+            ]}
           >
             {activityError}
           </Text>
@@ -283,7 +295,10 @@ export function LoyaltyScreen({ testID, onClose: _onClose }: Props) {
       ) : activityEvents.length === 0 ? (
         <View style={styles.emptyTx}>
           <Text
-            style={[styles.emptyText, { color: colors.espressoLight, fontFamily: typography.bodyFamily }]}
+            style={[
+              styles.emptyText,
+              { color: colors.espressoLight, fontFamily: typography.bodyFamily },
+            ]}
             testID="loyalty-no-activity"
           >
             No activity yet. Earn points by shopping!
@@ -299,13 +314,19 @@ export function LoyaltyScreen({ testID, onClose: _onClose }: Props) {
             >
               <Text style={styles.activityIcon}>{ACTIVITY_ICON[event.type] ?? '✨'}</Text>
               <Text
-                style={[styles.activityDesc, { color: colors.espresso, fontFamily: typography.bodyFamily }]}
+                style={[
+                  styles.activityDesc,
+                  { color: colors.espresso, fontFamily: typography.bodyFamily },
+                ]}
                 numberOfLines={1}
               >
                 {event.description}
               </Text>
               <Text
-                style={[styles.activityPoints, { color: colors.mountainBlue, fontFamily: typography.bodyFamilySemiBold }]}
+                style={[
+                  styles.activityPoints,
+                  { color: colors.mountainBlue, fontFamily: typography.bodyFamilySemiBold },
+                ]}
                 testID={`loyalty-activity-points-${event.id}`}
               >
                 {`+${event.points}`}

--- a/src/screens/__tests__/loyaltyScreen.unification.test.tsx
+++ b/src/screens/__tests__/loyaltyScreen.unification.test.tsx
@@ -72,7 +72,10 @@ jest.mock('@/services/crashReporting', () => ({
 }));
 
 jest.mock('@/services/wix/wixClientSingleton', () => ({
-  getWixClientSingleton: jest.fn(() => ({ emitStreakExtended: jest.fn(), emitTierChanged: jest.fn() })),
+  getWixClientSingleton: jest.fn(() => ({
+    emitStreakExtended: jest.fn(),
+    emitTierChanged: jest.fn(),
+  })),
 }));
 
 jest.mock('@/services/crossRigEventBus', () => ({
@@ -209,7 +212,12 @@ describe('Activity section — renders live points history', () => {
   });
 
   it('shows activity loading skeleton while history is loading', () => {
-    mockUsePointsHistory.mockReturnValue({ events: [], loading: true, error: null, refresh: jest.fn() });
+    mockUsePointsHistory.mockReturnValue({
+      events: [],
+      loading: true,
+      error: null,
+      refresh: jest.fn(),
+    });
     const { getByTestId } = render(<LoyaltyScreen />);
     expect(getByTestId('loyalty-activity-loading')).toBeTruthy();
   });
@@ -231,8 +239,20 @@ describe('Activity section — renders live points history', () => {
     mockUsePointsHistory.mockReturnValue({
       events: [
         POINTS_EVENT,
-        { id: 'ev-2', type: 'review' as const, description: 'Reviewed sofa', points: 50, earnedAt: '2026-04-02T10:00:00Z' },
-        { id: 'ev-3', type: 'referral' as const, description: 'Referred a friend', points: 100, earnedAt: '2026-04-03T10:00:00Z' },
+        {
+          id: 'ev-2',
+          type: 'review' as const,
+          description: 'Reviewed sofa',
+          points: 50,
+          earnedAt: '2026-04-02T10:00:00Z',
+        },
+        {
+          id: 'ev-3',
+          type: 'referral' as const,
+          description: 'Referred a friend',
+          points: 100,
+          earnedAt: '2026-04-03T10:00:00Z',
+        },
       ],
       loading: false,
       error: null,
@@ -258,7 +278,13 @@ describe('Your Perks section — tier perk deliveries', () => {
 
   it('renders delivered perk rows when perks are loaded', async () => {
     mockUseTierPerks.mockReturnValue({
-      perks: [{ perkType: 'FREE_WHITE_GLOVE', tier: 'Summit Master', deliveredAt: '2026-04-01T00:00:00Z' }],
+      perks: [
+        {
+          perkType: 'FREE_WHITE_GLOVE',
+          tier: 'Summit Master',
+          deliveredAt: '2026-04-01T00:00:00Z',
+        },
+      ],
       loading: false,
       error: null,
     });
@@ -270,7 +296,14 @@ describe('Your Perks section — tier perk deliveries', () => {
 
   it('renders coupon code when perk has one', async () => {
     mockUseTierPerks.mockReturnValue({
-      perks: [{ perkType: 'ACCESSORY_DISCOUNT', tier: 'Mountain Guide', deliveredAt: '2026-04-01T00:00:00Z', couponCode: 'CF-XYZ9999' }],
+      perks: [
+        {
+          perkType: 'ACCESSORY_DISCOUNT',
+          tier: 'Mountain Guide',
+          deliveredAt: '2026-04-01T00:00:00Z',
+          couponCode: 'CF-XYZ9999',
+        },
+      ],
       loading: false,
       error: null,
     });
@@ -282,7 +315,14 @@ describe('Your Perks section — tier perk deliveries', () => {
 
   it('renders booking link for STYLING_CALL perk', async () => {
     mockUseTierPerks.mockReturnValue({
-      perks: [{ perkType: 'STYLING_CALL', tier: 'Summit Master', deliveredAt: '2026-04-01T00:00:00Z', bookingUrl: 'https://calendly.com/test' }],
+      perks: [
+        {
+          perkType: 'STYLING_CALL',
+          tier: 'Summit Master',
+          deliveredAt: '2026-04-01T00:00:00Z',
+          bookingUrl: 'https://calendly.com/test',
+        },
+      ],
       loading: false,
       error: null,
     });

--- a/src/services/__tests__/gamificationPushHandler.test.ts
+++ b/src/services/__tests__/gamificationPushHandler.test.ts
@@ -262,7 +262,11 @@ describe('malformed payload', () => {
 // ── Full round-trip: all 4 event types ───────────────────────────────────────
 
 describe('all 4 event types — round-trip', () => {
-  const scenarios: Array<{ label: string; payload: GamificationPushPayload; handler: keyof GamificationPushActions }> = [
+  const scenarios: {
+    label: string;
+    payload: GamificationPushPayload;
+    handler: keyof GamificationPushActions;
+  }[] = [
     {
       label: 'badge_earned → showBadgeToast',
       payload: { event: 'badge_earned', badgeName: 'Gold', badgeId: 'b-gold' },

--- a/src/services/wix/wixClient.ts
+++ b/src/services/wix/wixClient.ts
@@ -995,13 +995,13 @@ export class WixClient {
    * via the getTierPerks webMethod (cm-jyl). Member token is required.
    */
   async getTierPerks(memberToken: string): Promise<{
-    perks: Array<{
+    perks: {
       perkType: string;
       tier: string;
       deliveredAt: string;
       couponCode?: string;
       bookingUrl?: string;
-    }>;
+    }[];
   }> {
     const url = `${this.baseUrl}/_functions/getTierPerks`;
     const controller = new AbortController();
@@ -1023,10 +1023,22 @@ export class WixClient {
           '/_functions/getTierPerks',
         );
       }
-      return response.json() as Promise<{ perks: Array<{ perkType: string; tier: string; deliveredAt: string; couponCode?: string; bookingUrl?: string }> }>;
+      return response.json() as Promise<{
+        perks: {
+          perkType: string;
+          tier: string;
+          deliveredAt: string;
+          couponCode?: string;
+          bookingUrl?: string;
+        }[];
+      }>;
     } catch (err) {
       if (err instanceof DOMException && err.name === 'AbortError') {
-        throw new WixApiError(`Request timeout after ${this.timeoutMs}ms`, undefined, '/_functions/getTierPerks');
+        throw new WixApiError(
+          `Request timeout after ${this.timeoutMs}ms`,
+          undefined,
+          '/_functions/getTierPerks',
+        );
       }
       if (err instanceof WixApiError) throw err;
       throw new WixApiError(


### PR DESCRIPTION
## Summary
- Auto-fix prettier formatting errors introduced by cm-jyl (loyalty unification) and cm-6ws (gamification push events) merges
- 8 files, zero logic changes — pure formatting

## Why a separate PR
These errors block PR #510 (cm-1we) CI. Fixing on main first so #510 can rebase clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)