### PR TITLE
fix(cm-gdz): LoyaltyScreen perks — error state + race + a11y

### DIFF
--- a/src/hooks/__tests__/useTierPerks.test.ts
+++ b/src/hooks/__tests__/useTierPerks.test.ts
@@ -177,3 +177,51 @@ describe('useTierPerks — unauthenticated', () => {
     expect(result.current.error).toBeNull();
   });
 });
+
+// ─── Race condition — unmount cancellation (cm-gdz) ──────────────────────────
+
+describe('useTierPerks — unmount cancellation', () => {
+  it('does not setState after unmount when fetch resolves later', async () => {
+    let resolvePerks: (value: { perks: ReturnType<typeof makeDelivery>[] }) => void = () => {};
+    mockGetTierPerks.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolvePerks = resolve;
+        }),
+    );
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { unmount } = renderHook(() => useTierPerks());
+    unmount();
+    resolvePerks({ perks: [makeDelivery()] });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const stateUpdateWarning = errSpy.mock.calls.find((args) =>
+      String(args[0]).includes("Can't perform a React state update on an unmounted component"),
+    );
+    expect(stateUpdateWarning).toBeUndefined();
+    errSpy.mockRestore();
+  });
+
+  it('does not setState after unmount when fetch rejects later', async () => {
+    let rejectPerks: (err: Error) => void = () => {};
+    mockGetTierPerks.mockImplementation(
+      () =>
+        new Promise((_, reject) => {
+          rejectPerks = reject;
+        }),
+    );
+    const errSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    const { unmount } = renderHook(() => useTierPerks());
+    unmount();
+    rejectPerks(new Error('Late failure'));
+    await new Promise((r) => setTimeout(r, 10));
+
+    const stateUpdateWarning = errSpy.mock.calls.find((args) =>
+      String(args[0]).includes("Can't perform a React state update on an unmounted component"),
+    );
+    expect(stateUpdateWarning).toBeUndefined();
+    errSpy.mockRestore();
+  });
+});

--- a/src/hooks/useTierPerks.ts
+++ b/src/hooks/useTierPerks.ts
@@ -9,7 +9,7 @@
  * Returns empty perks without error when unauthenticated (Trail Blazer state).
  */
 
-import { useState, useCallback, useEffect } from 'react';
+import { useState, useEffect } from 'react';
 import { getWixClientSingleton } from '@/services/wix/wixClientSingleton';
 import { getWixSdkClient } from '@/services/wix/wixSdkClient';
 
@@ -32,42 +32,48 @@ export function useTierPerks(): UseTierPerksResult {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchPerks = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      let memberToken: string | undefined;
-      try {
-        const tokens = getWixSdkClient().auth.getTokens();
-        memberToken = tokens.accessToken?.value;
-      } catch {
-        // SDK not initialized or user not authenticated — return empty perks
-      }
-
-      if (!memberToken) {
-        setPerks([]);
-        return;
-      }
-
-      const wixClient = getWixClientSingleton();
-      if (!wixClient) {
-        setError('Wix service unavailable');
-        return;
-      }
-
-      const data = await wixClient.getTierPerks(memberToken);
-      setPerks(Array.isArray(data?.perks) ? data.perks : []);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : String(err));
-      setPerks([]);
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
   useEffect(() => {
-    fetchPerks();
-  }, [fetchPerks]);
+    let cancelled = false;
+
+    (async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        let memberToken: string | undefined;
+        try {
+          const tokens = getWixSdkClient().auth.getTokens();
+          memberToken = tokens.accessToken?.value;
+        } catch {
+          // SDK not initialized or user not authenticated — return empty perks
+        }
+
+        if (!memberToken) {
+          if (!cancelled) setPerks([]);
+          return;
+        }
+
+        const wixClient = getWixClientSingleton();
+        if (!wixClient) {
+          if (!cancelled) setError('Wix service unavailable');
+          return;
+        }
+
+        const data = await wixClient.getTierPerks(memberToken);
+        if (cancelled) return;
+        setPerks(Array.isArray(data?.perks) ? data.perks : []);
+      } catch (err) {
+        if (cancelled) return;
+        setError(err instanceof Error ? err.message : String(err));
+        setPerks([]);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   return { perks, loading, error };
 }

--- a/src/screens/LoyaltyScreen.tsx
+++ b/src/screens/LoyaltyScreen.tsx
@@ -79,7 +79,7 @@ export function LoyaltyScreen({ testID, onClose: _onClose }: Props) {
     loading: activityLoading,
     error: activityError,
   } = usePointsHistory();
-  const { perks, loading: perksLoading } = useTierPerks();
+  const { perks, loading: perksLoading, error: perksError } = useTierPerks();
   const prevTierRef = useRef<LoyaltyTierConfig | null>(null);
 
   useEffect(() => {
@@ -212,55 +212,76 @@ export function LoyaltyScreen({ testID, onClose: _onClose }: Props) {
           },
         ]}
         testID="loyalty-perks-heading"
+        accessibilityRole="header"
       >
         Your Perks
       </Text>
       <View style={[styles.perksWrap, { paddingHorizontal: spacing.lg }]}>
         {perksLoading ? (
           <SkeletonRow testID="loyalty-perks-loading" height={16} />
+        ) : perksError ? (
+          <View style={styles.emptyTx} testID="loyalty-perks-error">
+            <Text
+              style={[
+                styles.emptyText,
+                { color: colors.espressoLight, fontFamily: typography.bodyFamily },
+              ]}
+            >
+              {perksError}
+            </Text>
+          </View>
         ) : perks.length === 0 ? (
           <View testID="loyalty-perks-empty">
             <TierPerkCard tier={tier} testID="loyalty-tier-perk-card" />
           </View>
         ) : (
-          perks.map((perk: TierPerk) => (
-            <View
-              key={perk.perkType}
-              style={styles.perkRow}
-              testID={`loyalty-perk-${perk.perkType}`}
-            >
-              <Text
-                style={[
-                  styles.perkLabel,
-                  { color: colors.espresso, fontFamily: typography.bodyFamily },
-                ]}
+          perks.map((perk: TierPerk) => {
+            const label = perkLabel(perk.perkType);
+            const a11yParts = [label];
+            if (perk.couponCode) a11yParts.push(`coupon code ${perk.couponCode}`);
+            if (perk.bookingUrl) a11yParts.push('booking available');
+            return (
+              <View
+                key={perk.perkType}
+                style={styles.perkRow}
+                testID={`loyalty-perk-${perk.perkType}`}
+                accessible
+                accessibilityRole="text"
+                accessibilityLabel={a11yParts.join(', ')}
               >
-                {perkLabel(perk.perkType)}
-              </Text>
-              {perk.couponCode ? (
                 <Text
                   style={[
-                    styles.perkCode,
-                    { color: colors.mountainBlue, fontFamily: typography.bodyFamilySemiBold },
+                    styles.perkLabel,
+                    { color: colors.espresso, fontFamily: typography.bodyFamily },
                   ]}
-                  testID={`loyalty-perk-coupon-${perk.perkType}`}
                 >
-                  {perk.couponCode}
+                  {label}
                 </Text>
-              ) : null}
-              {perk.bookingUrl ? (
-                <Text
-                  style={[
-                    styles.perkCode,
-                    { color: colors.sunsetCoral, fontFamily: typography.bodyFamilySemiBold },
-                  ]}
-                  testID={`loyalty-perk-booking-${perk.perkType}`}
-                >
-                  Book now
-                </Text>
-              ) : null}
-            </View>
-          ))
+                {perk.couponCode ? (
+                  <Text
+                    style={[
+                      styles.perkCode,
+                      { color: colors.mountainBlue, fontFamily: typography.bodyFamilySemiBold },
+                    ]}
+                    testID={`loyalty-perk-coupon-${perk.perkType}`}
+                  >
+                    {perk.couponCode}
+                  </Text>
+                ) : null}
+                {perk.bookingUrl ? (
+                  <Text
+                    style={[
+                      styles.perkCode,
+                      { color: colors.sunsetCoral, fontFamily: typography.bodyFamilySemiBold },
+                    ]}
+                    testID={`loyalty-perk-booking-${perk.perkType}`}
+                  >
+                    Book now
+                  </Text>
+                ) : null}
+              </View>
+            );
+          })
         )}
       </View>
       <Text

--- a/src/screens/__tests__/loyaltyScreen.unification.test.tsx
+++ b/src/screens/__tests__/loyaltyScreen.unification.test.tsx
@@ -339,4 +339,80 @@ describe('Your Perks section — tier perk deliveries', () => {
       expect(getByTestId('loyalty-perks-empty')).toBeTruthy();
     });
   });
+
+  it('shows perks error banner when fetch fails (cm-gdz)', async () => {
+    mockUseTierPerks.mockReturnValue({
+      perks: [],
+      loading: false,
+      error: 'Unable to load perks. Please try again.',
+    });
+    const { getByTestId } = render(<LoyaltyScreen />);
+    await waitFor(() => {
+      expect(getByTestId('loyalty-perks-error')).toBeTruthy();
+    });
+  });
+
+  it('does NOT show empty perks card when perks fetch errors (cm-gdz)', async () => {
+    mockUseTierPerks.mockReturnValue({
+      perks: [],
+      loading: false,
+      error: 'Network failure',
+    });
+    const { queryByTestId } = render(<LoyaltyScreen />);
+    await waitFor(() => {
+      expect(queryByTestId('loyalty-perks-empty')).toBeNull();
+    });
+  });
+});
+
+// ─── A11y on perks section (cm-gdz) ──────────────────────────────────────────
+
+describe('Your Perks section — a11y', () => {
+  it('perks heading has accessibilityRole="header"', async () => {
+    mockUseTierPerks.mockReturnValue(noPerks);
+    const { getByTestId } = render(<LoyaltyScreen />);
+    await waitFor(() => {
+      expect(getByTestId('loyalty-perks-heading').props.accessibilityRole).toBe('header');
+    });
+  });
+
+  it('perk row has descriptive accessibilityLabel including perk name', async () => {
+    mockUseTierPerks.mockReturnValue({
+      perks: [
+        {
+          perkType: 'FREE_WHITE_GLOVE',
+          tier: 'Summit Master',
+          deliveredAt: '2026-04-01T00:00:00Z',
+        },
+      ],
+      loading: false,
+      error: null,
+    });
+    const { getByTestId } = render(<LoyaltyScreen />);
+    await waitFor(() => {
+      const row = getByTestId('loyalty-perk-FREE_WHITE_GLOVE');
+      expect(row.props.accessibilityLabel).toBeTruthy();
+      expect(row.props.accessibilityLabel.toLowerCase()).toMatch(/white.glove|delivery/);
+    });
+  });
+
+  it('perk row with coupon code includes coupon in accessibilityLabel', async () => {
+    mockUseTierPerks.mockReturnValue({
+      perks: [
+        {
+          perkType: 'ACCESSORY_DISCOUNT',
+          tier: 'Mountain Guide',
+          deliveredAt: '2026-04-01T00:00:00Z',
+          couponCode: 'CF-XYZ9999',
+        },
+      ],
+      loading: false,
+      error: null,
+    });
+    const { getByTestId } = render(<LoyaltyScreen />);
+    await waitFor(() => {
+      const row = getByTestId('loyalty-perk-ACCESSORY_DISCOUNT');
+      expect(row.props.accessibilityLabel).toContain('CF-XYZ9999');
+    });
+  });
 });


### PR DESCRIPTION
## Summary
Audit fixes for LoyaltyScreen perks section from cm-jyl (a3291c8), reported by bishop 2026-04-16.

- **Error state**: `LoyaltyScreen.tsx:82` now destructures `error` from `useTierPerks` and renders a `loyalty-perks-error` banner (mirroring the Activity error pattern at lines 284-294). Previously dropped silently → blank section on network/auth/API failure.
- **Race fix**: `useTierPerks.ts` now uses a `cancelled` flag inside the effect, matching the `usePointsHistory` pattern. Late resolve/reject after unmount no longer setStates.
- **A11y**: perks heading gets `accessibilityRole="header"`. Each perk row is `accessible` with a descriptive `accessibilityLabel` (perk name + coupon code + booking availability).

## Tests (TDD — added before implementation)
- `loyaltyScreen.unification.test.tsx`: `+5 tests` — perks error banner shows on fetch failure, suppresses empty card; heading role; perk row a11y label includes name/coupon.
- `useTierPerks.test.ts`: `+2 tests` — no setState warnings after unmount on resolve OR reject.
- Full loyalty/TierPerk suite: **204 / 204 passing**.

## Test plan
- [x] `npx jest --testPathPattern "loyalty|TierPerk"` — 16 suites, 204 tests pass
- [x] `npx tsc --noEmit` — no new errors (one unrelated pre-existing CartSessionsSync error on main)
- [x] `npx prettier --check` — clean
- [x] `npx eslint` — only pre-existing warnings, none from this change

Closes convoy hq-cv-f3vzw.