### PR TITLE
feat(cm-p7q): CategoryScreen + CollectionsScreen skeleton loading states

### DIFF
--- a/src/components/SkeletonCollectionCard.tsx
+++ b/src/components/SkeletonCollectionCard.tsx
@@ -1,26 +1,17 @@
-/**
- * @module SkeletonCollectionCard
- *
- * Skeleton loading placeholder matching CollectionCard dimensions:
- * large hero image with title, subtitle, and mood tags below.
- * Used while editorial collections are loading.
- *
- * cm-thv: CollectionsScreen skeleton / error / empty states
- */
 import React, { memo } from 'react';
 import { StyleSheet, View } from 'react-native';
 import { useTheme } from '@/theme';
-import { Shimmer, ShimmerLines } from './Shimmer';
+import { SkeletonBox, SkeletonText } from './Skeleton';
 
 const HERO_HEIGHT = 220;
 
-/** Skeleton placeholder matching a single featured CollectionCard. */
 export const SkeletonCollectionCard = memo(function SkeletonCollectionCard({
   testID,
 }: {
   testID?: string;
 }) {
   const { colors, borderRadius, shadows, spacing } = useTheme();
+  const id = testID ?? 'skeleton-collection-card';
 
   return (
     <View
@@ -29,11 +20,11 @@ export const SkeletonCollectionCard = memo(function SkeletonCollectionCard({
         shadows.card,
         { backgroundColor: colors.white, borderRadius: borderRadius.card },
       ]}
-      testID={testID ?? 'skeleton-collection-card'}
+      testID={id}
       accessibilityLabel="Loading collection"
     >
-      {/* Hero image placeholder */}
-      <Shimmer
+      <SkeletonBox
+        testID={`${id}-image`}
         height={HERO_HEIGHT}
         borderRadius={0}
         style={{
@@ -43,16 +34,12 @@ export const SkeletonCollectionCard = memo(function SkeletonCollectionCard({
         }}
       />
 
-      {/* Info area */}
       <View style={[styles.info, { padding: spacing.md }]}>
-        {/* Title */}
-        <ShimmerLines lines={1} lineHeight={18} gap={0} lastLineWidth="80%" />
-        {/* Subtitle */}
-        <Shimmer width="60%" height={13} style={{ marginTop: 6 }} />
-        {/* Mood tags */}
+        <SkeletonText testID={`${id}-title`} lines={1} lineHeight={18} />
+        <SkeletonBox width="60%" height={13} borderRadius={4} style={{ marginTop: 6 }} />
         <View style={styles.tagsRow}>
-          <Shimmer width={60} height={22} borderRadius={11} />
-          <Shimmer width={50} height={22} borderRadius={11} />
+          <SkeletonBox width={60} height={22} borderRadius={11} />
+          <SkeletonBox width={50} height={22} borderRadius={11} />
         </View>
       </View>
     </View>

--- a/src/components/__tests__/skeletonCollectionCard.test.tsx
+++ b/src/components/__tests__/skeletonCollectionCard.test.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { SkeletonCollectionCard } from '../SkeletonCollectionCard';
+import { ThemeProvider } from '@/theme/ThemeProvider';
+
+jest.mock('react-native-reanimated', () => {
+  const { View } = require('react-native');
+  return {
+    __esModule: true,
+    default: { View, createAnimatedComponent: (c: any) => c },
+    useSharedValue: (init: any) => ({ value: init }),
+    useAnimatedStyle: (fn: any) => fn(),
+    withRepeat: (val: any) => val,
+    withTiming: (val: any) => val,
+    Easing: { inOut: () => undefined, ease: undefined },
+  };
+});
+
+jest.mock('@/hooks/useReducedMotion', () => ({ useReducedMotion: () => false }));
+
+function wrap(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+describe('SkeletonCollectionCard', () => {
+  it('renders with default testID', () => {
+    const { getByTestId } = wrap(<SkeletonCollectionCard />);
+    expect(getByTestId('skeleton-collection-card')).toBeTruthy();
+  });
+
+  it('accepts custom testID', () => {
+    const { getByTestId } = wrap(<SkeletonCollectionCard testID="custom-skel" />);
+    expect(getByTestId('custom-skel')).toBeTruthy();
+  });
+
+  it('has loading accessibility label', () => {
+    const { getByTestId } = wrap(<SkeletonCollectionCard />);
+    expect(getByTestId('skeleton-collection-card').props.accessibilityLabel).toBe(
+      'Loading collection',
+    );
+  });
+
+  it('renders Loading-labelled elements for shimmer placeholders', () => {
+    const { getAllByLabelText } = wrap(<SkeletonCollectionCard />);
+    expect(getAllByLabelText('Loading').length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('uses SkeletonBox for the hero image placeholder', () => {
+    const { getByTestId } = wrap(<SkeletonCollectionCard />);
+    expect(getByTestId('skeleton-collection-card-image')).toBeTruthy();
+  });
+
+  it('uses SkeletonText for the title placeholder', () => {
+    const { getByTestId } = wrap(<SkeletonCollectionCard />);
+    expect(getByTestId('skeleton-collection-card-title')).toBeTruthy();
+  });
+});

--- a/src/screens/__tests__/categoryScreen.test.tsx
+++ b/src/screens/__tests__/categoryScreen.test.tsx
@@ -208,4 +208,29 @@ describe('CategoryScreen', () => {
       expect(flatList.props.refreshControl).toBeTruthy();
     });
   });
+
+  describe('skeleton loading state', () => {
+    it('shows skeleton grid immediately before data loads', () => {
+      const { getByTestId } = render(
+        <ThemeProvider>
+          <WishlistProvider>
+            <CompareProvider>
+              <CategoryScreen onProductPress={jest.fn()} onBack={jest.fn()} categoryId="futons" />
+            </CompareProvider>
+          </WishlistProvider>
+        </ThemeProvider>,
+      );
+      expect(getByTestId('skeleton-category-grid')).toBeTruthy();
+    });
+
+    it('skeleton grid is NOT shown after data loads', async () => {
+      const { queryByTestId } = await renderCategory({ categoryId: 'futons' });
+      expect(queryByTestId('skeleton-category-grid')).toBeNull();
+    });
+
+    it('product list IS shown after data loads', async () => {
+      const { getByTestId } = await renderCategory({ categoryId: 'futons' });
+      expect(getByTestId('category-product-list')).toBeTruthy();
+    });
+  });
 });

--- a/src/screens/__tests__/collectionsScreen.test.tsx
+++ b/src/screens/__tests__/collectionsScreen.test.tsx
@@ -156,7 +156,7 @@ describe('CollectionsScreen — skeleton loading', () => {
       isLoading: true,
     });
     const { getAllByTestId } = renderCollectionsScreen();
-    expect(getAllByTestId(/^skeleton-collection-card-/).length).toBe(4);
+    expect(getAllByTestId(/^skeleton-collection-card-\d+$/).length).toBe(4);
   });
 
   it('does not show error state while loading', () => {


### PR DESCRIPTION
## Summary
- Migrates `SkeletonCollectionCard` from `Shimmer`/`ShimmerLines` to `SkeletonBox`/`SkeletonText`, following the cm-anr pattern — adds named testIDs (`image`, `title` slots)
- Adds `SkeletonCollectionCard` test suite (new file) covering default/custom testID, accessibility label, and SkeletonBox/SkeletonText slot assertions
- CategoryScreen: adds skeleton loading state tests — skeleton visible immediately on mount, hidden after data loads, product list visible post-load
- CollectionsScreen: fixes skeleton card count regex to exact-match (`\d+$`) to prevent false positives from sub-element testIDs added by migration

## Test plan
- [x] SkeletonCollectionCard renders SkeletonBox for hero image, SkeletonText for title
- [x] CategoryScreen shows `skeleton-category-grid` during `isInitialLoading`, hides it after load
- [x] CollectionsScreen skeleton card count still correctly asserts 4 cards
- [x] 50 tests pass across all 3 test files

🤖 Generated with [Claude Code](https://claude.com/claude-code)