### PR TITLE
fix(cm-b5f): CartScreen test isolation — mock useBundleSuggestion + implement sync error rollback

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -24,8 +24,6 @@ module.exports = {
   collectCoverageFrom: ['src/**/*.{ts,tsx}', '!src/**/*.d.ts', '!src/**/__tests__/**'],
   testMatch: ['**/__tests__/**/*.test.{ts,tsx}'],
   // TDD tests for unimplemented features — skip until modules exist
-  // CartScreen*: skipped in CI — OOM SIGTERM after BundleSuggestion wired in (cm-bun/deacon-y8lf)
-  //   CartScreen tests run fine locally; tracked in cm-b5f
   testPathIgnorePatterns: [
     '/node_modules/',
     '<rootDir>/crew/',
@@ -33,9 +31,6 @@ module.exports = {
     'storeCard\\.test\\.tsx',
     'storeLocatorScreen\\.test\\.tsx',
     'useStoreLocator\\.test\\.tsx',
-    'cartScreen\\.test\\.tsx',
-    'cartScreen\\.sync-error\\.test\\.tsx',
-    'CartScreenRecommendations\\.test\\.tsx',
   ],
   // Prevent zombie worker processes from accumulating memory after test runs.
   forceExit: true,

--- a/src/hooks/useCart.tsx
+++ b/src/hooks/useCart.tsx
@@ -377,8 +377,10 @@ export function CartProvider({ children }: { children: React.ReactNode }) {
       if (isOnlineRef.current) {
         const client = wixClientRef.current;
         if (client) {
+          const itemId = `${model.id}:${fabric.id}`;
           client.addToCart(model.id, quantity, fabric.id).catch(() => {
-            // Fire-and-forget: local cart is source of truth
+            dispatch({ type: 'REMOVE_ITEM', itemId });
+            setSyncError('Unable to sync cart — please try again');
           });
         }
       } else {

--- a/src/screens/__tests__/CartScreenRecommendations.test.tsx
+++ b/src/screens/__tests__/CartScreenRecommendations.test.tsx
@@ -72,6 +72,20 @@ jest.mock('@/services/wix/wixProvider', () => ({
   }),
 }));
 
+// Mock useBundleSuggestion to prevent async Wix fetches accumulating across tests (cm-b5f).
+jest.mock('@/hooks/useBundleSuggestion', () => ({
+  useBundleSuggestion: () => ({
+    bundle: null,
+    bundleProducts: [],
+    pricing: null,
+    isLoading: false,
+    error: null,
+    addBundleToCart: jest.fn(),
+    isAddingToCart: false,
+    addSuccess: false,
+  }),
+}));
+
 // ── Controlled recommendation mock ────────────────────────────────────────────
 
 const mockProductRecommendations = jest.fn();

--- a/src/screens/__tests__/cartScreen.sync-error.test.tsx
+++ b/src/screens/__tests__/cartScreen.sync-error.test.tsx
@@ -83,6 +83,11 @@ jest.mock('@/hooks/useBundleSuggestion', () => ({
   }),
 }));
 
+jest.mock('@/hooks/useProductRecommendations', () => ({
+  useProductRecommendations: () => ({ recommendations: [], isLoading: false, error: null }),
+  clearRecommendationsCache: jest.fn(),
+}));
+
 jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn().mockResolvedValue(null),
   setItem: jest.fn().mockResolvedValue(undefined),

--- a/src/screens/__tests__/cartScreen.sync-error.test.tsx
+++ b/src/screens/__tests__/cartScreen.sync-error.test.tsx
@@ -70,6 +70,19 @@ jest.mock('@/services/wix/wixProvider', () => ({
   }),
 }));
 
+jest.mock('@/hooks/useBundleSuggestion', () => ({
+  useBundleSuggestion: () => ({
+    bundle: null,
+    bundleProducts: [],
+    pricing: null,
+    isLoading: false,
+    error: null,
+    addBundleToCart: jest.fn(),
+    isAddingToCart: false,
+    addSuccess: false,
+  }),
+}));
+
 jest.mock('@react-native-async-storage/async-storage', () => ({
   getItem: jest.fn().mockResolvedValue(null),
   setItem: jest.fn().mockResolvedValue(undefined),

--- a/src/screens/__tests__/cartScreen.test.tsx
+++ b/src/screens/__tests__/cartScreen.test.tsx
@@ -70,6 +70,12 @@ jest.mock('@/hooks/useBundleSuggestion', () => ({
   useBundleSuggestion: (...args: unknown[]) => mockUseBundleSuggestion(...args),
 }));
 
+// Mock useProductRecommendations to prevent async Wix calls that leak between tests.
+jest.mock('@/hooks/useProductRecommendations', () => ({
+  useProductRecommendations: () => ({ recommendations: [], isLoading: false, error: null }),
+  clearRecommendationsCache: jest.fn(),
+}));
+
 const asheville = FUTON_MODELS[0]; // $349
 const blueRidge = FUTON_MODELS[1]; // $449
 const naturalLinen = FABRICS[0]; // $0
@@ -128,9 +134,9 @@ describe('CartScreen', () => {
   });
 
   describe('Empty cart', () => {
-    it('renders empty state when cart is empty', () => {
-      const { getByTestId } = renderCartScreen();
-      expect(getByTestId('cart-empty-state')).toBeTruthy();
+    it('renders empty state when cart is empty', async () => {
+      const { findByTestId } = renderCartScreen();
+      expect(await findByTestId('cart-empty-state')).toBeTruthy();
     });
 
     // Skip: illustration component not yet built (sprint bead cm-0qn)
@@ -139,17 +145,18 @@ describe('CartScreen', () => {
       expect(getByTestId('cart-illustration')).toBeTruthy();
     });
 
-    it('shows "Start Shopping" action when onContinueShopping provided', () => {
+    it('shows "Start Shopping" action when onContinueShopping provided', async () => {
       const onContinueShopping = jest.fn();
-      const { getByTestId } = renderCartScreen({ onContinueShopping });
-      const action = getByTestId('cart-empty-state-action');
+      const { findByTestId } = renderCartScreen({ onContinueShopping });
+      const action = await findByTestId('cart-empty-state-action');
       expect(action).toBeTruthy();
       fireEvent.press(action);
       expect(onContinueShopping).toHaveBeenCalledTimes(1);
     });
 
-    it('does not show action when onContinueShopping not provided', () => {
-      const { queryByTestId } = renderCartScreen();
+    it('does not show action when onContinueShopping not provided', async () => {
+      const { findByTestId, queryByTestId } = renderCartScreen();
+      await findByTestId('cart-empty-state');
       expect(queryByTestId('cart-empty-state-action')).toBeNull();
     });
   });
@@ -320,10 +327,11 @@ describe('CartScreen', () => {
       { model: blueRidge, fabric: mountainBlue, qty: 1 },
     ];
 
-    it('clears all items', () => {
-      const { getByTestId } = renderCartScreen({}, seed);
+    it('clears all items', async () => {
+      const { getByTestId, findByTestId } = renderCartScreen({}, seed);
+      await findByTestId('cart-clear-button');
       fireEvent.press(getByTestId('cart-clear-button'));
-      expect(getByTestId('cart-empty-state')).toBeTruthy();
+      expect(await findByTestId('cart-empty-state')).toBeTruthy();
     });
   });
 
@@ -359,9 +367,9 @@ describe('CartScreen', () => {
   });
 
   describe('Custom testID', () => {
-    it('accepts custom testID', () => {
-      const { getByTestId } = renderCartScreen({ testID: 'my-cart' });
-      expect(getByTestId('my-cart')).toBeTruthy();
+    it('accepts custom testID', async () => {
+      const { findByTestId } = renderCartScreen({ testID: 'my-cart' });
+      expect(await findByTestId('my-cart')).toBeTruthy();
     });
   });
 

--- a/src/screens/__tests__/cartScreen.test.tsx
+++ b/src/screens/__tests__/cartScreen.test.tsx
@@ -63,6 +63,13 @@ jest.mock('@/services/wix/wixProvider', () => ({
   }),
 }));
 
+// Mock useBundleSuggestion to prevent async Wix fetches accumulating across tests (cm-b5f).
+// Most tests return null bundle (no-op). Integration describe below tests real rendering.
+const mockUseBundleSuggestion = jest.fn();
+jest.mock('@/hooks/useBundleSuggestion', () => ({
+  useBundleSuggestion: (...args: unknown[]) => mockUseBundleSuggestion(...args),
+}));
+
 const asheville = FUTON_MODELS[0]; // $349
 const blueRidge = FUTON_MODELS[1]; // $449
 const naturalLinen = FABRICS[0]; // $0
@@ -102,10 +109,22 @@ function CartSeeder({
   return null;
 }
 
+const nullBundle = {
+  bundle: null,
+  bundleProducts: [],
+  pricing: null,
+  isLoading: false,
+  error: null,
+  addBundleToCart: jest.fn(),
+  isAddingToCart: false,
+  addSuccess: false,
+};
+
 describe('CartScreen', () => {
   beforeEach(() => {
     mockUseLoyalty.mockReturnValue(loyaltyBase);
     mockUseAuth.mockReturnValue({ isAuthenticated: true });
+    mockUseBundleSuggestion.mockReturnValue(nullBundle);
   });
 
   describe('Empty cart', () => {
@@ -556,6 +575,45 @@ describe('CartScreen', () => {
       const { getByTestId } = renderCartScreen({}, seed);
       const bar = getByTestId('cart-loyalty-progress');
       expect(bar.props.accessibilityLabel).toMatch(/maximum tier reached/i);
+    });
+  });
+
+  // cm-b5f: BundleSuggestion integration — verifies component renders/hides in CartScreen.
+  // Uses controlled hook mock (no async Wix fetch) to avoid OOM accumulation.
+  describe('BundleSuggestion integration (cm-b5f)', () => {
+    const seed = [{ model: asheville, fabric: FABRICS[0], qty: 1 }];
+
+    it('renders BundleSuggestion when cart has items and bundle is available', async () => {
+      mockUseBundleSuggestion.mockReturnValue({
+        bundle: { bundleId: 'b1', name: 'Asheville Comfort Bundle', productIds: ['p1', 'p2'], discountPercent: 10 },
+        bundleProducts: [
+          { id: 'p1', name: 'Asheville Full', slug: 'asheville-full', price: 349, category: 'futons' as const, fabricOptions: [], images: [], rating: 4.5, reviewCount: 12, description: '', inStock: true, featured: false },
+          { id: 'p2', name: 'Linen Cover', slug: 'linen-cover', price: 79, category: 'covers' as const, fabricOptions: [], images: [], rating: 4.0, reviewCount: 5, description: '', inStock: true, featured: false },
+        ],
+        pricing: { originalTotal: 428, bundlePrice: 385, savings: 43, savingsPercent: 10, couponCode: 'CF-BUNDLE-ASHVLLE1' },
+        isLoading: false,
+        error: null,
+        addBundleToCart: jest.fn(),
+        isAddingToCart: false,
+        addSuccess: false,
+      });
+      const { getByTestId } = renderCartScreen({}, seed);
+      await waitFor(() => expect(getByTestId('bundle-suggestion-cart')).toBeTruthy());
+    });
+
+    it('does not render BundleSuggestion when cart is empty', () => {
+      mockUseBundleSuggestion.mockReturnValue({
+        bundle: { bundleId: 'b1', name: 'Bundle', productIds: ['p1'], discountPercent: 10 },
+        bundleProducts: [],
+        pricing: { originalTotal: 349, bundlePrice: 314, savings: 35, savingsPercent: 10, couponCode: 'CF-BUNDLE-X' },
+        isLoading: false,
+        error: null,
+        addBundleToCart: jest.fn(),
+        isAddingToCart: false,
+        addSuccess: false,
+      });
+      const { queryByTestId } = renderCartScreen();
+      expect(queryByTestId('bundle-suggestion-cart')).toBeNull();
     });
   });
 });


### PR DESCRIPTION
Fixes SIGTERM OOM in CI when CartScreen tests run (gh issue #441):
- Mocks useBundleSuggestion hook in 3 cart test files to prevent async Wix fetches accumulating across tests
- Mocks useProductRecommendations to prevent async state leaks between tests
- Fixes pre-existing hydration timing in empty-cart tests (findByTestId for async hydration)
- Implements cart sync error rollback in useCart.addItem (cm-vjz): optimistic remove + setSyncError on addToCart rejection
- Removes cartScreen.test.tsx, cartScreen.sync-error.test.tsx, CartScreenRecommendations.test.tsx from testPathIgnorePatterns
- Adds BundleSuggestion integration tests verifying renders/hides based on cart state

88 tests pass, 1 skipped, 3.7s on Linux.

Closes cm-b5f