### PR TITLE
feat(hq-8k690): cart abandonment recovery push notification

### DIFF
--- a/src/components/CartAbandonmentBridge.tsx
+++ b/src/components/CartAbandonmentBridge.tsx
@@ -5,6 +5,11 @@
  * contexts. Wires:
  *  - 24hr reminder (useCartAbandonmentReminder)
  *  - 1hr recovery push with web email dedup (useCartAbandonmentRecovery, hq-8k690)
+ *
+ * When itemCount transitions to 0 from non-zero (checkout completed), both
+ * hooks' onOrderPlaced() are called to cancel scheduled pushes and clear
+ * dedup state. On any other itemCount change, normal cart activity callbacks
+ * fire.
  */
 import { useContext, useEffect, useMemo, useRef } from 'react';
 import { useCart } from '@/hooks/useCart';
@@ -33,14 +38,14 @@ export function CartAbandonmentBridge() {
   );
 
   // 24hr reminder
-  const { onCartChanged } = useCartAbandonmentReminder({
+  const { onCartChanged, onOrderPlaced: onReminderOrderPlaced } = useCartAbandonmentReminder({
     itemCount,
     cartRemindersEnabled: preferences.cartReminders,
     permissionGranted: pushPermitted,
   });
 
   // 1hr recovery push (hq-8k690)
-  const { onCartActivity } = useCartAbandonmentRecovery({
+  const { onCartActivity, onOrderPlaced: onRecoveryOrderPlaced } = useCartAbandonmentRecovery({
     items,
     subtotal,
     cartId,
@@ -49,16 +54,30 @@ export function CartAbandonmentBridge() {
   });
 
   const isFirstRender = useRef(true);
+  const prevItemCount = useRef(itemCount);
 
   useEffect(() => {
     // Skip initial mount to avoid scheduling on app launch
     if (isFirstRender.current) {
       isFirstRender.current = false;
+      prevItemCount.current = itemCount;
       return;
     }
+
+    const prev = prevItemCount.current;
+    prevItemCount.current = itemCount;
+
+    // Cart emptied after having items — checkout completed or all items removed.
+    // Cancel any scheduled push and clear dedup state on both hooks.
+    if (itemCount === 0 && prev > 0) {
+      void onReminderOrderPlaced();
+      void onRecoveryOrderPlaced();
+      return;
+    }
+
     onCartChanged();
     onCartActivity();
-  }, [itemCount, onCartChanged, onCartActivity]);
+  }, [itemCount, onCartChanged, onCartActivity, onReminderOrderPlaced, onRecoveryOrderPlaced]);
 
   return null;
 }

--- a/src/components/CartAbandonmentBridge.tsx
+++ b/src/components/CartAbandonmentBridge.tsx
@@ -23,7 +23,7 @@ export function CartAbandonmentBridge() {
   const { preferences, permissionStatus } = useNotifications();
   const authCtx = useContext(AuthContext);
   const userId = authCtx?.user?.id ?? null;
-  const pushPermitted = permissionStatus === 'granted';
+  const pushPermitted = permissionStatus === 'granted' && preferences.cartRecovery;
 
   // Stable cart ID derived from sorted item IDs — changes when cart composition changes.
   const cartId = useMemo(
@@ -77,7 +77,7 @@ export function CartAbandonmentBridge() {
 
     onCartChanged();
     onCartActivity();
-  }, [itemCount, onCartChanged, onCartActivity, onReminderOrderPlaced, onRecoveryOrderPlaced]);
+  }, [itemCount, cartId, onCartChanged, onCartActivity, onReminderOrderPlaced, onRecoveryOrderPlaced]);
 
   return null;
 }

--- a/src/components/__tests__/cartAbandonmentBridge.test.tsx
+++ b/src/components/__tests__/cartAbandonmentBridge.test.tsx
@@ -4,14 +4,10 @@
  * Covers: 24hr reminder hook wiring + 1hr recovery hook wiring (hq-8k690).
  */
 import React from 'react';
-import { render } from '@testing-library/react-native';
+import { render, act } from '@testing-library/react-native';
 import { CartAbandonmentBridge } from '../CartAbandonmentBridge';
 
-// Mock all dependencies
-const mockOnCartChanged = jest.fn();
-const mockOnOrderPlaced = jest.fn();
-const mockOnCartActivity = jest.fn();
-const mockOnRecoveryOrderPlaced = jest.fn();
+// ── mutable mock state (prefixed 'mock' so Jest hoisting allows factory access) ──
 
 const mockCartItems = [
   {
@@ -24,19 +20,32 @@ const mockCartItems = [
   },
 ];
 
+const mockCartState = {
+  items: mockCartItems as typeof mockCartItems | [],
+  itemCount: 2,
+  subtotal: 899,
+};
+
+const mockNotifState = {
+  preferences: { cartReminders: true, cartRecovery: true },
+  permissionStatus: 'granted',
+};
+
+// ── hook stubs ────────────────────────────────────────────────────────────────
+
+const mockOnCartChanged = jest.fn();
+const mockOnOrderPlaced = jest.fn();
+const mockOnCartActivity = jest.fn();
+const mockOnRecoveryOrderPlaced = jest.fn();
+
+// ── module mocks ──────────────────────────────────────────────────────────────
+
 jest.mock('@/hooks/useCart', () => ({
-  useCart: () => ({
-    items: mockCartItems,
-    itemCount: 2,
-    subtotal: 899,
-  }),
+  useCart: () => mockCartState,
 }));
 
 jest.mock('@/hooks/useNotifications', () => ({
-  useNotifications: () => ({
-    preferences: { cartReminders: true, cartRecovery: true },
-    permissionStatus: 'granted',
-  }),
+  useNotifications: () => mockNotifState,
 }));
 
 jest.mock('@/hooks/useAuth', () => {
@@ -46,9 +55,7 @@ jest.mock('@/hooks/useAuth', () => {
   });
   return {
     AuthContext,
-    useAuth: () => ({
-      user: { id: 'member-1', email: 'test@example.com' },
-    }),
+    useAuth: () => ({ user: { id: 'member-1', email: 'test@example.com' } }),
   };
 });
 
@@ -69,9 +76,21 @@ jest.mock('@/hooks/useCartAbandonmentRecovery', () => ({
     mockUseCartAbandonmentRecovery(opts),
 }));
 
+// ── test helpers ──────────────────────────────────────────────────────────────
+
+function resetCart() {
+  mockCartState.items = mockCartItems;
+  mockCartState.itemCount = 2;
+  mockCartState.subtotal = 899;
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
 describe('CartAbandonmentBridge', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    resetCart();
+    mockNotifState.permissionStatus = 'granted';
   });
 
   it('renders nothing (returns null)', () => {
@@ -82,6 +101,11 @@ describe('CartAbandonmentBridge', () => {
   it('does not call onCartChanged on initial mount', () => {
     render(<CartAbandonmentBridge />);
     expect(mockOnCartChanged).not.toHaveBeenCalled();
+  });
+
+  it('does not call onCartActivity on initial mount', () => {
+    render(<CartAbandonmentBridge />);
+    expect(mockOnCartActivity).not.toHaveBeenCalled();
   });
 
   it('passes cart items, subtotal, userId, and pushPermitted to recovery hook', () => {
@@ -97,11 +121,89 @@ describe('CartAbandonmentBridge', () => {
     );
   });
 
-  it('sets pushPermitted=false when permission is not granted', () => {
-    // Already tested via the mock — the bridge logic derives this from permissionStatus
-    // This test verifies the bridge correctly computes pushPermitted
-    render(<CartAbandonmentBridge />);
-    const callArgs = mockUseCartAbandonmentRecovery.mock.calls[0]?.[0];
-    expect(callArgs).toHaveProperty('pushPermitted');
+  describe('pushPermitted derivation', () => {
+    it('is true when permissionStatus is granted', () => {
+      mockNotifState.permissionStatus = 'granted';
+      render(<CartAbandonmentBridge />);
+      const callArgs = mockUseCartAbandonmentRecovery.mock.calls[0]?.[0];
+      expect(callArgs?.pushPermitted).toBe(true);
+    });
+
+    it('is false when permissionStatus is denied', () => {
+      mockNotifState.permissionStatus = 'denied';
+      render(<CartAbandonmentBridge />);
+      const callArgs = mockUseCartAbandonmentRecovery.mock.calls[0]?.[0];
+      expect(callArgs?.pushPermitted).toBe(false);
+    });
+
+    it('is false when permissionStatus is undetermined', () => {
+      mockNotifState.permissionStatus = 'undetermined';
+      render(<CartAbandonmentBridge />);
+      const callArgs = mockUseCartAbandonmentRecovery.mock.calls[0]?.[0];
+      expect(callArgs?.pushPermitted).toBe(false);
+    });
+  });
+
+  describe('onOrderPlaced integration — cart empties to 0 (checkout)', () => {
+    it('calls onOrderPlaced on both hooks when cart transitions to 0', async () => {
+      const { rerender } = render(<CartAbandonmentBridge />);
+      jest.clearAllMocks();
+
+      await act(async () => {
+        mockCartState.items = [];
+        mockCartState.itemCount = 0;
+        mockCartState.subtotal = 0;
+        rerender(<CartAbandonmentBridge />);
+      });
+
+      expect(mockOnRecoveryOrderPlaced).toHaveBeenCalledTimes(1);
+      expect(mockOnOrderPlaced).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT call onCartActivity when cart empties to 0', async () => {
+      const { rerender } = render(<CartAbandonmentBridge />);
+      jest.clearAllMocks();
+
+      await act(async () => {
+        mockCartState.items = [];
+        mockCartState.itemCount = 0;
+        mockCartState.subtotal = 0;
+        rerender(<CartAbandonmentBridge />);
+      });
+
+      expect(mockOnCartActivity).not.toHaveBeenCalled();
+    });
+
+    it('does NOT call onOrderPlaced when cart goes from 0 to non-zero', async () => {
+      mockCartState.items = [];
+      mockCartState.itemCount = 0;
+      mockCartState.subtotal = 0;
+      const { rerender } = render(<CartAbandonmentBridge />);
+      jest.clearAllMocks();
+
+      await act(async () => {
+        mockCartState.items = mockCartItems;
+        mockCartState.itemCount = 2;
+        mockCartState.subtotal = 899;
+        rerender(<CartAbandonmentBridge />);
+      });
+
+      expect(mockOnRecoveryOrderPlaced).not.toHaveBeenCalled();
+      expect(mockOnOrderPlaced).not.toHaveBeenCalled();
+    });
+
+    it('calls onCartActivity (not onOrderPlaced) for non-zero to non-zero item changes', async () => {
+      const { rerender } = render(<CartAbandonmentBridge />);
+      jest.clearAllMocks();
+
+      await act(async () => {
+        mockCartState.itemCount = 3;
+        rerender(<CartAbandonmentBridge />);
+      });
+
+      expect(mockOnCartActivity).toHaveBeenCalledTimes(1);
+      expect(mockOnRecoveryOrderPlaced).not.toHaveBeenCalled();
+      expect(mockOnOrderPlaced).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/__tests__/cartAbandonmentBridge.test.tsx
+++ b/src/components/__tests__/cartAbandonmentBridge.test.tsx
@@ -91,6 +91,7 @@ describe('CartAbandonmentBridge', () => {
     jest.clearAllMocks();
     resetCart();
     mockNotifState.permissionStatus = 'granted';
+    mockNotifState.preferences.cartRecovery = true;
   });
 
   it('renders nothing (returns null)', () => {
@@ -138,6 +139,14 @@ describe('CartAbandonmentBridge', () => {
 
     it('is false when permissionStatus is undetermined', () => {
       mockNotifState.permissionStatus = 'undetermined';
+      render(<CartAbandonmentBridge />);
+      const callArgs = mockUseCartAbandonmentRecovery.mock.calls[0]?.[0];
+      expect(callArgs?.pushPermitted).toBe(false);
+    });
+
+    it('is false when cartRecovery preference is disabled (even if OS permission granted)', () => {
+      mockNotifState.permissionStatus = 'granted';
+      mockNotifState.preferences.cartRecovery = false;
       render(<CartAbandonmentBridge />);
       const callArgs = mockUseCartAbandonmentRecovery.mock.calls[0]?.[0];
       expect(callArgs?.pushPermitted).toBe(false);

--- a/src/components/__tests__/cartAbandonmentBridge.test.tsx
+++ b/src/components/__tests__/cartAbandonmentBridge.test.tsx
@@ -215,4 +215,38 @@ describe('CartAbandonmentBridge', () => {
       expect(mockOnOrderPlaced).not.toHaveBeenCalled();
     });
   });
+
+  describe('cartId dep array — variant swap resets 1hr timer', () => {
+    it('calls onCartActivity when cartId changes but itemCount stays the same', async () => {
+      // Start with asheville:linen in cart
+      mockCartState.items = [{ ...mockCartItems[0], id: 'asheville:linen' }];
+      mockCartState.itemCount = 1;
+      const { rerender } = render(<CartAbandonmentBridge />);
+      jest.clearAllMocks();
+
+      await act(async () => {
+        // User swaps to a different fabric — same quantity, different item id
+        mockCartState.items = [{ ...mockCartItems[0], id: 'asheville:charcoal' }];
+        // itemCount stays 1
+        rerender(<CartAbandonmentBridge />);
+      });
+
+      expect(mockOnCartActivity).toHaveBeenCalledTimes(1);
+    });
+
+    it('does NOT call onOrderPlaced when only cartId changes (not going to 0)', async () => {
+      mockCartState.items = [{ ...mockCartItems[0], id: 'asheville:linen' }];
+      mockCartState.itemCount = 1;
+      const { rerender } = render(<CartAbandonmentBridge />);
+      jest.clearAllMocks();
+
+      await act(async () => {
+        mockCartState.items = [{ ...mockCartItems[0], id: 'asheville:charcoal' }];
+        rerender(<CartAbandonmentBridge />);
+      });
+
+      expect(mockOnRecoveryOrderPlaced).not.toHaveBeenCalled();
+      expect(mockOnOrderPlaced).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Register `cart_recovery` as a `NotificationType` with preferences, channel config, and deep link routing
- Wire `useCartAbandonmentRecovery` into `CartAbandonmentBridge` with items/subtotal/userId/pushPermitted
- Add `cart_recovery` case to `NotificationRouter` (tap → Cart tab)
- Add `cart_recovery` toggle to `NotificationPreferencesScreen`

## Test plan

- [x] `CartAbandonmentBridge` — tests for recovery hook wiring, auth context, push permission gating
- [x] `NotificationRouter` — test for `cart_recovery` tap → Cart navigation
- [x] `NotificationPreferencesScreen` — `cartRecovery` included in all preference mocks
- [x] `notifications.ts` — `cart_recovery` registered in type/channel/deeplink tables
- [x] 105 tests pass across all affected suites

Generated with Claude Code