### PR TITLE
feat(cm-skel): loading skeletons for CartScreen + AccountScreen

### DIFF
--- a/src/components/AccountSkeleton.tsx
+++ b/src/components/AccountSkeleton.tsx
@@ -1,0 +1,61 @@
+/**
+ * @module AccountSkeleton
+ *
+ * Loading skeleton for AccountScreen. Shown while auth is restoring the
+ * session so the user does not briefly see the guest sign-in prompt
+ * before the authenticated view appears.
+ */
+
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTheme } from '@/theme';
+import { darkPalette } from '@/theme/tokens';
+import { SkeletonRow, SkeletonCard } from './Skeleton';
+
+export function AccountSkeleton({ testID }: { testID?: string }) {
+  const { spacing } = useTheme();
+
+  return (
+    <View
+      style={[styles.root, { backgroundColor: darkPalette.background }]}
+      testID={testID ?? 'account-skeleton'}
+      accessibilityLabel="Loading account"
+      accessibilityRole="progressbar"
+    >
+      <View
+        style={[styles.profileHeader, { paddingTop: spacing.xl, paddingHorizontal: spacing.lg }]}
+      >
+        <SkeletonRow
+          width={60}
+          height={60}
+          borderRadius={30}
+          testID="account-skeleton-avatar"
+          style={{ marginBottom: 12 }}
+        />
+        <SkeletonRow width={160} height={22} style={{ marginBottom: 8 }} />
+        <SkeletonRow width={220} height={14} style={{ marginBottom: 4 }} />
+        <SkeletonRow width={120} height={14} />
+      </View>
+
+      <View style={[styles.menu, { paddingHorizontal: spacing.lg, gap: spacing.sm }]}>
+        <SkeletonCard lines={1} testID="account-skeleton-menu-0" />
+        <SkeletonCard lines={1} testID="account-skeleton-menu-1" />
+        <SkeletonCard lines={1} testID="account-skeleton-menu-2" />
+        <SkeletonCard lines={1} testID="account-skeleton-menu-3" />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  profileHeader: {
+    alignItems: 'center',
+    paddingBottom: 32,
+  },
+  menu: {
+    marginTop: 8,
+  },
+});

--- a/src/components/CartSkeleton.tsx
+++ b/src/components/CartSkeleton.tsx
@@ -1,0 +1,63 @@
+/**
+ * @module CartSkeleton
+ *
+ * Loading skeleton for CartScreen. Mirrors the rough layout (header row,
+ * 2-3 item cards, summary card, checkout bar) while cart state hydrates
+ * from AsyncStorage to prevent flash-of-empty-content.
+ */
+
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTheme } from '@/theme';
+import { darkPalette } from '@/theme/tokens';
+import { SkeletonRow, SkeletonCard } from './Skeleton';
+
+export function CartSkeleton({ testID }: { testID?: string }) {
+  const { spacing } = useTheme();
+
+  return (
+    <View
+      style={[styles.root, { backgroundColor: darkPalette.background }]}
+      testID={testID ?? 'cart-skeleton'}
+      accessibilityLabel="Loading cart"
+      accessibilityRole="progressbar"
+    >
+      <View style={[styles.header, { paddingHorizontal: spacing.lg }]}>
+        <SkeletonRow width={140} height={28} testID="cart-skeleton-header" />
+        <SkeletonRow width={70} height={16} />
+      </View>
+
+      <View style={[styles.itemList, { paddingHorizontal: spacing.lg, gap: spacing.md }]}>
+        <SkeletonCard header lines={2} testID="cart-skeleton-item-0" />
+        <SkeletonCard header lines={2} testID="cart-skeleton-item-1" />
+        <SkeletonCard header lines={2} testID="cart-skeleton-item-2" />
+      </View>
+
+      <View style={[styles.summary, { paddingHorizontal: spacing.lg, marginTop: spacing.lg }]}>
+        <SkeletonCard header lines={4} testID="cart-skeleton-summary" />
+      </View>
+
+      <View style={[styles.checkout, { paddingHorizontal: spacing.lg, marginTop: spacing.lg }]}>
+        <SkeletonRow height={52} borderRadius={8} testID="cart-skeleton-checkout" />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  root: {
+    flex: 1,
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingTop: 60,
+    paddingBottom: 12,
+  },
+  itemList: {
+    marginTop: 8,
+  },
+  summary: {},
+  checkout: {},
+});

--- a/src/hooks/useCart.tsx
+++ b/src/hooks/useCart.tsx
@@ -139,6 +139,8 @@ interface CartContextValue {
   syncError: string | null;
   /** Clear the current sync error. */
   clearSyncError: () => void;
+  /** True once initial AsyncStorage hydration has completed (with or without data). */
+  hydrated: boolean;
 }
 
 const CartContext = createContext<CartContextValue | null>(null);
@@ -213,6 +215,7 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
   const [state, dispatch] = useReducer(cartReducer, { items: [] });
   const [syncing, setSyncing] = useState(false);
   const [syncError, setSyncError] = useState<string | null>(null);
+  const [hydrated, setHydrated] = useState(false);
   const authCtx = useContext(AuthContext);
   const user = authCtx?.user ?? null;
   const prevUserRef = useRef<typeof user>(null);
@@ -291,6 +294,8 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
         }
       } catch {
         // AsyncStorage not available — operate in-memory
+      } finally {
+        setHydrated(true);
       }
     })();
   }, []);
@@ -458,6 +463,7 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
       loadItems,
       syncError,
       clearSyncError,
+      hydrated,
     }),
     [
       state.items,
@@ -473,6 +479,7 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
       loadItems,
       syncError,
       clearSyncError,
+      hydrated,
     ],
   );
 

--- a/src/screens/AccountScreen.tsx
+++ b/src/screens/AccountScreen.tsx
@@ -42,6 +42,7 @@ import { PremiumBadge } from '@/components/PremiumBadge';
 import { AccountGamificationHeader } from '@/components/AccountGamificationHeader';
 import { ShareSheet } from '@/components/ShareSheet';
 import { useGamificationEvents } from '@/hooks/useGamificationEvents';
+import { AccountSkeleton } from '@/components/AccountSkeleton';
 
 /** Props for the AccountScreen component. */
 interface Props {
@@ -242,6 +243,10 @@ export function AccountScreen({
         : 'We could not find any previous purchases for this account.',
     );
   };
+
+  if (loading && !isAuthenticated && !user) {
+    return <AccountSkeleton testID="account-skeleton" />;
+  }
 
   if (!isAuthenticated || !user) {
     return (

--- a/src/screens/CartScreen.tsx
+++ b/src/screens/CartScreen.tsx
@@ -54,6 +54,7 @@ import { modelIdToProductId } from '@/utils';
 import { useProductRecommendations } from '@/hooks/useProductRecommendations';
 import { RecommendationCarousel } from '@/components/RecommendationCarousel';
 import { SkeletonCarouselRow } from '@/components/SkeletonCarouselItem';
+import { CartSkeleton } from '@/components/CartSkeleton';
 
 /** Subtotal (in dollars) above which shipping becomes free. */
 const SHIPPING_THRESHOLD = 499;
@@ -90,6 +91,7 @@ export function CartScreen({ onCheckout, onContinueShopping, testID }: Props) {
     clearCart,
     syncError,
     clearSyncError,
+    hydrated,
   } = useCart();
   const { isAuthenticated } = useAuth();
   const promo = usePromoCode();
@@ -149,6 +151,10 @@ export function CartScreen({ onCheckout, onContinueShopping, testID }: Props) {
     },
     [updateQuantity, handleRemove],
   );
+
+  if (!hydrated && items.length === 0) {
+    return <CartSkeleton testID="cart-skeleton" />;
+  }
 
   if (items.length === 0) {
     return (

--- a/src/screens/__tests__/accountScreen.skeleton.test.tsx
+++ b/src/screens/__tests__/accountScreen.skeleton.test.tsx
@@ -1,0 +1,237 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import { AccountScreen } from '../AccountScreen';
+import { ThemeProvider } from '@/theme/ThemeProvider';
+
+jest.mock('expo-application', () => ({
+  nativeApplicationVersion: '1.2.3',
+  nativeBuildVersion: '42',
+  applicationId: 'com.carolinafutons.app',
+}));
+
+jest.mock('expo-haptics', () => ({
+  impactAsync: jest.fn(),
+  selectionAsync: jest.fn(),
+  notificationAsync: jest.fn(),
+  ImpactFeedbackStyle: { Light: 'Light', Medium: 'Medium', Heavy: 'Heavy' },
+  NotificationFeedbackType: { Success: 'Success', Warning: 'Warning', Error: 'Error' },
+}));
+
+const mockAuthState: {
+  user: null | { id: string; email: string; displayName: string; phone?: string };
+  loading: boolean;
+  isAuthenticated: boolean;
+  error: string | null;
+} = {
+  user: null,
+  loading: true,
+  isAuthenticated: false,
+  error: null,
+};
+
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({
+    ...mockAuthState,
+    signOut: jest.fn(),
+    updateProfile: jest.fn(),
+    clearError: jest.fn(),
+  }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+  AuthContext: { _currentValue: null },
+}));
+
+jest.mock('@/hooks/useBiometricAuth', () => ({
+  useBiometricAuth: () => ({
+    status: { isAvailable: false, isEnrolled: false, biometricType: 'none' },
+    isEnabled: false,
+    loading: false,
+    authenticating: false,
+    enableBiometric: jest.fn(),
+    disableBiometric: jest.fn(),
+    promptBiometric: jest.fn(),
+  }),
+}));
+
+jest.mock('@/hooks/usePremium', () => ({
+  PremiumProvider: ({ children }: any) => children,
+  usePremium: () => ({
+    isPremium: false,
+    isLoading: false,
+    offerings: [],
+    error: null,
+    purchase: jest.fn(),
+    restore: jest.fn(),
+    refreshStatus: jest.fn(),
+  }),
+}));
+
+jest.mock('@/hooks/useAccountDeletion', () => ({
+  useAccountDeletion: () => ({
+    status: 'idle',
+    error: null,
+    requestDeletion: jest.fn(),
+    confirmDeletion: jest.fn(),
+    cancel: jest.fn(),
+  }),
+}));
+
+jest.mock('@/hooks/useDataExport', () => ({
+  useDataExport: () => ({
+    status: 'idle',
+    error: null,
+    exportData: jest.fn(),
+  }),
+}));
+
+jest.mock('@/hooks/useSavedAddresses', () => ({
+  useSavedAddresses: () => ({
+    addresses: [],
+    defaultAddress: null,
+    loading: false,
+    addAddress: jest.fn(),
+    updateAddress: jest.fn(),
+    deleteAddress: jest.fn(),
+    setDefault: jest.fn(),
+    saveFromCheckout: jest.fn(),
+  }),
+}));
+
+jest.mock('@/hooks/useReferral', () => ({
+  useReferral: () => ({
+    code: null,
+    creditsEarned: 0,
+    referralCount: 0,
+    shareUrl: null,
+    loading: false,
+    error: null,
+    referredByCode: null,
+    referrals: [],
+    storeReferredByCode: jest.fn(),
+    submitReferral: jest.fn(),
+  }),
+}));
+
+jest.mock('@/hooks/useGamificationEvents', () => ({
+  useGamificationEvents: () => ({
+    referralShared: jest.fn(),
+    badgeEarned: jest.fn(),
+    tierChanged: jest.fn(),
+    streakExtended: jest.fn(),
+  }),
+}));
+
+jest.mock('@/services/wix/wixProvider', () => ({
+  useWixClient: () => ({ callFunction: jest.fn().mockResolvedValue(null) }),
+  useOptionalWixClient: () => null,
+}));
+
+jest.mock('@/components/ShareSheet', () => ({
+  ShareSheet: () => null,
+}));
+
+jest.mock('@/components/AccountGamificationHeader', () => ({
+  AccountGamificationHeader: () => null,
+}));
+
+jest.mock('@/hooks/useLoyalty', () => ({
+  useLoyalty: () => ({
+    points: 0,
+    tier: 'bronze',
+    totalEarned: 0,
+    transactions: [],
+    loading: false,
+    error: null,
+    refreshPoints: jest.fn(),
+  }),
+}));
+
+function renderAccount(props: Partial<React.ComponentProps<typeof AccountScreen>> = {}) {
+  return render(
+    <ThemeProvider>
+      <AccountScreen {...props} />
+    </ThemeProvider>,
+  );
+}
+
+describe('AccountScreen loading skeleton', () => {
+  beforeEach(() => {
+    mockAuthState.user = null;
+    mockAuthState.loading = true;
+    mockAuthState.isAuthenticated = false;
+    mockAuthState.error = null;
+  });
+
+  it('renders account skeleton while auth is loading and user is not yet known', () => {
+    mockAuthState.loading = true;
+    mockAuthState.isAuthenticated = false;
+    mockAuthState.user = null;
+    const { getByTestId } = renderAccount();
+    expect(getByTestId('account-skeleton')).toBeTruthy();
+  });
+
+  it('skeleton has accessibility label for screen readers', () => {
+    mockAuthState.loading = true;
+    const { getByTestId } = renderAccount();
+    expect(getByTestId('account-skeleton').props.accessibilityLabel).toBe('Loading account');
+  });
+
+  it('skeleton contains SkeletonRow/SkeletonCard primitives', () => {
+    mockAuthState.loading = true;
+    const { getAllByLabelText } = renderAccount();
+    const loadingElements = getAllByLabelText('Loading');
+    expect(loadingElements.length).toBeGreaterThan(0);
+  });
+
+  it('does not render skeleton when auth has resolved as guest', () => {
+    mockAuthState.loading = false;
+    mockAuthState.isAuthenticated = false;
+    mockAuthState.user = null;
+    const { queryByTestId, getByTestId } = renderAccount();
+    expect(queryByTestId('account-skeleton')).toBeNull();
+    expect(getByTestId('guest-title')).toBeTruthy();
+  });
+
+  it('does not render skeleton when auth has resolved as authenticated user', () => {
+    mockAuthState.loading = false;
+    mockAuthState.isAuthenticated = true;
+    mockAuthState.user = {
+      id: 'u1',
+      email: 'a@b.com',
+      displayName: 'Test User',
+    };
+    const { queryByTestId, getByTestId } = renderAccount();
+    expect(queryByTestId('account-skeleton')).toBeNull();
+    expect(getByTestId('user-display-name')).toBeTruthy();
+  });
+
+  it('renders guest view after loading flips to false', async () => {
+    mockAuthState.loading = true;
+    const { queryByTestId, rerender } = renderAccount();
+    expect(queryByTestId('account-skeleton')).toBeTruthy();
+
+    mockAuthState.loading = false;
+    rerender(
+      <ThemeProvider>
+        <AccountScreen />
+      </ThemeProvider>,
+    );
+    await waitFor(() => {
+      expect(queryByTestId('account-skeleton')).toBeNull();
+    });
+  });
+
+  it('does not render skeleton when already authenticated even if loading flickers true', () => {
+    // Edge case: auth can re-enter loading for token refresh on an authed user.
+    // In that case we should NOT blank the screen with a skeleton.
+    mockAuthState.loading = true;
+    mockAuthState.isAuthenticated = true;
+    mockAuthState.user = {
+      id: 'u1',
+      email: 'a@b.com',
+      displayName: 'Existing User',
+    };
+    const { queryByTestId, getByTestId } = renderAccount();
+    expect(queryByTestId('account-skeleton')).toBeNull();
+    expect(getByTestId('user-display-name')).toBeTruthy();
+  });
+});

--- a/src/screens/__tests__/cartScreen.deeper.test.tsx
+++ b/src/screens/__tests__/cartScreen.deeper.test.tsx
@@ -129,9 +129,10 @@ beforeEach(() => {
 // ── Empty cart CTA accessibility ──────────────────────────────────────────────
 
 describe('empty cart CTA accessibility', () => {
-  it('empty state CTA has accessibilityRole button', () => {
+  it('empty state CTA has accessibilityRole button', async () => {
     const onContinueShopping = jest.fn();
-    const { getByTestId } = renderCartScreen({ onContinueShopping });
+    const { getByTestId, findByTestId } = renderCartScreen({ onContinueShopping });
+    await findByTestId('cart-empty-state-action');
     expect(getByTestId('cart-empty-state-action').props.accessibilityRole).toBe('button');
   });
 

--- a/src/screens/__tests__/cartScreen.skeleton.test.tsx
+++ b/src/screens/__tests__/cartScreen.skeleton.test.tsx
@@ -1,0 +1,126 @@
+import React from 'react';
+import { render, waitFor } from '@testing-library/react-native';
+import { CartScreen } from '../CartScreen';
+import { CartProvider, useCart } from '@/hooks/useCart';
+import { ConnectivityProvider } from '@/hooks/useConnectivity';
+import { ThemeProvider } from '@/theme/ThemeProvider';
+import { FUTON_MODELS, FABRICS } from '@/data/futons';
+
+jest.mock('react-native-gesture-handler/ReanimatedSwipeable', () => {
+  const React = require('react');
+  const { View } = require('react-native');
+  const MockSwipeable = React.forwardRef(({ children, testID }: any) => (
+    <View testID={testID}>{children}</View>
+  ));
+  MockSwipeable.displayName = 'MockSwipeable';
+  return { __esModule: true, default: MockSwipeable };
+});
+
+jest.mock('@/hooks/useAuth', () => ({
+  useAuth: () => ({ isAuthenticated: false }),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => children,
+  AuthContext: { _currentValue: null },
+}));
+
+jest.mock('@/hooks/useLoyalty', () => ({
+  useLoyalty: () => ({
+    points: 0,
+    tier: 'bronze',
+    nextTier: 'silver',
+    pointsToNext: 500,
+    progress: 0,
+    loading: false,
+    error: null,
+    refreshPoints: jest.fn(),
+  }),
+}));
+
+jest.mock('@/services/wix/wixProvider', () => ({
+  useOptionalWixClient: () => null,
+}));
+
+const asheville = FUTON_MODELS[0];
+const naturalLinen = FABRICS[0];
+
+function renderCart(
+  props: Partial<React.ComponentProps<typeof CartScreen>> = {},
+  seedItems?: { model: typeof asheville; fabric: typeof naturalLinen; qty: number }[],
+) {
+  function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <ConnectivityProvider initialOnline={true} skipNetInfo={true}>
+        <ThemeProvider>
+          <CartProvider>
+            {seedItems && <CartSeeder items={seedItems} />}
+            {children}
+          </CartProvider>
+        </ThemeProvider>
+      </ConnectivityProvider>
+    );
+  }
+  return render(<CartScreen {...props} />, { wrapper: Wrapper });
+}
+
+function CartSeeder({
+  items,
+}: {
+  items: { model: typeof asheville; fabric: typeof naturalLinen; qty: number }[];
+}) {
+  const { addItem } = useCart();
+  React.useEffect(() => {
+    items.forEach(({ model, fabric, qty }) => addItem(model, fabric, qty));
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+  return null;
+}
+
+describe('CartScreen loading skeleton', () => {
+  it('renders cart skeleton on initial mount before hydration completes', () => {
+    const { getByTestId } = renderCart();
+    expect(getByTestId('cart-skeleton')).toBeTruthy();
+  });
+
+  it('skeleton has accessibility label for screen readers', () => {
+    const { getByTestId } = renderCart();
+    const skeleton = getByTestId('cart-skeleton');
+    expect(skeleton.props.accessibilityLabel).toBe('Loading cart');
+  });
+
+  it('skeleton contains SkeletonRow/SkeletonCard primitives', () => {
+    const { getAllByLabelText } = renderCart();
+    // SkeletonRow and SkeletonCard use accessibilityLabel="Loading"
+    const loadingElements = getAllByLabelText('Loading');
+    expect(loadingElements.length).toBeGreaterThan(0);
+  });
+
+  it('does not render empty-state when skeleton is showing', () => {
+    const { queryByTestId } = renderCart();
+    expect(queryByTestId('cart-skeleton')).toBeTruthy();
+    expect(queryByTestId('cart-empty-state')).toBeNull();
+  });
+
+  it('replaces skeleton with empty state after hydration resolves with no items', async () => {
+    const { getByTestId, queryByTestId } = renderCart();
+    await waitFor(() => {
+      expect(queryByTestId('cart-skeleton')).toBeNull();
+    });
+    expect(getByTestId('cart-empty-state')).toBeTruthy();
+  });
+
+  it('replaces skeleton with cart contents once items arrive', async () => {
+    const { getByTestId, queryByTestId } = renderCart({}, [
+      { model: asheville, fabric: naturalLinen, qty: 1 },
+    ]);
+    await waitFor(() => {
+      expect(queryByTestId('cart-skeleton')).toBeNull();
+    });
+    expect(getByTestId('cart-item-asheville-full:natural-linen')).toBeTruthy();
+  });
+
+  it('does not show skeleton when cart already has items (seeded post-hydration)', async () => {
+    const { queryByTestId } = renderCart({}, [{ model: asheville, fabric: naturalLinen, qty: 1 }]);
+    await waitFor(() => {
+      expect(queryByTestId('cart-item-asheville-full:natural-linen')).toBeTruthy();
+    });
+    expect(queryByTestId('cart-skeleton')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes flash-of-empty-content on CartScreen (during AsyncStorage hydration) and AccountScreen (during auth session restore) by rendering Skeleton.Row/Skeleton.Card placeholders instead
- `useCart` now exposes a `hydrated` flag; CartScreen uses `CartSkeleton` until hydration completes
- AccountScreen uses `AccountSkeleton` when `loading && !isAuthenticated && !user` (suppressed if already authenticated, e.g. token refresh)
- TDD: 14 new tests (7 cart, 7 account) including accessibility labels, empty→guest transition, and authenticated-loading edge case

## Test plan
- [x] `cartScreen.skeleton.test.tsx` — 7 passing (skeleton on mount, a11y, transitions to empty/items)
- [x] `accountScreen.skeleton.test.tsx` — 7 passing (skeleton on loading, a11y, resolves to guest/authed, edge case for token refresh)
- [x] Full suite: 10,468 passing / 31 skipped (no regressions; one existing test in `cartScreen.deeper` updated to `await findByTestId`)
- [x] Prettier + ESLint clean on changed files
- [x] TSC clean on changed files (pre-existing errors in other crew dirs are unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)