### PR TITLE
feat(cm-anr): wire SkeletonBox/SkeletonText into ProductCard and HomeScreen loading states

### DIFF
--- a/src/components/SkeletonCarouselItem.tsx
+++ b/src/components/SkeletonCarouselItem.tsx
@@ -1,29 +1,18 @@
-/**
- * @module SkeletonCarouselItem
- *
- * Skeleton loading placeholder that mirrors the RecommendationCarousel card
- * dimensions (160x120 image, name, price, rating). Used while recommendation
- * data is being fetched to prevent layout shift.
- */
-
 import React, { memo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTheme } from '@/theme';
-import { Shimmer } from './Shimmer';
+import { SkeletonBox, SkeletonText } from './Skeleton';
 
 const CARD_WIDTH = 160;
 const IMAGE_HEIGHT = 120;
 
-/**
- * Skeleton placeholder matching RecommendationCarousel card layout:
- * Image (160x120) → name (2 lines) → price → rating stars
- */
 export const SkeletonCarouselItem = memo(function SkeletonCarouselItem({
   testID,
 }: {
   testID?: string;
 }) {
   const { colors, borderRadius, shadows, spacing } = useTheme();
+  const id = testID ?? 'skeleton-carousel-item';
 
   return (
     <View
@@ -31,10 +20,11 @@ export const SkeletonCarouselItem = memo(function SkeletonCarouselItem({
         styles.card,
         { backgroundColor: colors.white, borderRadius: borderRadius.md, ...shadows.card },
       ]}
-      testID={testID ?? 'skeleton-carousel-item'}
+      testID={id}
       accessibilityLabel="Loading recommendation"
     >
-      <Shimmer
+      <SkeletonBox
+        testID={`${id}-image`}
         width={CARD_WIDTH}
         height={IMAGE_HEIGHT}
         borderRadius={0}
@@ -44,16 +34,20 @@ export const SkeletonCarouselItem = memo(function SkeletonCarouselItem({
         }}
       />
       <View style={[styles.body, { padding: spacing.sm }]}>
-        <Shimmer width="90%" height={13} />
-        <Shimmer width="60%" height={13} style={{ marginTop: 4 }} />
-        <Shimmer width={50} height={14} style={{ marginTop: 6 }} />
-        <Shimmer width={70} height={12} style={{ marginTop: 4 }} />
+        <SkeletonText testID={`${id}-name`} lines={2} lineHeight={13} />
+        <SkeletonBox
+          testID={`${id}-price`}
+          width={50}
+          height={14}
+          borderRadius={4}
+          style={{ marginTop: 6 }}
+        />
+        <SkeletonBox width={70} height={12} borderRadius={4} style={{ marginTop: 4 }} />
       </View>
     </View>
   );
 });
 
-/** Horizontal row of skeleton carousel items. */
 export function SkeletonCarouselRow({ count = 3 }: { count?: number }) {
   const { spacing } = useTheme();
 

--- a/src/components/SkeletonProductCard.tsx
+++ b/src/components/SkeletonProductCard.tsx
@@ -1,20 +1,8 @@
-/**
- * @module SkeletonProductCard
- *
- * Skeleton loading placeholder that mirrors the ProductCard dimensions
- * (4:3 image, name, description, rating, price). Used in product grids
- * while data is loading to prevent layout shift and give visual feedback.
- */
-
 import React, { memo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTheme } from '@/theme';
-import { Shimmer, ShimmerLines } from './Shimmer';
+import { SkeletonBox, SkeletonText } from './Skeleton';
 
-/**
- * Skeleton placeholder matching ProductCard layout:
- * 4:3 image area + name (2 lines) + description (1 line) + rating + price
- */
 export const SkeletonProductCard = memo(function SkeletonProductCard({
   testID,
 }: {
@@ -32,8 +20,8 @@ export const SkeletonProductCard = memo(function SkeletonProductCard({
       testID={testID ?? 'skeleton-product-card'}
       accessibilityLabel="Loading product"
     >
-      {/* Image placeholder */}
-      <Shimmer
+      <SkeletonBox
+        testID={`${testID ?? 'skeleton-product-card'}-image`}
         height={0}
         borderRadius={0}
         style={{
@@ -44,28 +32,37 @@ export const SkeletonProductCard = memo(function SkeletonProductCard({
         }}
       />
 
-      {/* Info area */}
       <View style={[styles.info, { padding: spacing.sm }]}>
-        {/* Name - 2 lines */}
-        <ShimmerLines lines={2} lineHeight={14} gap={4} lastLineWidth="70%" />
+        <SkeletonText
+          testID={`${testID ?? 'skeleton-product-card'}-name`}
+          lines={2}
+          lineHeight={14}
+        />
 
-        {/* Description - 1 line */}
-        <Shimmer width="85%" height={12} style={{ marginTop: 4 }} />
+        <SkeletonText
+          testID={`${testID ?? 'skeleton-product-card'}-description`}
+          lines={1}
+          lineHeight={12}
+          style={{ marginTop: 4 }}
+        />
 
-        {/* Rating row */}
         <View style={styles.ratingRow}>
-          <Shimmer width={70} height={12} />
-          <Shimmer width={24} height={12} />
+          <SkeletonBox width={70} height={12} borderRadius={4} />
+          <SkeletonBox width={24} height={12} borderRadius={4} />
         </View>
 
-        {/* Price */}
-        <Shimmer width={60} height={16} borderRadius={4} style={{ marginTop: 2 }} />
+        <SkeletonBox
+          testID={`${testID ?? 'skeleton-product-card'}-price`}
+          width={60}
+          height={16}
+          borderRadius={4}
+          style={{ marginTop: 2 }}
+        />
       </View>
     </View>
   );
 });
 
-/** Grid of skeleton product cards matching ShopScreen 2-column layout. */
 export function SkeletonProductGrid({ count = 4, testID }: { count?: number; testID?: string }) {
   const rows = [];
   for (let i = 0; i < count; i += 2) {

--- a/src/components/__tests__/skeletonCarouselItem.test.tsx
+++ b/src/components/__tests__/skeletonCarouselItem.test.tsx
@@ -3,6 +3,21 @@ import { render } from '@testing-library/react-native';
 import { SkeletonCarouselItem, SkeletonCarouselRow } from '../SkeletonCarouselItem';
 import { ThemeProvider } from '@/theme/ThemeProvider';
 
+jest.mock('react-native-reanimated', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: { View, createAnimatedComponent: (c: any) => c },
+    useSharedValue: (init: any) => ({ value: init }),
+    useAnimatedStyle: (fn: any) => fn(),
+    withRepeat: (val: any) => val,
+    withTiming: (val: any) => val,
+    Easing: { inOut: () => undefined, ease: undefined },
+  };
+});
+
+jest.mock('@/hooks/useReducedMotion', () => ({ useReducedMotion: () => false }));
+
 function wrap(ui: React.ReactElement) {
   return render(<ThemeProvider>{ui}</ThemeProvider>);
 }
@@ -21,6 +36,21 @@ describe('SkeletonCarouselItem', () => {
   it('has accessibility label', () => {
     const { getByLabelText } = wrap(<SkeletonCarouselItem />);
     expect(getByLabelText('Loading recommendation')).toBeTruthy();
+  });
+
+  it('uses SkeletonBox for the image placeholder', () => {
+    const { getByTestId } = wrap(<SkeletonCarouselItem />);
+    expect(getByTestId('skeleton-carousel-item-image')).toBeTruthy();
+  });
+
+  it('uses SkeletonText for the name placeholder', () => {
+    const { getByTestId } = wrap(<SkeletonCarouselItem />);
+    expect(getByTestId('skeleton-carousel-item-name')).toBeTruthy();
+  });
+
+  it('uses SkeletonBox for the price placeholder', () => {
+    const { getByTestId } = wrap(<SkeletonCarouselItem />);
+    expect(getByTestId('skeleton-carousel-item-price')).toBeTruthy();
   });
 });
 

--- a/src/components/__tests__/skeletonProductCard.test.tsx
+++ b/src/components/__tests__/skeletonProductCard.test.tsx
@@ -46,22 +46,42 @@ describe('SkeletonProductCard', () => {
     const shimmers = getAllByLabelText('Loading');
     expect(shimmers.length).toBeGreaterThanOrEqual(6);
   });
+
+  it('uses SkeletonBox for the image area placeholder', () => {
+    const { getByTestId } = wrap(<SkeletonProductCard />);
+    expect(getByTestId('skeleton-product-card-image')).toBeTruthy();
+  });
+
+  it('uses SkeletonText for the product name placeholder', () => {
+    const { getByTestId } = wrap(<SkeletonProductCard />);
+    expect(getByTestId('skeleton-product-card-name')).toBeTruthy();
+  });
+
+  it('uses SkeletonText for the description placeholder', () => {
+    const { getByTestId } = wrap(<SkeletonProductCard />);
+    expect(getByTestId('skeleton-product-card-description')).toBeTruthy();
+  });
+
+  it('uses SkeletonBox for the price placeholder', () => {
+    const { getByTestId } = wrap(<SkeletonProductCard />);
+    expect(getByTestId('skeleton-product-card-price')).toBeTruthy();
+  });
 });
 
 describe('SkeletonProductGrid', () => {
   it('renders default 4 skeleton cards', () => {
     const { getByTestId, getAllByTestId } = wrap(<SkeletonProductGrid />);
     expect(getByTestId('skeleton-product-grid')).toBeTruthy();
-    expect(getAllByTestId(/^skeleton-card-/)).toHaveLength(4);
+    expect(getAllByTestId(/^skeleton-card-\d+$/)).toHaveLength(4);
   });
 
   it('renders specified count of cards', () => {
     const { getAllByTestId } = wrap(<SkeletonProductGrid count={6} />);
-    expect(getAllByTestId(/^skeleton-card-/)).toHaveLength(6);
+    expect(getAllByTestId(/^skeleton-card-\d+$/)).toHaveLength(6);
   });
 
   it('handles odd count (last row has one card)', () => {
     const { getAllByTestId } = wrap(<SkeletonProductGrid count={3} />);
-    expect(getAllByTestId(/^skeleton-card-/)).toHaveLength(3);
+    expect(getAllByTestId(/^skeleton-card-\d+$/)).toHaveLength(3);
   });
 });

--- a/src/screens/HomeScreen.tsx
+++ b/src/screens/HomeScreen.tsx
@@ -33,6 +33,7 @@ import { darkPalette } from '@/theme/tokens';
 import { GlassCard } from '@/components/GlassCard';
 import { CollectionCard } from '@/components/CollectionCard';
 import { SkeletonCarouselRow } from '@/components/SkeletonCarouselItem';
+import { SkeletonText } from '@/components/Skeleton';
 import { MountainSkyline } from '@/components/MountainSkyline';
 import { LivingSkyBackground } from '@/components/LivingSkyBackground';
 import { LivingSkyMountainSkyline } from '@/components/LivingSkyMountainSkyline';
@@ -417,7 +418,15 @@ export function HomeScreen({ onOpenAR, onOpenShop, onCollectionPress }: Props) {
               Shop the Look
             </Text>
             {collectionsLoading && featured.length === 0 ? (
-              <SkeletonCarouselRow count={3} />
+              <>
+                <SkeletonText
+                  testID="skeleton-collections-title"
+                  lines={1}
+                  lineHeight={20}
+                  style={{ paddingHorizontal: spacing.lg, marginBottom: 12, width: 140 }}
+                />
+                <SkeletonCarouselRow count={3} />
+              </>
             ) : (
               <ScrollView
                 horizontal
@@ -461,6 +470,12 @@ export function HomeScreen({ onOpenAR, onOpenShop, onCollectionPress }: Props) {
           <View style={styles.carouselSection}>
             {quizLoading ? (
               <View testID="skeleton-personalized-picks">
+                <SkeletonText
+                  testID="skeleton-picks-title"
+                  lines={1}
+                  lineHeight={20}
+                  style={{ paddingHorizontal: spacing.lg, marginBottom: 12, width: 160 }}
+                />
                 <SkeletonCarouselRow count={3} />
               </View>
             ) : quizRecs.length > 0 ? (

--- a/src/screens/__tests__/homeScreen.deeper.test.tsx
+++ b/src/screens/__tests__/homeScreen.deeper.test.tsx
@@ -384,3 +384,51 @@ describe('refresh error', () => {
     expect(getByTestId('home-connection-error')).toBeTruthy();
   });
 });
+
+// ─── Skeleton section titles (SkeletonBox/SkeletonText integration) ───────────
+
+describe('skeleton section titles', () => {
+  it('shows skeleton title placeholder when collections are loading and featured is empty', () => {
+    mockUseCollections.mockReturnValue({ ...collectionsEmpty, isLoading: true });
+    const { getByTestId } = renderHomeScreen();
+    expect(getByTestId('skeleton-collections-title')).toBeTruthy();
+  });
+
+  it('does NOT show skeleton title when collections are loaded', () => {
+    mockUseCollections.mockReturnValue(collectionsLoaded);
+    const { queryByTestId } = renderHomeScreen();
+    expect(queryByTestId('skeleton-collections-title')).toBeNull();
+  });
+
+  it('shows skeleton title placeholder when quiz recommendations are loading', () => {
+    mockUsePersonalization.mockReturnValue({ ...noPersonalization, isLoading: true });
+    const { getByTestId } = renderHomeScreen();
+    expect(getByTestId('skeleton-picks-title')).toBeTruthy();
+  });
+
+  it('does NOT show skeleton picks title when quiz is loaded', () => {
+    mockUsePersonalization.mockReturnValue({
+      sommelierResult: null,
+      recommendations: [
+        {
+          id: 'p1',
+          slug: 'asheville-full',
+          name: 'Asheville Full',
+          price: 349,
+          images: [],
+          category: 'futon',
+          description: '',
+          isFeatured: false,
+          rating: 4.5,
+          reviewCount: 10,
+          sizeOptions: [],
+        },
+      ],
+      topStyle: null,
+      isLoading: false,
+      error: null,
+    });
+    const { queryByTestId } = renderHomeScreen();
+    expect(queryByTestId('skeleton-picks-title')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Migrates SkeletonProductCard and SkeletonCarouselItem from ad-hoc Shimmer/ShimmerLines to standardized SkeletonBox/SkeletonText primitives
- Adds named testIDs to all skeleton slot elements (image, name, description, price) enabling targeted test assertions
- Wires SkeletonText title placeholders into HomeScreen collections and personalized-picks loading states (skeleton-collections-title, skeleton-picks-title)
- All changes TDD: failing tests written first, implementation follows

## Test plan
- [x] SkeletonProductCard renders SkeletonBox for image, SkeletonText for name/description, SkeletonBox for price
- [x] SkeletonCarouselItem renders SkeletonBox for image, SkeletonText for name, SkeletonBox for price
- [x] SkeletonProductGrid count assertions use exact-match regex to avoid sub-element testID collisions
- [x] HomeScreen shows skeleton-collections-title when loading, absent when loaded
- [x] HomeScreen shows skeleton-picks-title when quiz loading, absent when loaded
- [x] 64 skeleton-related tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)