### PR TITLE
feat(hq-8zif): usePendingSyncCount + OfflineBanner a11y announcements

### DIFF
--- a/src/components/OfflineBanner.tsx
+++ b/src/components/OfflineBanner.tsx
@@ -7,8 +7,8 @@
  * Automatically hides when connectivity is restored.
  */
 
-import React from 'react';
-import { StyleSheet, Text } from 'react-native';
+import React, { useEffect, useRef } from 'react';
+import { AccessibilityInfo, StyleSheet, Text } from 'react-native';
 import Animated, { SlideInUp, SlideOutUp } from 'react-native-reanimated';
 import { useTheme } from '@/theme';
 import { useConnectivity } from '@/hooks/useConnectivity';
@@ -45,6 +45,25 @@ export function OfflineBanner({ testID }: Props) {
   const { isOnline } = useConnectivity();
   const reduceMotion = useReducedMotion();
   const { pendingCount } = useQueueStatus();
+
+  const prevOnlineRef = useRef<boolean | null>(null);
+
+  useEffect(() => {
+    // Skip announcement on initial render
+    if (prevOnlineRef.current === null) {
+      prevOnlineRef.current = isOnline;
+      return;
+    }
+    if (prevOnlineRef.current === isOnline) return;
+
+    prevOnlineRef.current = isOnline;
+
+    if (!isOnline) {
+      AccessibilityInfo.announceForAccessibility(accessibilityLabel(pendingCount));
+    } else {
+      AccessibilityInfo.announceForAccessibility("You're back online. Syncing queued changes.");
+    }
+  }, [isOnline, pendingCount]);
 
   if (isOnline) return null;
 

--- a/src/components/__tests__/offlineBannerA11y.test.tsx
+++ b/src/components/__tests__/offlineBannerA11y.test.tsx
@@ -1,0 +1,98 @@
+/**
+ * A11y announcement tests for OfflineBanner — hq-8zif
+ *
+ * Verifies AccessibilityInfo.announceForAccessibility is called when
+ * connectivity transitions so screen reader users get immediate feedback
+ * even before VoiceOver focus reaches the banner.
+ */
+import React from 'react';
+import { render, act } from '@testing-library/react-native';
+import { AccessibilityInfo } from 'react-native';
+import { OfflineBanner } from '../OfflineBanner';
+import { ConnectivityProvider, useConnectivity } from '@/hooks/useConnectivity';
+import { ThemeProvider } from '@/theme/ThemeProvider';
+import { enqueue, _resetForTesting } from '@/services/offlineQueue';
+
+beforeEach(() => {
+  _resetForTesting();
+  jest.clearAllMocks();
+});
+
+let announceSpy: jest.SpyInstance;
+beforeEach(() => {
+  announceSpy = jest
+    .spyOn(AccessibilityInfo, 'announceForAccessibility')
+    .mockImplementation(() => {});
+});
+afterEach(() => {
+  announceSpy.mockRestore();
+});
+
+function renderWithControl(initialOnline = true) {
+  let setOnlineRef: (v: boolean) => void = () => {};
+
+  function Control() {
+    const { setOnline } = useConnectivity();
+    setOnlineRef = setOnline;
+    return null;
+  }
+
+  const result = render(
+    <ThemeProvider>
+      <ConnectivityProvider initialOnline={initialOnline} skipNetInfo>
+        <Control />
+        <OfflineBanner />
+      </ConnectivityProvider>
+    </ThemeProvider>,
+  );
+  return {
+    ...result,
+    setOnline: (v: boolean) =>
+      act(() => {
+        setOnlineRef(v);
+      }),
+  };
+}
+
+describe('OfflineBanner — a11y announcements', () => {
+  it('announces going offline to screen readers', async () => {
+    const { setOnline } = renderWithControl(true);
+    await setOnline(false);
+    expect(AccessibilityInfo.announceForAccessibility).toHaveBeenCalledWith(
+      expect.stringMatching(/offline/i),
+    );
+  });
+
+  it('announces coming back online to screen readers', async () => {
+    const { setOnline } = renderWithControl(false);
+    await setOnline(true);
+    expect(AccessibilityInfo.announceForAccessibility).toHaveBeenCalledWith(
+      expect.stringMatching(/online/i),
+    );
+  });
+
+  it('does not announce on initial render when already online', () => {
+    renderWithControl(true);
+    expect(AccessibilityInfo.announceForAccessibility).not.toHaveBeenCalled();
+  });
+
+  it('includes pending count in offline announcement when items are queued', async () => {
+    act(() => {
+      enqueue('cart', 'ADD_ITEM', { productId: 'p1' });
+      enqueue('cart', 'ADD_ITEM', { productId: 'p2' });
+    });
+    const { setOnline } = renderWithControl(true);
+    await setOnline(false);
+    expect(AccessibilityInfo.announceForAccessibility).toHaveBeenCalledWith(
+      expect.stringContaining('2'),
+    );
+  });
+
+  it('announces offline with "browsing cached products" when queue is empty', async () => {
+    const { setOnline } = renderWithControl(true);
+    await setOnline(false);
+    expect(AccessibilityInfo.announceForAccessibility).toHaveBeenCalledWith(
+      expect.stringMatching(/browsing cached products/i),
+    );
+  });
+});

--- a/src/hooks/__tests__/usePendingSyncCount.test.tsx
+++ b/src/hooks/__tests__/usePendingSyncCount.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * @module usePendingSyncCount tests
+ * TDD spec — written before implementation.
+ */
+import React from 'react';
+import { Text } from 'react-native';
+import { render, act } from '@testing-library/react-native';
+import { usePendingSyncCount } from '../usePendingSyncCount';
+import { enqueue, clearQueue, _resetForTesting } from '@/services/offlineQueue';
+
+beforeEach(() => {
+  _resetForTesting();
+});
+
+function CountHarness() {
+  const count = usePendingSyncCount();
+  return <Text testID="count">{count}</Text>;
+}
+
+describe('usePendingSyncCount', () => {
+  it('returns 0 when queue is empty', () => {
+    const { getByTestId } = render(<CountHarness />);
+    expect(getByTestId('count').props.children).toBe(0);
+  });
+
+  it('returns current queue length after enqueue', () => {
+    const { getByTestId } = render(<CountHarness />);
+    act(() => {
+      enqueue('cart', 'ADD_ITEM', { productId: 'p1' });
+      enqueue('wishlist', 'ADD', { productId: 'p2' });
+    });
+    expect(getByTestId('count').props.children).toBe(2);
+  });
+
+  it('updates reactively when queue is cleared', () => {
+    act(() => {
+      enqueue('cart', 'ADD_ITEM', { productId: 'p1' });
+    });
+    const { getByTestId } = render(<CountHarness />);
+    expect(getByTestId('count').props.children).toBe(1);
+
+    act(() => {
+      clearQueue();
+    });
+    expect(getByTestId('count').props.children).toBe(0);
+  });
+
+  it('returns a number, not an object', () => {
+    const { getByTestId } = render(<CountHarness />);
+    const value = getByTestId('count').props.children;
+    expect(typeof value).toBe('number');
+  });
+});

--- a/src/hooks/usePendingSyncCount.ts
+++ b/src/hooks/usePendingSyncCount.ts
@@ -1,0 +1,12 @@
+/**
+ * @module usePendingSyncCount
+ *
+ * Returns the number of offline writes queued for replay as a plain number.
+ * Thin wrapper over useQueueStatus for callers that need just the count.
+ */
+import { useQueueStatus } from '@/hooks/useQueueStatus';
+
+export function usePendingSyncCount(): number {
+  const { pendingCount } = useQueueStatus();
+  return pendingCount;
+}


### PR DESCRIPTION
## Summary

Completes hq-8zif — the OfflineBanner and queue infrastructure already landed on main; this PR adds the two pieces that were missing:

**`usePendingSyncCount` hook** — returns pending offline write count as a plain `number` (vs. `useQueueStatus` which returns an object). Thinner API for callers that need just the count.

**OfflineBanner a11y announcements** — `AccessibilityInfo.announceForAccessibility` on connectivity transitions:
- Going offline → announces current queue status (e.g. "You are offline. 2 changes queued — will sync when reconnected.")
- Coming back online → announces "You're back online. Syncing queued changes."
- Initial render: silent (no false announcement on mount)

`accessibilityRole="alert"` alone is not reliable on Android for elements that slide in; explicit `announceForAccessibility` ensures both platforms hear the state change.

## Test plan

- [x] `usePendingSyncCount` — 4 tests: empty queue, after enqueue, reactive clear, returns number
- [x] OfflineBanner a11y — 5 tests: offline announced, online announced, silent on mount, count in offline msg, "browsing cached" when empty
- [x] Full offline/connectivity suite: 122 tests, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)