### PR TITLE
fix(hq-5sa4): a11y audit — GamificationPushBridge + TierCelebrationModal

### DIFF
--- a/src/components/GamificationPushBridge.tsx
+++ b/src/components/GamificationPushBridge.tsx
@@ -14,6 +14,7 @@
  *       streak_milestone   → reportTriggers({ milestoneUnlocked: true })
  */
 import { useEffect } from 'react';
+import { AccessibilityInfo } from 'react-native';
 import * as Notifications from 'expo-notifications';
 import { dispatchCrossRigPush } from '@/services/crossRigPushDispatch';
 import {
@@ -37,6 +38,14 @@ export function GamificationPushBridge() {
       const memberId = typeof data.memberId === 'string' ? data.memberId : '';
 
       dispatchCrossRigPush(memberId, event, data);
+
+      if (event === 'badge_earned') {
+        const badgeName = typeof data.badgeName === 'string' ? data.badgeName : 'a badge';
+        AccessibilityInfo.announceForAccessibility('You earned ' + badgeName);
+      } else if (event === 'tier_changed') {
+        const newTier = typeof data.newTier === 'string' ? data.newTier : 'a new tier';
+        AccessibilityInfo.announceForAccessibility('You reached ' + newTier);
+      }
 
       handleGamificationPushEvent(data as GamificationPushPayload, {
         showBadgeToast,

--- a/src/components/TierCelebrationModal.tsx
+++ b/src/components/TierCelebrationModal.tsx
@@ -207,6 +207,7 @@ export const TierCelebrationModal = memo(function TierCelebrationModal({
         testID="tier-celebration-modal"
         style={[styles.overlay, { backgroundColor: 'rgba(0,0,0,0.85)' }]}
         accessibilityViewIsModal
+        accessibilityLabel={tierLabel + ' tier celebration'}
       >
         {/* Confetti layer — hidden when reduce motion is enabled */}
         {!reduceMotion && (
@@ -233,7 +234,12 @@ export const TierCelebrationModal = memo(function TierCelebrationModal({
           ]}
         >
           {/* Animated badge */}
-          <Animated.View testID="tier-celebration-badge" style={[styles.badgeWrap, badgeStyle]}>
+          <Animated.View
+            testID="tier-celebration-badge"
+            style={[styles.badgeWrap, badgeStyle]}
+            accessibilityElementsHidden={true}
+            importantForAccessibility="no-hide-descendants"
+          >
             <Text style={styles.badgeEmoji}>{tierEmoji}</Text>
           </Animated.View>
 

--- a/src/components/__tests__/GamificationPushBridge.test.tsx
+++ b/src/components/__tests__/GamificationPushBridge.test.tsx
@@ -7,6 +7,7 @@
  */
 import React from 'react';
 import { render } from '@testing-library/react-native';
+import { AccessibilityInfo } from 'react-native';
 
 import * as Notifications from 'expo-notifications';
 import { dispatchCrossRigPush } from '@/services/crossRigPushDispatch';
@@ -157,5 +158,60 @@ describe('GamificationPushBridge', () => {
     triggerPush({ event: 'badge_earned', badgeName: 'First AR', badgeId: 'ar-01' });
 
     expect(dispatchCrossRigPush).toHaveBeenCalledWith('', 'badge_earned', expect.anything());
+  });
+
+  describe('accessibility', () => {
+    let announceSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      announceSpy = jest
+        .spyOn(AccessibilityInfo, 'announceForAccessibility')
+        .mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      announceSpy.mockRestore();
+    });
+
+    it('announces badge_earned event to screen readers', () => {
+      const { triggerPush } = setupListener();
+      render(<GamificationPushBridge />);
+
+      triggerPush({ event: 'badge_earned', memberId: 'member-1', badgeName: 'First AR' });
+
+      expect(AccessibilityInfo.announceForAccessibility).toHaveBeenCalledWith(
+        expect.stringContaining('First AR'),
+      );
+    });
+
+    it('announces tier_changed event to screen readers', () => {
+      const { triggerPush } = setupListener();
+      render(<GamificationPushBridge />);
+
+      triggerPush({ event: 'tier_changed', memberId: 'member-2', newTier: 'silver' });
+
+      expect(AccessibilityInfo.announceForAccessibility).toHaveBeenCalledWith(
+        expect.stringContaining('silver'),
+      );
+    });
+
+    it('does not announce for events with no recognized event field', () => {
+      const { triggerPush } = setupListener();
+      render(<GamificationPushBridge />);
+
+      triggerPush({ someOtherField: 'value' });
+
+      expect(AccessibilityInfo.announceForAccessibility).not.toHaveBeenCalled();
+    });
+
+    it('does not announce for challenge_complete or streak_milestone (modal handles it)', () => {
+      const { triggerPush } = setupListener();
+      render(<GamificationPushBridge />);
+
+      triggerPush({ event: 'challenge_complete', memberId: 'member-1', challengeName: 'AR Pro' });
+      triggerPush({ event: 'streak_milestone', memberId: 'member-1' });
+
+      expect(AccessibilityInfo.announceForAccessibility).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/components/__tests__/tierCelebrationModal.test.tsx
+++ b/src/components/__tests__/tierCelebrationModal.test.tsx
@@ -43,7 +43,7 @@ describe('TierCelebrationModal', () => {
 
     it('shows tier badge element', () => {
       const { getByTestId } = renderModal(LOYALTY_TIERS[1]);
-      expect(getByTestId('tier-celebration-badge')).toBeTruthy();
+      expect(getByTestId('tier-celebration-badge', { includeHiddenElements: true })).toBeTruthy();
     });
 
     it('shows confetti container', () => {
@@ -83,10 +83,34 @@ describe('TierCelebrationModal', () => {
       expect(btn.props.accessibilityRole).toBe('button');
     });
 
+    it('dismiss button has descriptive accessibilityLabel', () => {
+      const { getByTestId } = renderModal(LOYALTY_TIERS[1]);
+      const btn = getByTestId('tier-celebration-dismiss');
+      expect(btn.props.accessibilityLabel).toMatch(/Mountain Guide/i);
+    });
+
+    it('heading has accessibilityRole="header"', () => {
+      const { getByTestId } = renderModal(LOYALTY_TIERS[1]);
+      const heading = getByTestId('tier-celebration-heading');
+      expect(heading.props.accessibilityRole).toBe('header');
+    });
+
     it('modal has accessibilityViewIsModal', () => {
       const { getByTestId } = renderModal(LOYALTY_TIERS[1]);
       const modal = getByTestId('tier-celebration-modal');
       expect(modal.props.accessibilityViewIsModal).toBe(true);
+    });
+
+    it('modal overlay has an accessibilityLabel for screen readers', () => {
+      const { getByTestId } = renderModal(LOYALTY_TIERS[1]);
+      const modal = getByTestId('tier-celebration-modal');
+      expect(modal.props.accessibilityLabel).toBeTruthy();
+    });
+
+    it('badge emoji container is hidden from accessibility tree (decorative)', () => {
+      const { getByTestId } = renderModal(LOYALTY_TIERS[1]);
+      const badge = getByTestId('tier-celebration-badge', { includeHiddenElements: true });
+      expect(badge.props.accessibilityElementsHidden).toBe(true);
     });
 
     it('renders without crash when reduced motion is enabled', () => {


### PR DESCRIPTION
## Summary

A11y audit of PR #527 (GamificationPushBridge + TriggerMomentsContext).

**TierCelebrationModal fixes:**
- Add `accessibilityLabel` to modal overlay — VoiceOver/TalkBack announces context when focus enters
- Badge emoji container: `accessibilityElementsHidden={true}` + `importantForAccessibility="no-hide-descendants"` — emoji is decorative; heading already conveys the tier name

**GamificationPushBridge fix:**
- Call `AccessibilityInfo.announceForAccessibility` for `badge_earned` and `tier_changed` push events — gives screen reader users an early cue before the celebration modal becomes visible
- `challenge_complete` and `streak_milestone` are intentionally silent — their downstream modals handle focus

**No issues found in TriggerMomentsContext** — provider-only, no rendered UI.

## Test plan

- [x] Modal overlay has `accessibilityLabel` (new test)
- [x] Badge emoji container has `accessibilityElementsHidden={true}` (new test)
- [x] Heading has `accessibilityRole="header"` (new test)
- [x] Dismiss button has descriptive `accessibilityLabel` (new test)
- [x] `badge_earned` announces to screen readers (new test)
- [x] `tier_changed` announces to screen readers (new test)
- [x] No announcement for unrecognized / silent events (new test)
- [x] 29 tests total, all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)