### PR TITLE
feat(cm-g5q): AccountScreen a11y audit + deeper tests

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,17 +1,17 @@
 # cfutons_mobile — Status
 
-**Updated:** 2026-05-04 17:10 MDT
+**Updated:** 2026-05-04 17:43 MDT
 **Branch:** main
-**Last commit:** c3937db2 chore(report): progress-report update [skip ci]
+**Last commit:** 47bd04da chore(report): progress-report update [skip ci]
 
 ## Recent Commits
 | Hash | Message |
 |------|---------|
-| c3937db2 | chore(report): progress-report update [skip ci] |
-| ec7a6802 | chore(report): progress-report update [skip ci] |
-| d7a5b975 | feat(cm-4sp): BookingCancellationScreen a11y audit + deeper tests (burke) |
-| 173d741f | test(cm-2su): VisualSearchScreen + VisualSearchResultsScreen deeper tests (nux) |
-| 325d21fc | test(cm-gyd): StyleQuizScreen deeper edge-case suite — 26 tests |
+| 47bd04da | chore(report): progress-report update [skip ci] |
+| e463da60 | test(cm-2a2): OrderDetailScreen deeper edge-case suite (bishop) |
+| d87c97d2 | test(cm-5xf): NotificationsScreen deeper edge cases (ripley) |
+| 90e1904c | test(cm-4j2): ARCameraScreen deeper tests (nux) |
+| 2b47d148 | test(cm-yex): WishlistScreen deeper edge-case test suite (bishop) |
 
 ## Open PRs
 Dependabot only — no crew feature PRs open.
@@ -20,12 +20,14 @@ Dependabot only — no crew feature PRs open.
 | Bead | Priority | Title |
 |------|----------|-------|
 | cm-rpz | P1 | Refinery test_command misconfigured (refinery-owned) |
+| cm-7s4 | P2 | PushNotificationScreen: deeper tests (bishop) |
+| cm-f6h | P2 | StoreLocatorScreen + StoreDetailScreen skeleton loading states (hicks) |
 
 ## Crew Status
 | Member | Status | Bead |
 |--------|--------|------|
-| bishop | hooked | cm-yex (WishlistScreen deeper tests) |
-| hicks | nudged | cm-f6h (StoreLocatorScreen skeleton) |
-| ripley | FINAL NOTICE | cm-bue (re-push or convoy closes without) |
-| nux | hooked | cm-4j2 (ARCameraScreen deeper tests) |
+| bishop | hooked | cm-7s4 (PushNotificationScreen deeper tests) |
+| hicks | overdue — re-nudged | cm-f6h (StoreLocator skeleton) |
+| ripley | hooked | cm-z49 (SearchScreen deeper tests) |
+| nux | hooked | cm-ggn (CheckoutScreen deeper tests) |
 | burke | hooked | cm-g5q (ProfileScreen a11y + deeper tests) |

--- a/src/screens/AccountScreen.tsx
+++ b/src/screens/AccountScreen.tsx
@@ -312,6 +312,7 @@ export function AccountScreen({
           <View
             style={[styles.avatar, { backgroundColor: colors.mountainBlue, borderRadius: 30 }]}
             testID="user-avatar"
+            accessibilityLabel={`Profile avatar for ${user.displayName}`}
           >
             <Text style={styles.avatarText}>{user.displayName.charAt(0).toUpperCase()}</Text>
           </View>
@@ -567,7 +568,7 @@ export function AccountScreen({
                         <TouchableOpacity
                           onPress={() => addressBook.setDefault(addr.id)}
                           testID={`set-default-${addr.id}`}
-                          accessibilityLabel="Set as default address"
+                          accessibilityLabel={`Set ${addr.line1} as default address`}
                           accessibilityRole="button"
                         >
                           <Text style={[styles.addressAction, { color: colors.mountainBlue }]}>
@@ -587,7 +588,7 @@ export function AccountScreen({
                           ]);
                         }}
                         testID={`delete-address-${addr.id}`}
-                        accessibilityLabel="Delete address"
+                        accessibilityLabel={`Delete address ${addr.line1}`}
                         accessibilityRole="button"
                       >
                         <Text style={[styles.addressAction, { color: colors.sunsetCoral }]}>
@@ -873,6 +874,7 @@ export function AccountScreen({
             onPress={handleVersionTap}
             activeOpacity={0.8}
             testID="app-version-tap"
+            accessibilityRole="button"
             accessibilityLabel={`App version ${appVersion}, build ${buildNumber}`}
           >
             <Text

--- a/src/screens/__tests__/profileScreen.deeper.test.tsx
+++ b/src/screens/__tests__/profileScreen.deeper.test.tsx
@@ -77,17 +77,9 @@ jest.mock('@/hooks/useAddressBook', () => ({
   }),
 }));
 
+const mockUseSavedAddresses = jest.fn();
 jest.mock('@/hooks/useSavedAddresses', () => ({
-  useSavedAddresses: () => ({
-    addresses: [],
-    addAddress: jest.fn(),
-    updateAddress: jest.fn(),
-    deleteAddress: jest.fn(),
-    setDefault: jest.fn(),
-    saveFromCheckout: jest.fn(),
-    defaultAddress: null,
-    loading: false,
-  }),
+  useSavedAddresses: () => mockUseSavedAddresses(),
 }));
 
 jest.mock('@/hooks/useBiometricAuth', () => ({
@@ -173,6 +165,26 @@ function renderProfile(props: Partial<React.ComponentProps<typeof AccountScreen>
 
 // ── Setup ─────────────────────────────────────────────────────────────────────
 
+const defaultSavedAddresses = {
+  addresses: [] as {
+    id: string;
+    fullName: string;
+    line1: string;
+    line2: string;
+    city: string;
+    state: string;
+    zip: string;
+    isDefault: boolean;
+  }[],
+  addAddress: jest.fn(),
+  updateAddress: jest.fn(),
+  deleteAddress: jest.fn(),
+  setDefault: jest.fn(),
+  saveFromCheckout: jest.fn(),
+  defaultAddress: null,
+  loading: false,
+};
+
 beforeEach(() => {
   jest.clearAllMocks();
   mockUpdateProfile.mockResolvedValue(undefined);
@@ -188,6 +200,7 @@ beforeEach(() => {
   });
   mockUseLoyalty.mockReturnValue({ ...loyaltyBase, points: 0, tier: 'bronze' });
   mockUseStreak.mockReturnValue({ streak: 0, loading: false });
+  mockUseSavedAddresses.mockReturnValue(defaultSavedAddresses);
 });
 
 // ── Avatar upload error ───────────────────────────────────────────────────────
@@ -464,5 +477,130 @@ describe('logout confirmation', () => {
     // Press sign out while editing
     expect(() => fireEvent.press(getByTestId('sign-out-button'))).not.toThrow();
     expect(mockSignOut).toHaveBeenCalledTimes(1);
+  });
+});
+
+// ── A11y: avatar ──────────────────────────────────────────────────────────────
+
+describe('AccountScreen — a11y: avatar', () => {
+  it('user-avatar has accessibilityLabel', async () => {
+    const { getByTestId } = renderProfile();
+    await waitFor(() => {
+      expect(getByTestId('user-avatar').props.accessibilityLabel).toBeTruthy();
+    });
+  });
+
+  it('user-avatar accessibilityLabel references the display name', async () => {
+    const { getByTestId } = renderProfile();
+    await waitFor(() => {
+      expect(getByTestId('user-avatar').props.accessibilityLabel).toContain('Jane Smith');
+    });
+  });
+});
+
+// ── A11y: address action buttons ──────────────────────────────────────────────
+
+const ADDR = {
+  id: 'addr-1',
+  fullName: 'Jane Smith',
+  line1: '123 Main St',
+  line2: '',
+  city: 'Charlotte',
+  state: 'NC',
+  zip: '28201',
+  isDefault: false,
+};
+
+describe('AccountScreen — a11y: address action buttons', () => {
+  beforeEach(() => {
+    mockUseSavedAddresses.mockReturnValue({
+      ...defaultSavedAddresses,
+      addresses: [ADDR],
+    });
+  });
+
+  it('set-default button label identifies the address street', async () => {
+    const { getByTestId } = renderProfile();
+    await waitFor(() => {
+      expect(getByTestId(`set-default-${ADDR.id}`).props.accessibilityLabel).toContain(
+        '123 Main St',
+      );
+    });
+  });
+
+  it('set-default button has accessibilityRole="button"', async () => {
+    const { getByTestId } = renderProfile();
+    await waitFor(() => {
+      expect(getByTestId(`set-default-${ADDR.id}`).props.accessibilityRole).toBe('button');
+    });
+  });
+
+  it('delete-address button label identifies the address street', async () => {
+    const { getByTestId } = renderProfile();
+    await waitFor(() => {
+      expect(getByTestId(`delete-address-${ADDR.id}`).props.accessibilityLabel).toContain(
+        '123 Main St',
+      );
+    });
+  });
+
+  it('delete-address button has accessibilityRole="button"', async () => {
+    const { getByTestId } = renderProfile();
+    await waitFor(() => {
+      expect(getByTestId(`delete-address-${ADDR.id}`).props.accessibilityRole).toBe('button');
+    });
+  });
+});
+
+// ── A11y: app version tap ─────────────────────────────────────────────────────
+
+describe('AccountScreen — a11y: app version tap', () => {
+  it('has accessibilityRole="button"', async () => {
+    const { getByTestId } = renderProfile();
+    await waitFor(() => {
+      expect(getByTestId('app-version-tap').props.accessibilityRole).toBe('button');
+    });
+  });
+
+  it('accessibilityLabel mentions version', async () => {
+    const { getByTestId } = renderProfile();
+    await waitFor(() => {
+      expect(getByTestId('app-version-tap').props.accessibilityLabel).toMatch(/version/i);
+    });
+  });
+});
+
+// ── Edit flow: updateProfile call ────────────────────────────────────────────
+
+describe('AccountScreen — edit flow: updateProfile call', () => {
+  it('calls updateProfile with trimmed first name', async () => {
+    const { getByTestId } = renderProfile();
+    await waitFor(() => expect(getByTestId('edit-profile-button')).toBeTruthy());
+
+    fireEvent.press(getByTestId('edit-profile-button'));
+    await waitFor(() => expect(getByTestId('edit-first-name-input')).toBeTruthy());
+
+    fireEvent.changeText(getByTestId('edit-first-name-input'), '  Jane  ');
+    fireEvent.press(getByTestId('edit-save-button'));
+
+    await waitFor(() => {
+      expect(mockUpdateProfile).toHaveBeenCalledWith(
+        expect.objectContaining({ firstName: 'Jane' }),
+      );
+    });
+  });
+
+  it('edit form closes after a successful save', async () => {
+    const { getByTestId, queryByTestId } = renderProfile();
+    await waitFor(() => expect(getByTestId('edit-profile-button')).toBeTruthy());
+
+    fireEvent.press(getByTestId('edit-profile-button'));
+    await waitFor(() => expect(getByTestId('edit-profile-form')).toBeTruthy());
+
+    fireEvent.press(getByTestId('edit-save-button'));
+
+    await waitFor(() => {
+      expect(queryByTestId('edit-profile-form')).toBeNull();
+    });
   });
 });


### PR DESCRIPTION
## Summary
- Add `accessibilityLabel` to user avatar referencing display name
- Improve set-default/delete address button labels to include `addr.line1` so VoiceOver reads which address is being acted on
- Add `accessibilityRole="button"` to `app-version-tap`
- Refactor `useSavedAddresses` mock to factory pattern enabling per-test override
- Add 10 new tests: avatar a11y, address button a11y, app version tap, edit flow (31 total in deeper suite)

## Test plan
- [x] `npx jest src/screens/__tests__/profileScreen.deeper.test.tsx` → 31 passed
- [x] All existing profileScreen tests pass (21 total)
- [ ] VoiceOver on avatar reads user display name
- [ ] VoiceOver on address buttons reads street address

🤖 Generated with [Claude Code](https://claude.com/claude-code)