### PR TITLE
feat(cm-bue): AchievementBadgesScreen — migrate ActivityIndicator to SkeletonBadgeGrid

### DIFF
--- a/src/components/SkeletonBadgeCard.tsx
+++ b/src/components/SkeletonBadgeCard.tsx
@@ -1,0 +1,57 @@
+/**
+ * @module SkeletonBadgeCard
+ *
+ * Skeleton placeholder matching a single badge card in AchievementBadgesScreen's
+ * 3-column grid. Circular shimmer for the icon + text shimmer for the label.
+ *
+ * cm-bue: migrate AchievementBadgesScreen from ActivityIndicator to skeleton
+ */
+import React, { memo } from 'react';
+import { StyleSheet, View } from 'react-native';
+import { useTheme } from '@/theme';
+import { ShimmerCircle, Shimmer } from './Shimmer';
+
+/** Single skeleton badge card — mirrors the TouchableOpacity card layout. */
+export const SkeletonBadgeCard = memo(function SkeletonBadgeCard({
+  testID,
+}: {
+  testID?: string;
+}) {
+  const { spacing, borderRadius } = useTheme();
+  return (
+    <View
+      testID={testID}
+      style={[styles.card, { borderRadius: borderRadius.card, padding: spacing.sm }]}
+    >
+      <ShimmerCircle size={48} />
+      <Shimmer width="80%" height={10} borderRadius={4} style={{ marginTop: spacing.xs }} />
+      <Shimmer width="55%" height={10} borderRadius={4} style={{ marginTop: 4 }} />
+    </View>
+  );
+});
+
+/** 3-column grid of 6 skeleton badge cards matching AchievementBadgesScreen layout. */
+export function SkeletonBadgeGrid({ testID }: { testID?: string }) {
+  return (
+    <View testID={testID ?? 'achievements-skeleton'} style={styles.grid}>
+      {Array.from({ length: 6 }, (_, i) => (
+        <SkeletonBadgeCard key={i} testID={`badge-skeleton-${i}`} />
+      ))}
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  grid: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    padding: 16,
+    gap: 8,
+  },
+  card: {
+    width: '30%',
+    alignItems: 'center',
+    borderWidth: 1,
+    borderColor: 'rgba(255,255,255,0.08)',
+  },
+});

--- a/src/screens/AchievementBadgesScreen.tsx
+++ b/src/screens/AchievementBadgesScreen.tsx
@@ -16,7 +16,6 @@ import {
   FlatList,
   Modal,
   TouchableOpacity,
-  ActivityIndicator,
   StyleSheet,
   Dimensions,
 } from 'react-native';
@@ -25,6 +24,7 @@ import { darkPalette } from '@/theme/tokens';
 import { useAchievements } from '@/hooks/useAchievements';
 import type { Achievement } from '@/hooks/useAchievements';
 import { BadgeSvgIcon } from '@/components/BadgeSvgIcon';
+import { SkeletonBadgeGrid } from '@/components/SkeletonBadgeCard';
 
 // ── Badge catalog ─────────────────────────────────────────────────────────────
 
@@ -95,7 +95,12 @@ function formatDate(iso: string): string {
 
 // ── Screen ────────────────────────────────────────────────────────────────────
 
-export function AchievementBadgesScreen() {
+export interface AchievementBadgesScreenProps {
+  testID?: string;
+}
+
+export function AchievementBadgesScreen({ testID }: AchievementBadgesScreenProps = {}) {
+  const id = testID ?? 'achievements-screen';
   const { colors, spacing, borderRadius } = useTheme();
   const { achievements, loading, error } = useAchievements();
   const [selected, setSelected] = useState<SelectedBadge | null>(null);
@@ -178,11 +183,8 @@ export function AchievementBadgesScreen() {
 
   if (loading) {
     return (
-      <View
-        testID="achievements-screen"
-        style={[styles.centered, { backgroundColor: darkPalette.background }]}
-      >
-        <ActivityIndicator testID="achievements-loading" size="large" color={colors.mountainBlue} />
+      <View testID={id} style={[styles.container, { backgroundColor: darkPalette.background }]}>
+        <SkeletonBadgeGrid testID="achievements-skeleton" />
       </View>
     );
   }
@@ -191,10 +193,7 @@ export function AchievementBadgesScreen() {
 
   if (error) {
     return (
-      <View
-        testID="achievements-screen"
-        style={[styles.centered, { backgroundColor: darkPalette.background }]}
-      >
+      <View testID={id} style={[styles.centered, { backgroundColor: darkPalette.background }]}>
         <Text testID="achievements-error" style={[styles.errorText, { color: colors.sunsetCoral }]}>
           {error}
         </Text>
@@ -206,7 +205,7 @@ export function AchievementBadgesScreen() {
 
   return (
     <View
-      testID="achievements-screen"
+      testID={id}
       style={[styles.container, { backgroundColor: darkPalette.background }]}
     >
       <FlatList

--- a/src/screens/__tests__/achievementBadgesScreen.skeleton.test.tsx
+++ b/src/screens/__tests__/achievementBadgesScreen.skeleton.test.tsx
@@ -1,0 +1,108 @@
+/**
+ * AchievementBadgesScreen — cm-bue skeleton migration tests.
+ *
+ * TDD: written BEFORE skeleton implementation.
+ * Verifies ActivityIndicator is replaced by SkeletonBox/Shimmer grid matching
+ * the 3-column badge layout (6 skeleton cards).
+ */
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import { AchievementBadgesScreen } from '../AchievementBadgesScreen';
+import { ThemeProvider } from '@/theme/ThemeProvider';
+
+const mockUseAchievements = jest.fn();
+jest.mock('@/hooks/useAchievements', () => ({
+  useAchievements: () => mockUseAchievements(),
+}));
+
+const LOADING_STATE = { achievements: [], loading: true, error: null };
+const ERROR_STATE = { achievements: [], loading: false, error: 'Fetch failed' };
+const LOADED_STATE = { achievements: [], loading: false, error: null };
+
+function wrap(ui: React.ReactElement) {
+  return render(<ThemeProvider>{ui}</ThemeProvider>);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockUseAchievements.mockReturnValue(LOADED_STATE);
+});
+
+// ── Skeleton replaces ActivityIndicator ──────────────────────────────────────
+
+describe('AchievementBadgesScreen — skeleton loading (cm-bue)', () => {
+  it('shows achievements-skeleton wrapper while loading', () => {
+    mockUseAchievements.mockReturnValue(LOADING_STATE);
+    const { getByTestId } = wrap(<AchievementBadgesScreen />);
+    expect(getByTestId('achievements-skeleton')).toBeTruthy();
+  });
+
+  it('does NOT show ActivityIndicator achievements-loading while loading', () => {
+    mockUseAchievements.mockReturnValue(LOADING_STATE);
+    const { queryByTestId } = wrap(<AchievementBadgesScreen />);
+    expect(queryByTestId('achievements-loading')).toBeNull();
+  });
+
+  it('shows 6 skeleton badge cards while loading', () => {
+    mockUseAchievements.mockReturnValue(LOADING_STATE);
+    const { getByTestId } = wrap(<AchievementBadgesScreen />);
+    for (let i = 0; i < 6; i++) {
+      expect(getByTestId(`badge-skeleton-${i}`)).toBeTruthy();
+    }
+  });
+
+  it('skeleton is hidden when not loading', () => {
+    mockUseAchievements.mockReturnValue(LOADED_STATE);
+    const { queryByTestId } = wrap(<AchievementBadgesScreen />);
+    expect(queryByTestId('achievements-skeleton')).toBeNull();
+  });
+
+  it('skeleton is hidden on error', () => {
+    mockUseAchievements.mockReturnValue(ERROR_STATE);
+    const { queryByTestId } = wrap(<AchievementBadgesScreen />);
+    expect(queryByTestId('achievements-skeleton')).toBeNull();
+  });
+});
+
+// ── Screen accepts testID prop ────────────────────────────────────────────────
+
+describe('AchievementBadgesScreen — testID prop (cm-bue)', () => {
+  it('accepts custom testID on loading state root', () => {
+    mockUseAchievements.mockReturnValue(LOADING_STATE);
+    const { getByTestId } = wrap(<AchievementBadgesScreen testID="my-achievements" />);
+    expect(getByTestId('my-achievements')).toBeTruthy();
+  });
+
+  it('accepts custom testID on loaded state root', () => {
+    mockUseAchievements.mockReturnValue(LOADED_STATE);
+    const { getByTestId } = wrap(<AchievementBadgesScreen testID="my-achievements" />);
+    expect(getByTestId('my-achievements')).toBeTruthy();
+  });
+
+  it('accepts custom testID on error state root', () => {
+    mockUseAchievements.mockReturnValue(ERROR_STATE);
+    const { getByTestId } = wrap(<AchievementBadgesScreen testID="my-achievements" />);
+    expect(getByTestId('my-achievements')).toBeTruthy();
+  });
+
+  it('defaults to achievements-screen when no testID provided', () => {
+    const { getByTestId } = wrap(<AchievementBadgesScreen />);
+    expect(getByTestId('achievements-screen')).toBeTruthy();
+  });
+});
+
+// ── Mutual exclusivity ────────────────────────────────────────────────────────
+
+describe('AchievementBadgesScreen — skeleton state exclusivity (cm-bue)', () => {
+  it('skeleton loading does NOT show badge-grid', () => {
+    mockUseAchievements.mockReturnValue(LOADING_STATE);
+    const { queryByTestId } = wrap(<AchievementBadgesScreen />);
+    expect(queryByTestId('badge-grid')).toBeNull();
+  });
+
+  it('skeleton loading does NOT show achievements-error', () => {
+    mockUseAchievements.mockReturnValue({ ...LOADING_STATE, error: 'stale' });
+    const { queryByTestId } = wrap(<AchievementBadgesScreen />);
+    expect(queryByTestId('achievements-error')).toBeNull();
+  });
+});

--- a/src/screens/__tests__/achievementBadgesScreen.test.tsx
+++ b/src/screens/__tests__/achievementBadgesScreen.test.tsx
@@ -281,10 +281,10 @@ describe('Bottom sheet — dismiss', () => {
 // ── Loading state ─────────────────────────────────────────────────────────────
 
 describe('Loading state', () => {
-  it('shows loading indicator while loading', () => {
+  it('shows skeleton grid while loading', () => {
     mockUseAchievements.mockReturnValue(LOADING_STATE);
     const { getByTestId } = wrap(<AchievementBadgesScreen />);
-    expect(getByTestId('achievements-loading')).toBeTruthy();
+    expect(getByTestId('achievements-skeleton')).toBeTruthy();
   });
 
   it('hides badge grid while loading', () => {


### PR DESCRIPTION
## Summary
- Replaces `ActivityIndicator` loading state with `SkeletonBadgeGrid` — 6 circular shimmer badge cards in a 3-column flex layout matching the real badge grid
- Creates `SkeletonBadgeCard` component using `ShimmerCircle` + `Shimmer` primitives
- Adds `testID` prop to `AchievementBadgesScreen` via `const id = testID ?? 'achievements-screen'` pattern (all three states: loading, error, loaded)

## Test plan
- [x] 11 new skeleton tests: `achievements-skeleton` wrapper, `badge-skeleton-0..5` cards, `testID` prop on all states, mutual exclusivity (skeleton hides grid/error)
- [x] Updated existing loading test from `achievements-loading` (ActivityIndicator) to `achievements-skeleton`
- [x] All 67 achievement tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)