### PR TITLE
fix(cm-isj): sentry module isolation + PDS useWishlist async leak

### DIFF
--- a/src/screens/__tests__/productDetailScreen.test.tsx
+++ b/src/screens/__tests__/productDetailScreen.test.tsx
@@ -210,6 +210,25 @@ jest.mock('@/hooks/useProductResources', () => ({
   useProductResources: () => ({ resources: [], loading: false, error: null }),
 }));
 
+// Mock useWishlist to prevent async AsyncStorage operations that cause setIsLoading
+// state updates outside act() when the worker is shared across test files (cm-isj).
+jest.mock('@/hooks/useWishlist', () => ({
+  WishlistProvider: ({ children }: { children: React.ReactNode }) => children,
+  useWishlist: () => ({
+    items: [],
+    count: 0,
+    isInWishlist: () => false,
+    toggle: jest.fn(),
+    add: jest.fn(),
+    remove: jest.fn(),
+    clear: jest.fn(),
+    getProducts: jest.fn(() => []),
+    getShareText: jest.fn(() => ''),
+    pendingSync: 0,
+    isSyncing: false,
+  }),
+}));
+
 const mockAlert = jest.fn();
 Alert.alert = mockAlert;
 
@@ -1923,6 +1942,24 @@ describe('ProductDetailScreen', () => {
       // Default: isWixConfigured returns false (no env vars in test), local models render fine
       const { queryByTestId } = renderDetail({ productId: 'asheville-full' });
       expect(queryByTestId('wix-network-error')).toBeNull();
+    });
+  });
+
+  // cm-isj: cross-file isolation — verifies useWishlist mock prevents async state leaks
+  // that caused intermittent failures when full suite runs (gh issue #261).
+  describe('wishlist isolation (cm-isj)', () => {
+    it('isInWishlist returns false by default — no async state from previous tests', () => {
+      const { getByTestId } = renderDetail({ productId: 'asheville-full' });
+      expect(getByTestId('detail-wishlist-button')).toBeTruthy();
+    });
+
+    it('wishlist toggle mock is callable and does not trigger async operations', () => {
+      const { getByTestId } = renderDetail({ productId: 'asheville-full' });
+      const btn = getByTestId('detail-wishlist-button');
+      fireEvent.press(btn);
+      // If real useWishlist were used, this would trigger AsyncStorage + setIsLoading
+      // outside act(). With mock, it's synchronous and clean.
+      expect(btn).toBeTruthy();
     });
   });
 });

--- a/src/services/providers/__tests__/sentryCrashReporting.withSentry.test.ts
+++ b/src/services/providers/__tests__/sentryCrashReporting.withSentry.test.ts
@@ -66,6 +66,12 @@ beforeEach(() => {
   });
 });
 
+// Reset after each test so the next test file doesn't inherit a stale module registry
+// after this file's resetModules() calls. Prevents the cm-isj cross-file state leak.
+afterEach(() => {
+  jest.resetModules();
+});
+
 describe('SentryCrashReportingProvider (with Sentry)', () => {
   it('calls Sentry.init with DSN and defaults', () => {
     const provider = new SentryCrashReportingProvider({
@@ -212,5 +218,14 @@ describe('SentryCrashReportingProvider (with Sentry)', () => {
     const result = wrapWithSentry(FakeComponent);
     expect(mockWrap).toHaveBeenCalledWith(FakeComponent);
     expect(result).toBe(FakeComponent);
+  });
+
+  // cm-isj: module isolation — verifies each test gets a fresh SentryCrashReportingProvider
+  // with a clean mock. If isolateModules breaks, init would be called with stale state.
+  it('provider is freshly loaded each test — mock call counts reset between tests (cm-isj)', () => {
+    expect(mockInit).not.toHaveBeenCalled(); // clearAllMocks in beforeEach cleared prior calls
+    const provider = new SentryCrashReportingProvider({ dsn: 'https://x@sentry.io/1' });
+    provider.init();
+    expect(mockInit).toHaveBeenCalledTimes(1); // exactly one call, not accumulated
   });
 });


### PR DESCRIPTION
Fixes intermittent test failures (gh issue #261) when full suite runs:

- sentryCrashReporting.withSentry: add afterEach(jest.resetModules()) so module registry is clean after each test; add TDD isolation test
- productDetailScreen.test: mock useWishlist to prevent async AsyncStorage setIsLoading firing outside act() after tests complete; add 2 TDD isolation tests

216 tests pass in productDetailScreen.test + sentryCrashReporting.withSentry suites.

Closes cm-isj