### PR TITLE
fix(ci): unblock main — TS in shopScreen.edge-cases + prettier in orderHistoryScreen.edgeCases

### DIFF
--- a/src/screens/__tests__/orderHistoryScreen.edgeCases.test.tsx
+++ b/src/screens/__tests__/orderHistoryScreen.edgeCases.test.tsx
@@ -117,7 +117,11 @@ function makeOrder(overrides: Partial<Order> & { id: string }): Order {
 
 const DELIVERED_ORDER = makeOrder({ id: 'ord-edge-1' });
 
-const SHIPPED_ORDER = makeOrder({ id: 'ord-edge-2', orderNumber: 'CF-2026-0002', status: 'shipped' });
+const SHIPPED_ORDER = makeOrder({
+  id: 'ord-edge-2',
+  orderNumber: 'CF-2026-0002',
+  status: 'shipped',
+});
 
 function makeBaseHook(overrides = {}) {
   return {
@@ -332,9 +336,7 @@ describe('OrderHistoryScreen — order card accessibility', () => {
 
   it('order number text node renders the order number', () => {
     const { getByTestId } = renderScreen({ orders: [DELIVERED_ORDER] });
-    expect(getByTestId('order-number-ord-edge-1').props.children).toBe(
-      DELIVERED_ORDER.orderNumber,
-    );
+    expect(getByTestId('order-number-ord-edge-1').props.children).toBe(DELIVERED_ORDER.orderNumber);
   });
 
   it('reorder button on delivered order has accessibilityRole button', () => {

--- a/src/screens/__tests__/shopScreen.edge-cases.test.tsx
+++ b/src/screens/__tests__/shopScreen.edge-cases.test.tsx
@@ -30,6 +30,7 @@ import * as useProductsModule from '@/hooks/useProducts';
 import * as useRecentSearchesModule from '@/hooks/useRecentSearches';
 import * as CompareContextModule from '@/contexts/CompareContext';
 import type { ProductCategory, ProductFilters } from '@/hooks/useProducts';
+import type { Product } from '@/data/products';
 import { PRODUCTS } from '@/data/products';
 
 // ── Navigation mock (module-level so factory closure captures it) ──────────────
@@ -63,7 +64,7 @@ const EMPTY_FILTERS: ProductFilters = {
 };
 
 const BASE_PRODUCTS = {
-  products: [],
+  products: [] as Product[],
   categories: [],
   searchQuery: '',
   selectedCategory: null as ProductCategory | null,


### PR DESCRIPTION
## Summary

Main CI was failing on both **type-check** and **lint**, blocking every open PR. Two small, independent fixes:

1. **`src/screens/__tests__/shopScreen.edge-cases.test.tsx`** (TS2322 ×3)
   `BASE_PRODUCTS.products: []` was inferred as `never[]`, so any `renderShopControlled({ products: PRODUCTS.slice(...) })` call rejected the `Product[]`. Added explicit `as Product[]` annotation.

2. **`src/screens/__tests__/orderHistoryScreen.edgeCases.test.tsx`** (prettier/prettier ×2)
   Two formatting errors at lines 120 & 335. Applied `eslint --fix`.

Both files were introduced by recent sibling test-suite PRs that landed on `main` without the typecheck/lint actually passing on the merged tree.

## Test plan
- [x] `npx tsc --noEmit` clean for the two files
- [x] `npx eslint src/ --ext .ts,.tsx` → `0 errors` (warnings unchanged)
- [x] `npx jest src/screens/__tests__/shopScreen.edge-cases.test.tsx` → **28 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)