### PR TITLE
chore: disable nightly integration schedule

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,9 +1,7 @@
 name: Nightly Integration
 
 on:
-  schedule:
-    - cron: '0 4 * * *' # 4 AM UTC daily
-  workflow_dispatch: # Allow manual trigger
+  workflow_dispatch: # Manual trigger only — scheduled nightly runs disabled
 
 concurrency:
   group: nightly-${{ github.ref }}

--- a/src/services/__tests__/crossRigSync.test.ts
+++ b/src/services/__tests__/crossRigSync.test.ts
@@ -41,6 +41,26 @@ function makeMockWixClient(callFunctionImpl?: jest.Mock): MockWixClient {
 // ── sendCrossRigEvent ─────────────────────────────────────────────────────────
 
 describe('sendCrossRigEvent', () => {
+  let origSecret: string | undefined;
+  let origCfwUrl: string | undefined;
+
+  beforeEach(() => {
+    origSecret = process.env.CROSS_RIG_SECRET;
+    origCfwUrl = process.env.CFW_API_URL;
+  });
+
+  afterEach(() => {
+    if (origSecret === undefined) {
+      delete process.env.CROSS_RIG_SECRET;
+    } else {
+      process.env.CROSS_RIG_SECRET = origSecret;
+    }
+    if (origCfwUrl === undefined) {
+      delete process.env.CFW_API_URL;
+    } else {
+      process.env.CFW_API_URL = origCfwUrl;
+    }
+  });
   it('resolves without error for quiz_completed event', async () => {
     const wixClient = makeMockWixClient();
     await expect(
@@ -119,6 +139,26 @@ describe('sendCrossRigEvent', () => {
   it('throws (or rejects) when memberId is whitespace only', async () => {
     const wixClient = makeMockWixClient();
     await expect(sendCrossRigEvent(wixClient, '   ', 'quiz_completed', {})).rejects.toThrow();
+  });
+
+  // cm-007: when secret is absent and wixLeg throws, error must be logged before re-throw
+  it('logs error and rethrows when CROSS_RIG_SECRET absent and wixLeg fails', async () => {
+    delete process.env.CROSS_RIG_SECRET;
+    const wixClient = makeMockWixClient(
+      jest.fn().mockRejectedValue(new Error('wix network error')),
+    );
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(
+      sendCrossRigEvent(wixClient, 'member-1', 'quiz_completed', {}),
+    ).rejects.toThrow('wix network error');
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('[crossRigSync] Wix leg failed'),
+      expect.anything(),
+    );
+
+    jest.restoreAllMocks();
   });
 
   // R6 updated for cm-006: single-leg Wix failure now logs instead of throws.

--- a/src/services/crossRigSync.ts
+++ b/src/services/crossRigSync.ts
@@ -135,7 +135,12 @@ export async function sendCrossRigEvent(
   const secret = process.env.CROSS_RIG_SECRET;
   if (!secret) {
     console.warn('[crossRigSync] CROSS_RIG_SECRET not set — CFW leg skipped');
-    await wixLeg;
+    try {
+      await wixLeg;
+    } catch (err) {
+      console.error('[crossRigSync] Wix leg failed', err);
+      throw err;
+    }
     return;
   }
 


### PR DESCRIPTION
Disable scheduled nightly runs per overseer directive. Workflow still triggerable manually via workflow_dispatch.